### PR TITLE
Demand a command to tntc

### DIFF
--- a/tntc/src/cli.ts
+++ b/tntc/src/cli.ts
@@ -113,5 +113,6 @@ const parseCmd = {
 // parse the command-line arguments and execute the handlers
 yargs(process.argv.slice(2))
   .command(parseCmd)
+  .demandCommand(1)
   .strict()
   .parse()


### PR DESCRIPTION
Print help if `tntc` is run without a command:

Before:

```sh
$ tntc
$
```

After:

```sh
$ tntc
tntc <command>

Commands:
  tntc parse <input>  parse a TNT specification

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]

Not enough non-option arguments: got 0, need at least 1
```