### PR TITLE
Define built-in names

### DIFF
--- a/tntc/src/definitionsCollector.ts
+++ b/tntc/src/definitionsCollector.ts
@@ -6,7 +6,7 @@ export interface NameDefinition {
   scope?: bigint
 }
 
-const defaultDefinitions: NameDefinition[] = [
+export const defaultDefinitions: NameDefinition[] = [
   { kind: 'def', identifier: 'not' },
   { kind: 'def', identifier: 'and' },
   { kind: 'def', identifier: 'or' },

--- a/tntc/test/definitionsCollector.test.ts
+++ b/tntc/test/definitionsCollector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha'
 import { assert } from 'chai'
-import { NameDefinition, collectDefinitions } from '../src/definitionsCollector'
+import { NameDefinition, collectDefinitions, defaultDefinitions } from '../src/definitionsCollector'
 import { TntModule } from '../src/tntIr'
 
 describe('collectDefinitions', () => {
@@ -16,7 +16,7 @@ describe('collectDefinitions', () => {
       ],
     }
 
-    const expectedDefinitions: NameDefinition[] = [
+    const expectedDefinitions: NameDefinition[] = defaultDefinitions.concat([
       {
         identifier: 'TEST_CONSTANT',
         kind: 'const',
@@ -33,7 +33,7 @@ describe('collectDefinitions', () => {
         identifier: 'TestModule',
         kind: 'namespace',
       },
-    ]
+    ])
 
     const result = collectDefinitions(tntModule)
     assert.deepEqual(result, expectedDefinitions)
@@ -75,7 +75,7 @@ describe('collectDefinitions', () => {
       ],
     }
 
-    const expectedDefinitions: NameDefinition[] = [
+    const expectedDefinitions: NameDefinition[] = defaultDefinitions.concat([
       {
         identifier: 'test_definition',
         kind: 'def',
@@ -90,7 +90,7 @@ describe('collectDefinitions', () => {
         kind: 'def',
         scope: BigInt(4),
       },
-    ]
+    ])
 
     const result = collectDefinitions(tntModule)
     assert.deepEqual(result, expectedDefinitions)


### PR DESCRIPTION
Hello :octocat: 

TNT has built-in definitions such as `union`, `mapOf` and `length` that have to be defined somehow in order for name resolution to find them and accept the spec. Here, they are listed as definitions, and this list can be later incremented to contain information about types and perhaps some pointer to their semantic.

I've checked that this definitions are sufficient to resolve names from our `testFixtures` and `examples` directory.

Closes https://github.com/informalsystems/tnt/issues/30