### PR TITLE
Read input from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [unreleased]
+
+### Added
+
+- Support for reading input from stdin when the filename is `-`.

--- a/tntc/cli-tests.md
+++ b/tntc/cli-tests.md
@@ -135,6 +135,13 @@ bash -
 <!-- !test check tuples -->
     tntc parse ../examples/tuples.tnt
  
+### OK on parse from stdin
+
+<!-- !test check parse stdin -->
+```
+echo "module Foo { val x: int = 2 }" | tntc parse -
+```
+
 ### OK on typecheck tuples
 
 <!-- !test check tuples - Types & Effects-->

--- a/tntc/src/cli.ts
+++ b/tntc/src/cli.ts
@@ -24,7 +24,7 @@ function handleResult<A>(result: Either<String, A>) {
 // construct parsing commands with yargs
 const parseCmd = {
   command: 'parse <input>',
-  desc: 'parse a TNT specification',
+  desc: 'Parse a TNT specification. Reads from stdin if <input> is -.',
   builder: (yargs: any) =>
     yargs
       .option('out', {
@@ -45,7 +45,7 @@ const parseCmd = {
 // construct typecheck commands with yargs
 const typecheckCmd = {
   command: 'typecheck <input>',
-  desc: 'check types (TBD) and effects of a TNT specification',
+  desc: 'Check types (TBD) and effects of a TNT specification. Reads from stdin if <input> is -.',
   builder: (yargs: any) =>
     yargs
       .option('out', {
@@ -64,7 +64,7 @@ const typecheckCmd = {
 // construct repl commands with yargs
 const replCmd = {
   command: 'repl',
-  desc: 'run REPL',
+  desc: 'Run the REPL.',
   builder: (yargs: any) =>
     yargs,
   handler: runRepl,

--- a/tntc/src/cliCommands.ts
+++ b/tntc/src/cliCommands.ts
@@ -80,10 +80,14 @@ interface TypecheckedStatus extends ParsedStatus {
  *
  * @param args the CLI arguments parsed by yargs */
 export function load(args: any): Either<string, LoadedStatus> {
+  // Set the file descriptor to stdin (0) if the input path is `-`
+  // otherwise, resolve from the current working directory
+  const fd = args.input === '-' ? 0 : resolve(cwd(), args.input)
+  const path = fd === 0 ? '<stdin>' : args.input
+
   if (existsSync(args.input)) {
     try {
-      const path = resolve(cwd(), args.input)
-      const sourceCode = readFileSync(path, 'utf8')
+      const sourceCode = readFileSync(fd, 'utf8')
       return right({
         args,
         path,


### PR DESCRIPTION
I thought this would help make tntc a bit more unixy and also make it
easier to write some simple stuff in our integration tests.

This follows the relatively common convention documented in
https://www.baeldung.com/linux/dash-in-command-line-parameters

However, it is currently blocked by https://github.com/yargs/yargs/issues/1312#issuecomment-1338157693

Two other alternatives would be:

- read from `stdin` if a `--stdin` flag were given
- read from stdin if an input file isn't given. This is what `cat` does. This
  can sometimes be a git confusing however, as the program can appear to be
  hanging if accidentally leave off the file name and don't realize what you're
  doing.