### PR TITLE
Clear VSCode diagnostics when validation succeeds

### DIFF
--- a/vscode/tnt/server/src/server.ts
+++ b/vscode/tnt/server/src/server.ts
@@ -153,6 +153,8 @@ documents.onDidChangeContent(change => {
     .then((result) => {
       return checkTypesAndEffects(change.document, result.tntModule, result.sourceMap, result.definitionTable)
     })
+    // Clear possible old diagnostics
+    .then((_) => connection.sendDiagnostics({ uri: change.document.uri, diagnostics: [] }))
     .catch(diagnostics => {
       // Send the computed diagnostics to VSCode.
       connection.sendDiagnostics({ uri: change.document.uri, diagnostics })


### PR DESCRIPTION
Hello :octocat:

This fixes #214 by cleaning up diagnosis if the chain of promises resolves. I assumed diagnosis were cleared automatically on file change and I just needed to push the new ones, but I actually need to clear them manually.