### PR TITLE
Build vscode plugin in all CI operating systems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,11 @@ jobs:
       - run: cd ./quint && npm run antlr
 
   quint-vscode-plugin:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
We have not been checking CI whether the vscode plugin can be compiled on Mac
and Windows. This change adds that CI check.