### PR TITLE
Call operator/name definitions "value definitions"

### DIFF
--- a/tntc/src/nameResolver.ts
+++ b/tntc/src/nameResolver.ts
@@ -17,14 +17,14 @@
 
 import { TntModule, TntEx } from './tntIr'
 import { TntType } from './tntTypes'
-import { DefinitionTable, NameDefinition, TypeDefinition } from './definitionsCollector'
+import { DefinitionTable, ValueDefinition, TypeDefinition } from './definitionsCollector'
 
 /**
  * A single name resolution error
  */
 export interface NameError {
-  /* Either a 'type' or 'operator' name error */
-  kind: 'type' | 'operator';
+  /* Either a 'type' or 'value' name error */
+  kind: 'type' | 'value';
   /* The name that couldn't be resolved */
   name: string;
   /* The module-level definition containing the error */
@@ -158,12 +158,12 @@ function checkNamesInExpr (
       // This is a name expression, the name must be defined
       // either globally or under a scope that contains the expression
       // The list of scopes containing the expression is accumulated in param scopes
-      const nameDefinitionsForScope = filterScope(table.nameDefinitions, scopes)
+      const valueDefinitionsForScope = filterScope(table.valueDefinitions, scopes)
 
-      if (!nameDefinitionsForScope.some(name => name.identifier === expr.name)) {
+      if (!valueDefinitionsForScope.some(name => name.identifier === expr.name)) {
         results.push({
           kind: 'error',
-          errors: [{ kind: 'operator', name: expr.name, definitionName: defName, reference: expr.id }],
+          errors: [{ kind: 'value', name: expr.name, definitionName: defName, reference: expr.id }],
         })
       }
       break
@@ -171,12 +171,12 @@ function checkNamesInExpr (
 
     case 'app': {
       // Application, check that the operator being applied is defined
-      const nameDefinitionsForScope = filterScope(table.nameDefinitions, scopes)
+      const valueDefinitionsForScope = filterScope(table.valueDefinitions, scopes)
 
-      if (!nameDefinitionsForScope.some(name => name.identifier === expr.opcode)) {
+      if (!valueDefinitionsForScope.some(name => name.identifier === expr.opcode)) {
         results.push({
           kind: 'error',
-          errors: [{ kind: 'operator', name: expr.opcode, definitionName: defName, reference: expr.id }],
+          errors: [{ kind: 'value', name: expr.opcode, definitionName: defName, reference: expr.id }],
         })
       }
 
@@ -220,8 +220,8 @@ function mergeNameResults (results: NameResolutionResult[]): NameResolutionResul
   return errors.length > 0 ? { kind: 'error', errors: errors } : { kind: 'ok' }
 }
 
-function filterScope (nameDefinitions: NameDefinition[], scopes: BigInt[]): NameDefinition[] {
-  return nameDefinitions.filter(definition => {
+function filterScope (valueDefinitions: ValueDefinition[], scopes: BigInt[]): ValueDefinition[] {
+  return valueDefinitions.filter(definition => {
     // A definition should be considered in a scope if it's either unscoped or its scope is included
     // in some scope containing the name expression's scope
     return !definition.scope || scopes.includes(definition.scope)

--- a/tntc/test/definitionsCollector.test.ts
+++ b/tntc/test/definitionsCollector.test.ts
@@ -10,7 +10,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.deepInclude(result.nameDefinitions, { kind: 'const', identifier: 'TEST_CONSTANT', reference: BigInt(1) })
+      assert.deepInclude(result.valueDefinitions, { kind: 'const', identifier: 'TEST_CONSTANT', reference: BigInt(1) })
     })
 
     it('collects variable definitions', () => {
@@ -18,7 +18,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.deepInclude(result.nameDefinitions, { kind: 'var', identifier: 'test_variable', reference: BigInt(1) })
+      assert.deepInclude(result.valueDefinitions, { kind: 'var', identifier: 'test_variable', reference: BigInt(1) })
     })
 
     it('collects operator definitions and its parameters including a scope', () => {
@@ -26,7 +26,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'def', identifier: 'test_operator', reference: BigInt(4) },
         { kind: 'def', identifier: 'x', reference: BigInt(4), scope: BigInt(4) },
       ])
@@ -37,7 +37,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'def', identifier: 'test_operator', reference: BigInt(7) },
         { kind: 'def', identifier: 'x', reference: BigInt(5), scope: BigInt(5) },
       ])
@@ -48,7 +48,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'def', identifier: 'test_operator', reference: BigInt(7) },
         { kind: 'val', identifier: 'x', reference: BigInt(2), scope: BigInt(6) },
       ])
@@ -62,7 +62,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'namespace', identifier: 'test_module', reference: BigInt(8) },
         { kind: 'namespace', identifier: 'test_module_instance', reference: BigInt(13) },
         { kind: 'def', identifier: 'test_module_instance::a', reference: BigInt(13) },
@@ -77,7 +77,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'namespace', identifier: 'test_module', reference: BigInt(6) },
         { kind: 'namespace', identifier: 'test_module::nested_module', reference: BigInt(6) },
         { kind: 'def', identifier: 'test_module::nested_module::a', reference: BigInt(6) },
@@ -89,7 +89,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'assumption', identifier: 'test_assumption', reference: BigInt(7) },
         { kind: 'val', identifier: 'x', reference: BigInt(3), scope: BigInt(5) },
       ])
@@ -103,7 +103,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.includeDeepMembers(result.nameDefinitions, [
+      assert.includeDeepMembers(result.valueDefinitions, [
         { kind: 'namespace', identifier: 'test_module', reference: BigInt(8) },
         { kind: 'def', identifier: 'test_module::a', reference: BigInt(8) },
         { kind: 'namespace', identifier: 'test_module::nested_module', reference: BigInt(8) },
@@ -123,7 +123,7 @@ describe('collectDefinitions', () => {
 
       const result = collectDefinitions(tntModule)
 
-      assert.deepInclude(result.nameDefinitions, { kind: 'def', identifier: 'a', reference: BigInt(5) })
+      assert.deepInclude(result.valueDefinitions, { kind: 'def', identifier: 'a', reference: BigInt(5) })
     })
   })
 

--- a/tntc/test/definitionsScanner.test.ts
+++ b/tntc/test/definitionsScanner.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from 'mocha'
 import { assert } from 'chai'
-import { NameDefinition, DefinitionTable, TypeDefinition } from '../src/definitionsCollector'
+import { ValueDefinition, DefinitionTable, TypeDefinition } from '../src/definitionsCollector'
 import { ConflictSource, scanConflicts } from '../src/definitionsScanner'
 import { ScopeTree } from '../src/scoping'
 
 describe('scanConflicts', () => {
   it('finds top-level name conflicts', () => {
-    const nameDefinitions: NameDefinition[] = [
+    const valueDefinitions: ValueDefinition[] = [
       { kind: 'const', identifier: 'TEST_CONSTANT', reference: BigInt(1) },
       { kind: 'def', identifier: 'conflicting_name', reference: BigInt(2) },
       { kind: 'val', identifier: 'conflicting_name', reference: BigInt(3), scope: BigInt(3) },
@@ -16,7 +16,7 @@ describe('scanConflicts', () => {
       { identifier: 'MY_TYPE', type: { kind: 'int' }, reference: BigInt(1) },
     ]
 
-    const table: DefinitionTable = { nameDefinitions: nameDefinitions, typeDefinitions: typeDefinitions }
+    const table: DefinitionTable = { valueDefinitions: valueDefinitions, typeDefinitions: typeDefinitions }
 
     const tree: ScopeTree = {
       value: BigInt(0),
@@ -36,12 +36,12 @@ describe('scanConflicts', () => {
 
     assert.deepEqual(result, {
       kind: 'error',
-      conflicts: [{ kind: 'operator', identifier: 'conflicting_name', sources: expectedSources }],
+      conflicts: [{ kind: 'value', identifier: 'conflicting_name', sources: expectedSources }],
     })
   })
 
   it('finds type alias conflicts', () => {
-    const nameDefinitions: NameDefinition[] = [
+    const valueDefinitions: ValueDefinition[] = [
       { kind: 'const', identifier: 'TEST_CONSTANT', reference: BigInt(1) },
     ]
 
@@ -50,7 +50,7 @@ describe('scanConflicts', () => {
       { identifier: 'MY_TYPE', type: { kind: 'str' }, reference: BigInt(3) },
     ]
 
-    const table: DefinitionTable = { nameDefinitions: nameDefinitions, typeDefinitions: typeDefinitions }
+    const table: DefinitionTable = { valueDefinitions: valueDefinitions, typeDefinitions: typeDefinitions }
 
     const tree: ScopeTree = {
       value: BigInt(0),
@@ -75,7 +75,7 @@ describe('scanConflicts', () => {
   })
 
   it('finds name conflicts within nested scopes', () => {
-    const nameDefinitions: NameDefinition[] = [
+    const valueDefinitions: ValueDefinition[] = [
       { kind: 'def', identifier: 'conflicting_name', reference: BigInt(1), scope: BigInt(1) },
       { kind: 'val', identifier: 'conflicting_name', reference: BigInt(2), scope: BigInt(2) },
     ]
@@ -84,7 +84,7 @@ describe('scanConflicts', () => {
       { identifier: 'MY_TYPE', type: { kind: 'int' }, reference: BigInt(1) },
     ]
 
-    const table: DefinitionTable = { nameDefinitions: nameDefinitions, typeDefinitions: typeDefinitions }
+    const table: DefinitionTable = { valueDefinitions: valueDefinitions, typeDefinitions: typeDefinitions }
 
     const tree: ScopeTree = { value: BigInt(1), children: [{ value: BigInt(2), children: [] }] }
 
@@ -97,12 +97,12 @@ describe('scanConflicts', () => {
 
     assert.deepEqual(result, {
       kind: 'error',
-      conflicts: [{ kind: 'operator', identifier: 'conflicting_name', sources: expectedSources }],
+      conflicts: [{ kind: 'value', identifier: 'conflicting_name', sources: expectedSources }],
     })
   })
 
   it('finds conflicts with built-in definitions', () => {
-    const nameDefinitions: NameDefinition[] = [
+    const valueDefinitions: ValueDefinition[] = [
       { kind: 'def', identifier: 'conflicting_name' },
       { kind: 'val', identifier: 'conflicting_name', reference: BigInt(2) },
     ]
@@ -112,7 +112,7 @@ describe('scanConflicts', () => {
       { identifier: 'MY_TYPE', type: { kind: 'int' }, reference: BigInt(1) },
     ]
 
-    const table: DefinitionTable = { nameDefinitions: nameDefinitions, typeDefinitions: typeDefinitions }
+    const table: DefinitionTable = { valueDefinitions: valueDefinitions, typeDefinitions: typeDefinitions }
 
     const tree: ScopeTree = {
       value: BigInt(0),
@@ -136,14 +136,14 @@ describe('scanConflicts', () => {
     assert.deepEqual(result, {
       kind: 'error',
       conflicts: [
-        { kind: 'operator', identifier: 'conflicting_name', sources: expectedSources },
+        { kind: 'value', identifier: 'conflicting_name', sources: expectedSources },
         { kind: 'type', identifier: 'MY_TYPE', sources: expectedTypeSources },
       ],
     })
   })
 
   it('finds no conflicts when there are none', () => {
-    const nameDefinitions: NameDefinition[] = [
+    const valueDefinitions: ValueDefinition[] = [
       { kind: 'const', identifier: 'TEST_CONSTANT', reference: BigInt(1) },
       { kind: 'def', identifier: 'conflicting_name', reference: BigInt(2), scope: BigInt(2) },
       { kind: 'val', identifier: 'conflicting_name', reference: BigInt(3), scope: BigInt(3) },
@@ -154,7 +154,7 @@ describe('scanConflicts', () => {
       { identifier: 'OTHER_TYPE', type: { kind: 'int' }, reference: BigInt(5) },
     ]
 
-    const table: DefinitionTable = { nameDefinitions: nameDefinitions, typeDefinitions: typeDefinitions }
+    const table: DefinitionTable = { valueDefinitions: valueDefinitions, typeDefinitions: typeDefinitions }
 
     const tree: ScopeTree = {
       value: BigInt(0),

--- a/tntc/test/nameResolver.test.ts
+++ b/tntc/test/nameResolver.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from 'mocha'
 import { assert } from 'chai'
-import { NameDefinition, defaultDefinitions, DefinitionTable, TypeDefinition } from '../src/definitionsCollector'
+import { ValueDefinition, defaultDefinitions, DefinitionTable, TypeDefinition } from '../src/definitionsCollector'
 import { resolveNames, NameResolutionResult } from '../src/nameResolver'
 
 import { buildModuleWithExpressions, buildModuleWithDefs } from './builders/modules'
 
 describe('nameResolver', () => {
-  const nameDefinitions: NameDefinition[] = defaultDefinitions.nameDefinitions.concat([
+  const valueDefinitions: ValueDefinition[] = defaultDefinitions.valueDefinitions.concat([
     { kind: 'const', identifier: 'TEST_CONSTANT' },
     { kind: 'def', identifier: 'unscoped_def' },
     { kind: 'def', identifier: 'scoped_def', scope: BigInt(2) },
@@ -15,7 +15,7 @@ describe('nameResolver', () => {
     { identifier: 'MY_TYPE', type: { kind: 'int' } },
   ]
 
-  const table: DefinitionTable = { nameDefinitions: nameDefinitions, typeDefinitions: typeDefinitions }
+  const table: DefinitionTable = { valueDefinitions: valueDefinitions, typeDefinitions: typeDefinitions }
 
   describe('operator definitions', () => {
     it('finds top level definitions', () => {
@@ -38,7 +38,7 @@ describe('nameResolver', () => {
       const result = resolveNames(tntModule, table)
       const expectedResult: NameResolutionResult = {
         kind: 'error',
-        errors: [{ kind: 'operator', name: 'scoped_def', definitionName: 'd1', reference: BigInt(3) }],
+        errors: [{ kind: 'value', name: 'scoped_def', definitionName: 'd1', reference: BigInt(3) }],
       }
       assert.deepEqual(result, expectedResult)
     })
@@ -50,8 +50,8 @@ describe('nameResolver', () => {
       const expectedResult: NameResolutionResult = {
         kind: 'error',
         errors: [
-          { kind: 'operator', name: 'x', definitionName: 'd0', reference: BigInt(1) },
-          { kind: 'operator', name: 'x', definitionName: 'd1', reference: BigInt(5) },
+          { kind: 'value', name: 'x', definitionName: 'd0', reference: BigInt(1) },
+          { kind: 'value', name: 'x', definitionName: 'd1', reference: BigInt(5) },
         ],
       }
       assert.deepEqual(result, expectedResult)
@@ -64,7 +64,7 @@ describe('nameResolver', () => {
       const expectedResult: NameResolutionResult = {
         kind: 'error',
         errors: [
-          { kind: 'operator', name: 'x', definitionName: 'd0', reference: BigInt(2) },
+          { kind: 'value', name: 'x', definitionName: 'd0', reference: BigInt(2) },
         ],
       }
       assert.deepEqual(result, expectedResult)
@@ -77,7 +77,7 @@ describe('nameResolver', () => {
       const expectedResult: NameResolutionResult = {
         kind: 'error',
         errors: [
-          { kind: 'operator', name: 'x', definitionName: 'd0', reference: BigInt(2) },
+          { kind: 'value', name: 'x', definitionName: 'd0', reference: BigInt(2) },
         ],
       }
       assert.deepEqual(result, expectedResult)
@@ -90,8 +90,8 @@ describe('nameResolver', () => {
       const expectedResult: NameResolutionResult = {
         kind: 'error',
         errors: [
-          { kind: 'operator', name: 'x', definitionName: 'd0', reference: BigInt(1) },
-          { kind: 'operator', name: 'x', definitionName: 'd1', reference: BigInt(8) },
+          { kind: 'value', name: 'x', definitionName: 'd0', reference: BigInt(1) },
+          { kind: 'value', name: 'x', definitionName: 'd1', reference: BigInt(8) },
         ],
       }
       assert.deepEqual(result, expectedResult)


### PR DESCRIPTION
Hello :octocat: 

@shonfeder [suggested](https://github.com/informalsystems/tnt/pull/54#discussion_r838804527) a better name for what I've been calling name/operator definitions or conflicts, so here is a simple easy-to-review PR with just this renaming
- `NameDefinition` -> `ValueDefinition`
- `nameConflicts` -> `valueConflicts`
- `kind: 'operator'` -> `kind: 'value'`