### PR TITLE
add signatures for setToMap

### DIFF
--- a/tntc/src/effects/builtinSignatures.ts
+++ b/tntc/src/effects/builtinSignatures.ts
@@ -42,6 +42,7 @@ const mapOperators = [
   { name: 'get', effect: '(Read[r1], Read[r2]) => Read[r1, r2]' },
   { name: 'keys', effect: '(Read[r1]) => Read[r1]' },
   { name: 'mapOf', effect: '(Read[r1], (Read[r1]) => Read[r2]) => Read[r1, r2]' },
+  { name: 'setToMap', effect: '(Read[r1]) => Read[r1]' },
   { name: 'setOfMaps', effect: '(Read[r1], Read[r2]) => Read[r1, r2]' },
   { name: 'update', effect: '(Read[r1], Read[r2], Read[r3]) => Read[r1, r2, r3]' },
   { name: 'updateAs', effect: '(Read[r1], Read[r2], (Read[r1]) => Read[r3]) => Read[r1, r2, r3]' },

--- a/tntc/src/types/builtinSignatures.ts
+++ b/tntc/src/types/builtinSignatures.ts
@@ -46,6 +46,7 @@ const mapOperators = [
   { name: 'get', type: '(a -> b, a) => b' },
   { name: 'keys', type: '(a -> b) => set(a)' },
   { name: 'mapOf', type: '(set(a), (a) => b) => a -> b' },
+  { name: 'setToMap', type: '(set((a, b))) => (a -> b)' },
   { name: 'setOfMaps', type: '(set(a), set(b)) => set(a -> b)' },
   { name: 'update', type: '(a -> b, a, b) => a -> b' },
   { name: 'updateAs', type: '(a -> b, a, (a) => b) => a -> b' },


### PR DESCRIPTION
A two-line fix that add type and effects signatures for `setToMap`.