### PR TITLE
add support for flatten

### DIFF
--- a/tntc/src/runtime/impl/compilerImpl.ts
+++ b/tntc/src/runtime/impl/compilerImpl.ts
@@ -194,6 +194,11 @@ export class CompilerVisitor implements IRVisitor {
         )
         break
 
+      case 'flatten':
+        this.applyFun(1, (set: Set<Set<EvalResult>>) =>
+          just(set.flatten(1) as Set<EvalResult>))
+        break
+
       case 'exists':
         this.mapLambdaThenReduce(
           set => set.find(([result, _]) => result === true) !== undefined

--- a/tntc/test/runtime/compile.test.ts
+++ b/tntc/test/runtime/compile.test.ts
@@ -254,6 +254,20 @@ describe('compiling specs to runtime values', () => {
       )
     })
 
+    it('computes flatten', () => {
+      assertResultAsString(
+        'set(set(1, 2), set(2, 3), set(3, 4)).flatten()',
+        'set(1, 2, 3, 4)'
+      )
+    })
+
+    it('computes flatten on nested sets', () => {
+      assertResultAsString(
+        'set(set(set(1, 2), set(2, 3)), set(set(3, 4))).flatten()',
+        'set(set(1, 2), set(2, 3), set(3, 4))'
+      )
+    })
+
     it('computes exists', () => {
       assertResult('set(1, 2, 3).exists(x => true)', true)
       assertResult('set(1, 2, 3).exists(x => false)', false)


### PR DESCRIPTION
Closes #151. Add support for `flatten`, which is basically delegating to `Set.flatten(1)` of immutable-js.