### PR TITLE
Name each IR component interface

### DIFF
--- a/tntc/.eslintrc.json
+++ b/tntc/.eslintrc.json
@@ -21,6 +21,7 @@
         "imports": "never",
         "exports": "never",
         "functions": "never"
-    }]
+     }],
+     "no-use-before-define": "off"
    }
 }

--- a/tntc/src/tntIr.ts
+++ b/tntc/src/tntIr.ts
@@ -51,30 +51,67 @@ export interface WithType {
  */
 export type OpQualifier = 'val' | 'def' | 'pred' | 'action' | 'temporal'
 
+export interface TntName extends WithId, WithType {
+  /** Expressions kind ('name' -- name reference) */
+  kind: 'name',
+  /** A name of: a variable, constant, parameter, user-defined operator */
+  name: string,
+}
+
+export interface TntBool extends WithId, WithType {
+  /** Expressions kind ('bool' -- a boolean literal) */
+  kind: 'bool',
+  /** The boolean literal value */
+  value: boolean,
+}
+
+export interface TntInt extends WithId, WithType {
+  /** Expressions kind ('int' -- an integer literal) */
+  kind: 'int',
+  /** The integer literal value */
+  value: bigint,
+}
+
+export interface TntStr extends WithId, WithType {
+  /** Expressions kind ('str' -- a string literal) */
+  kind: 'str',
+  /** The string literal value */
+  value: string,
+}
+
+export interface TntApp extends WithId, WithType {
+  /** Expressions kind ('app' -- operator application) */
+  kind: 'app',
+  /** The name of the operator being applied */
+  opcode: string,
+  /** A list of arguments to the operator */
+  args: TntEx[],
+}
+
+export interface TntLambda extends WithId, WithType {
+  /** Expressions kind ('lambda' -- operator abstraction) */
+  kind: 'lambda',
+  /** Identifiers for the formal parameters */
+  params: string[],
+  /** The qualifier for the defined operator */
+  qualifier: OpQualifier,
+  /** The definition body */
+  expr: TntEx,
+}
+
+export interface TntLet extends WithId, WithType {
+  /** Expressions kind ('let' -- a let-in binding defined via 'def', 'val', etc.) */
+  kind: 'let',
+  /** The operator being defined to be used in the body */
+  opdef: TntOpDef,
+  /** The body */
+  expr: TntEx,
+}
+
 /**
  * Discriminated union of TNT expressions.
  */
-export type TntEx =
-  // A name of: a variable, constant, parameter, user-defined operator
-  | { kind: 'name', name: string } & WithId & WithType
-  // A Boolean literal
-  | { kind: 'bool', value: boolean } & WithId & WithType
-  // An integer literal
-  | { kind: 'int', value: bigint } & WithId & WithType
-  // A string literal
-  | { kind: 'str', value: string } & WithId & WithType
-  // Operator application by its name, supplying the arguments in `args`
-  | { kind: 'app', opcode: string, args: TntEx[] } & WithId & WithType
-  // Operator abstraction: an anonymous operator (lambda) over a list of parameters.
-  | {
-    kind: 'lambda',
-    params: string[],
-    qualifier: OpQualifier,
-    expr: TntEx
-  } & WithId & WithType
-  // A let-in binding (defined via 'def', 'val', etc.).
-  // eslint-disable-next-line no-use-before-define
-  | { kind: 'let', opdef: TntOpDef, expr: TntEx } & WithId & WithType
+export type TntEx = TntName | TntBool | TntInt | TntStr | TntApp | TntLambda | TntLet
 
 /**
  * A user-defined operator that is defined via one of the qualifiers:
@@ -94,66 +131,71 @@ export interface TntOpDef extends WithId, WithType {
   expr: TntEx
 }
 
+export interface TntConst extends WithId, WithType {
+  /** definition kind ('const') */
+  kind: 'const',
+  /** name of the constant */
+  name: string,
+}
+
+export interface TntVar extends WithId, WithType {
+  /** definition kind ('var') */
+  kind: 'var',
+  /** name of the variable */
+  name: string
+}
+
+export interface TntAssume extends WithId, WithType {
+  /** definition kind ('assume') */
+  kind: 'assume',
+  /** name of the assumption, may be '_' */
+  name: string,
+  /** an expression to associate with the name */
+  assumption: TntEx
+}
+
+export interface TntTypeDef extends WithId, WithType {
+  /** definition kind ('typedef') */
+  kind: 'typedef',
+  /** name of a type alias */
+  name: string,
+  /** type to associate with the alias (none for uninterpreted type) */
+  type?: TntType
+}
+
+export interface TntImport extends WithId, WithType {
+  /** definition kind ('import') */
+  kind: 'import',
+  /** name to import, or '*' to denote all */
+  name: string,
+  /** path to the module, e.g., Foo.Bar */
+  path: string
+}
+
+export interface TntInstance extends WithId, WithType {
+  /** definition kind ('instance') */
+  kind: 'instance',
+  /** instance name */
+  name: string,
+  /** the name of the module to instantiate */
+  protoName: string,
+  /** how to override constants and variables */
+  overrides: [string, TntEx][],
+  /** whether to use identity substitution on missing names */
+  identityOverride: boolean
+}
+
+export interface TntModuleDef extends WithId, WithType {
+  /** definition kind ('module') */
+  kind: 'module',
+  /** nested module */
+  module: TntModule
+}
+
 /**
  * Definition: constant, state variable, operator definition, assumption, instance, module.
  */
-export type TntDef =
-  | TntOpDef
-  | {
-    /** definition kind ('const') */
-    kind: 'const',
-    /** name of the constant */
-    name: string
-  } & WithId & WithType
-  | {
-    /** definition kind ('var') */
-    kind: 'var',
-    /** name of the variable */
-    name: string
-  } & WithId & WithType
-  | {
-    /** definition kind ('assume') */
-    kind: 'assume',
-    /** name of the assumption, may be '_' */
-    name: string,
-    /** an expression to associate with the name */
-    assumption: TntEx
-  } & WithId
-  | {
-    /** definition kind ('typedef') */
-    kind: 'typedef',
-    /** name of a type alias */
-    name: string,
-    /** type to associate with the alias (none for uninterpreted type) */
-    type?: TntType
-  } & WithId
-  | {
-    /** definition kind ('import') */
-    kind: 'import',
-    /** name to import, or '*' to denote all */
-    name: string,
-    /** path to the module, e.g., Foo.Bar */
-    path: string
-  } & WithId
-  | {
-    /** definition kind ('instance') */
-    kind: 'instance',
-    /** instance name */
-    name: string,
-    /** the name of the module to instantiate */
-    protoName: string,
-    /** how to override constants and variables */
-    overrides: [string, TntEx][],
-    /** whether to use identity substitution on missing names */
-    identityOverride: boolean
-  } & WithId
-  | {
-    /** definition kind ('module') */
-    kind: 'module',
-    /** nested module */
-    // eslint-disable-next-line no-use-before-define
-    module: TntModule
-  } & WithId
+export type TntDef = TntOpDef | TntConst | TntVar | TntAssume | TntTypeDef | TntImport | TntInstance | TntModuleDef
 
 /**
  * Module definition.

--- a/tntc/src/tntTypes.ts
+++ b/tntc/src/tntTypes.ts
@@ -16,31 +16,85 @@
  * to recover expression metadata such as source information, annotations, etc.
  */
 export interface WithId {
-  id: bigint;
+  id: bigint
+}
+
+export interface TntBoolType extends WithId {
+  kind: 'bool'
+}
+
+export interface TntIntType extends WithId {
+  kind: 'int'
+}
+
+export interface TntStrType extends WithId {
+  kind: 'str'
+}
+
+export interface TntConstType extends WithId {
+  kind: 'const',
+  name: string,
+}
+
+export interface TntVarType extends WithId {
+  kind: 'var',
+  name: string,
+}
+
+export interface TntSetType extends WithId {
+  kind: 'set',
+  elem: TntType,
+}
+
+export interface TntSeqType extends WithId {
+  kind: 'seq',
+  elem: TntType,
+}
+
+export interface TntFunType extends WithId {
+  kind: 'fun',
+  arg: TntType,
+  res: TntType,
+}
+
+export interface TntOperType extends WithId {
+  kind: 'oper',
+  args: TntType[],
+  res: TntType,
+}
+
+export interface TntTupleType extends WithId {
+  kind: 'tuple',
+  elems: TntType[],
+}
+
+export interface TntRecordType extends WithId {
+  kind: 'record',
+  fields: { fieldName: string, fieldType: TntType }[]
+}
+
+export interface TntUnionType extends WithId {
+  kind: 'union',
+  tag: string,
+  records: {
+    tagValue: string,
+    fields: { fieldName: string, fieldType: TntType }[]
+  }[]
 }
 
 /**
  * A type in Type System 1.2.
  */
 export type TntType =
-  | { kind: 'bool' } & WithId
-  | { kind: 'int' } & WithId
-  | { kind: 'str' } & WithId
-  | { kind: 'const', name: string } & WithId
-  | { kind: 'var', name: string } & WithId
-  | { kind: 'set', elem: TntType } & WithId
-  | { kind: 'seq', elem: TntType } & WithId
-  | { kind: 'fun', arg: TntType, res: TntType } & WithId
-  | { kind: 'oper', args: TntType[], res: TntType } & WithId
-  | { kind: 'tuple', elems: TntType[] } & WithId
-  | {
-    kind: 'record',
-    fields: { fieldName: string, fieldType: TntType }[]
-  } & WithId
-  | {
-    kind: 'union', tag: string,
-    records: {
-      tagValue: string,
-      fields: { fieldName: string, fieldType: TntType }[]
-    }[]
-  } & WithId
+  | TntBoolType
+  | TntIntType
+  | TntStrType
+  | TntConstType
+  | TntVarType
+  | TntSetType
+  | TntSeqType
+  | TntFunType
+  | TntOperType
+  | TntTupleType
+  | TntRecordType
+  | TntUnionType


### PR DESCRIPTION
Hello :octocat: 

This simply introduces exported interfaes for each IR component (that is, each `TntDef`, `TntEx` and `TntType`). We need this in order to allow method signatures receiving each component without having to replicate the interface structure.

Closes https://github.com/informalsystems/tnt/issues/72