### PR TITLE
Update documentation for the VSCode extension

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,4 +78,4 @@ jobs:
       - name: Install yalc
         run: npm i yalc -g
       - name: Compile quint vscode plugin
-        run: make vscode
+        run: make local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,39 @@ true
 true
 ```
 
+## Using the VSCode plugin from source
 
+There are many ways to use the VSCode plugin from source. You also may want to use it with an unpublished version of `quint`.
+This section is a suggestion on how to do it, and its also how we do it.
+
+To build the vscode plugin, run the `vscode` make target from [the root of this repo](../../):
+
+```sh
+make vscode
+```
+
+To install the plugin for use, link the combined pluging into your vscode
+extensions. From the root of this repo, you can run
+
+```sh
+ln --symbolic $PWD/vscode/quint-vscode/ $HOME/.vscode/extensions/informal.quint-vscode
+```
+
+### Using the VSCode plugin with an unpublished version of `quint`
+
+We use `yalc` to manage unpublished packages. To install it, run
+
+``` sh
+npm i yalc -g
+```
+
+Then use the `local` make target to replace the published version of `quint` with the local one and build the plugin:
+
+``` sh
+make local
+```
+
+Make sure you have the folder linked to your vscode extensions as described above.
 
 [Apalache]: https://github.com/informalsystems/apalache
 [Contributing to Apalache]: https://github.com/informalsystems/apalache/blob/unstable/CONTRIBUTING.md

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,21 @@
 # @file
 # @version 0.1
 
-.PHONY: vscode quint all
+.PHONY: vscode quint local all
 
 all: vscode
 
 # Build quint and install it to local packages
 quint:
-	cd quint; npm install; npm run compile; npm link; yalc publish
+	cd quint; npm install; npm run compile; npm link;
 
 # Build quint and install it to local packages
 vscode: quint
-	cd vscode/quint-vscode/server; yalc add @informalsystems/quint
+	cd vscode/quint-vscode; npm install; npm run compile
+
+local: quint
+	cd quint; yalc publish
+	cd vscode/quint-vscode/server; npm uninstall @informalsystems/quint; yalc add @informalsystems/quint
 	cd vscode/quint-vscode; npm install; npm run compile
 
 # end

--- a/examples/tictactoe/tictactoe.qnt
+++ b/examples/tictactoe/tictactoe.qnt
@@ -14,7 +14,7 @@ module tictactoe {
   action Move(player, coordinate) = all {
     BoardIs(coordinate, "_"),
     board' = board.set(
-      coordinate._1, 
+      coordinate._1,
       board.get(coordinate._1).set(coordinate._2, player)
     ),
   }
@@ -49,8 +49,8 @@ module tictactoe {
   }
 
   val corners = Set(
-    (1,1), 
-    (3,1), 
+    (1,1),
+    (3,1),
     (1,3),
     (3,3)
   )
@@ -126,7 +126,7 @@ module tictactoe {
   // Invariants: The things we are checking for.
   val XHasNotWon = not(Won("X"))
   val OHasNotWon = not(Won("O"))
-  
+
   val BoardFilled = not(tuples(1.to(3), 1.to(3)).exists(coordinate =>
     BoardIs(coordinate, "_")
   ))

--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -1,19 +1,36 @@
-# Change Log
+# Changelog
 
-All notable changes to the "quint" extension will be documented in this file.
+All notable changes to the Quint VSCode extension will be documented in this file.
 
-### 0.0.9
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### v0.1.0 -- 2022-12-23
+
+#### Added
+
+Improved documentation and prepared for publishing.
+
+### v0.0.9 -- 2022-12-23
+
+#### Added
 
 Included type and effect checking.
 
-### 0.0.8
+### v0.0.8
+
+#### Added
 
 Included the second parser pass that diagnoses name errors.
 
-### 0.0.7
+### v0.0.7
+
+#### Added
 
 Included a parser pass that diagnoses syntax errors.
 
-### 0.0.1
+### v0.0.1
+
+#### Added
 
 The very first version that has minimal syntax highlighting.

--- a/vscode/quint-vscode/README.md
+++ b/vscode/quint-vscode/README.md
@@ -1,54 +1,53 @@
 # Quint
 
-
+This extension provides language support for Quint, the specification language.
 
 ## Features
 
 - Syntax Highlighting
-- Syntax errors
-- Undefined and conflicting names
+- Diagnostics:
+  - Syntax errors
+  - Undefined and conflicting names
+  - Type errors
+  - Effect errors
+  - Mode errors
+
+New features are listed and discussed on [this GitHub
+discussion](https://github.com/informalsystems/quint/discussions/254).
+
+Parse errors are highlighted in red, and hovering over the error will show the
+error message.
+
+![parseerror](https://user-images.githubusercontent.com/18356186/209388281-c3f24d4d-9fe0-4958-ba4e-e3b20ca89e8a.gif)
+
+Hovering over an expression or definition will show its inferred type and
+effect.
+
+![hover](https://user-images.githubusercontent.com/18356186/209388287-1888c715-484d-4a34-a3e5-13c50166b3dd.gif)
+
+Type errors are highlighted in red, and hovering over the error will show the
+error message, including unification errors.
+
+![typeerror](https://user-images.githubusercontent.com/18356186/209388285-fc1f42ab-0b07-4feb-92af-54011a7a250c.gif)
+
+Effects can help you quickly notice if you forgot to update a state variable or
+are trying to update the same variables more than one time. Effect errors are
+highlighted in red, and hovering over the error will show the error message.
+
+![effecterror](https://user-images.githubusercontent.com/18356186/209388284-5d47d0da-3861-426f-b016-b5b686ec6dc7.gif)
+
+Modes can help you maintain expectations regarding an operator. `pure` operators
+can't interact with the state, `def`s and `val`s can read the state (but not
+write), and only `action`s can update the state. Mode errors are highlighted in
+red, and hovering over the error will show the error message.
+
+![modeerror](https://user-images.githubusercontent.com/18356186/209388278-6e55583e-85c1-4f74-adab-301860c6c0fd.gif)
 
 ## Requirements
 
-Since Quint packages are still not on npm, we use `yalc` to locally publish and manage packages
+There are no external requirements.
 
 ## Known Issues
 
-No known issues yet.
-
-## Release Notes
-
-Users appreciate release notes as you update your extension.
-
-### 0.0.1
-
-The very first version that has minimal syntax highlighting.
-
-### 0.0.7
-
-Included a parser pass that diagnoses syntax errors.
-
-### 0.0.8
-
-Included the second parser pass that diagnoses name errors.
-
-## [Temp] How to run it locally
-
-We use `yalc` to manage unpublished packages. To install it, run
-
-``` sh
-npm i yalc -g
-```
-
-To build the vscode plugin, run the `vscode` make target from [the root of this repo](../../):
-
-```sh
-make vscode
-```
-
-To install the plugin for use, link the combined pluging into your vscode
-extensions. From the roof of this repo, you can run
-
-```sh
-ln --symbolic $PWD/vscode/quint-vscode $HOME/.vscode/extensions/
-```
+Issues are tracked on GitHub under the [Fvscode
+tag](https://github.com/informalsystems/quint/labels/Fvscode).

--- a/vscode/quint-vscode/README.md
+++ b/vscode/quint-vscode/README.md
@@ -18,30 +18,30 @@ discussion](https://github.com/informalsystems/quint/discussions/254).
 Parse errors are highlighted in red, and hovering over the error will show the
 error message.
 
-<img src=https://user-images.githubusercontent.com/18356186/209388281-c3f24d4d-9fe0-4958-ba4e-e3b20ca89e8a.gif width=400>
+<img src=https://user-images.githubusercontent.com/18356186/209388281-c3f24d4d-9fe0-4958-ba4e-e3b20ca89e8a.gif width=600>
 
 Hovering over an expression or definition will show its inferred type and
 effect.
 
-<img src=https://user-images.githubusercontent.com/18356186/209388287-1888c715-484d-4a34-a3e5-13c50166b3dd.gif width=400>
+<img src=https://user-images.githubusercontent.com/18356186/209388287-1888c715-484d-4a34-a3e5-13c50166b3dd.gif width=600>
 
 Type errors are highlighted in red, and hovering over the error will show the
 error message, including unification errors.
 
-<img src=https://user-images.githubusercontent.com/18356186/209388285-fc1f42ab-0b07-4feb-92af-54011a7a250c.gif width=400>
+<img src=https://user-images.githubusercontent.com/18356186/209388285-fc1f42ab-0b07-4feb-92af-54011a7a250c.gif width=600>
 
 Effects can help you quickly notice if you forgot to update a state variable or
 are trying to update the same variables more than one time. Effect errors are
 highlighted in red, and hovering over the error will show the error message.
 
-<img src=https://user-images.githubusercontent.com/18356186/209388284-5d47d0da-3861-426f-b016-b5b686ec6dc7.gif width=400>
+<img src=https://user-images.githubusercontent.com/18356186/209388284-5d47d0da-3861-426f-b016-b5b686ec6dc7.gif width=600>
 
 Modes can help you maintain expectations regarding an operator. `pure` operators
 can't interact with the state, `def`s and `val`s can read the state (but not
 write), and only `action`s can update the state. Mode errors are highlighted in
 red, and hovering over the error will show the error message.
 
-<img src=https://user-images.githubusercontent.com/18356186/209388278-6e55583e-85c1-4f74-adab-301860c6c0fd.gif width=400>
+<img src=https://user-images.githubusercontent.com/18356186/209388278-6e55583e-85c1-4f74-adab-301860c6c0fd.gif width=600>
 
 ## Requirements
 

--- a/vscode/quint-vscode/README.md
+++ b/vscode/quint-vscode/README.md
@@ -18,30 +18,30 @@ discussion](https://github.com/informalsystems/quint/discussions/254).
 Parse errors are highlighted in red, and hovering over the error will show the
 error message.
 
-![parseerror](https://user-images.githubusercontent.com/18356186/209388281-c3f24d4d-9fe0-4958-ba4e-e3b20ca89e8a.gif)
+<img src=https://user-images.githubusercontent.com/18356186/209388281-c3f24d4d-9fe0-4958-ba4e-e3b20ca89e8a.gif width=400>
 
 Hovering over an expression or definition will show its inferred type and
 effect.
 
-![hover](https://user-images.githubusercontent.com/18356186/209388287-1888c715-484d-4a34-a3e5-13c50166b3dd.gif)
+<img src=https://user-images.githubusercontent.com/18356186/209388287-1888c715-484d-4a34-a3e5-13c50166b3dd.gif width=400>
 
 Type errors are highlighted in red, and hovering over the error will show the
 error message, including unification errors.
 
-![typeerror](https://user-images.githubusercontent.com/18356186/209388285-fc1f42ab-0b07-4feb-92af-54011a7a250c.gif)
+<img src=https://user-images.githubusercontent.com/18356186/209388285-fc1f42ab-0b07-4feb-92af-54011a7a250c.gif width=400>
 
 Effects can help you quickly notice if you forgot to update a state variable or
 are trying to update the same variables more than one time. Effect errors are
 highlighted in red, and hovering over the error will show the error message.
 
-![effecterror](https://user-images.githubusercontent.com/18356186/209388284-5d47d0da-3861-426f-b016-b5b686ec6dc7.gif)
+<img src=https://user-images.githubusercontent.com/18356186/209388284-5d47d0da-3861-426f-b016-b5b686ec6dc7.gif width=400>
 
 Modes can help you maintain expectations regarding an operator. `pure` operators
 can't interact with the state, `def`s and `val`s can read the state (but not
 write), and only `action`s can update the state. Mode errors are highlighted in
 red, and hovering over the error will show the error message.
 
-![modeerror](https://user-images.githubusercontent.com/18356186/209388278-6e55583e-85c1-4f74-adab-301860c6c0fd.gif)
+<img src=https://user-images.githubusercontent.com/18356186/209388278-6e55583e-85c1-4f74-adab-301860c6c0fd.gif width=400>
 
 ## Requirements
 

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -1,69 +1,75 @@
 {
-    "name": "quint-vscode",
-    "displayName": "Quint",
-    "description": "Language support for Quint specifications",
-    "version": "0.0.9",
-    "publisher": "informal",
-    "engines": {
-        "vscode": "^1.43.0"
-    },
-    "categories": [
-        "Programming Languages"
-    ],
-    "bugs": {
-        "url": "https://github.com/informalsystems/quint"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/informalsystems/quint.git"
-    },
-    "activationEvents": [
-        "onLanguage:quint"
-    ],
-    "main": "./client/out/extension",
-    "contributes": {
-        "languages": [
-            {
-                "id": "quint",
-                "aliases": [
-                    "Quint",
-                    "quint"
-                ],
-                "extensions": [
-                    ".qnt"
-                ],
-                "configuration": "./language-configuration.json"
-            }
-        ],
-        "grammars": [
-            {
-                "language": "quint",
-                "scopeName": "source.quint",
-                "path": "./syntaxes/quint.tmLanguage.json"
-            }
-        ]
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -b",
-        "watch": "tsc -b -w",
-        "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
-        "test": "sh ./scripts/e2e.sh",
-        "format": "eslint --fix '**/*.ts'"
-    },
-    "devDependencies": {
-        "@types/mocha": "^8.2.2",
-        "@types/node": "^12.12.0",
-        "@typescript-eslint/eslint-plugin": "^5.30.6",
-        "@typescript-eslint/parser": "^5.30.6",
-        "eslint": "^8.27.0",
-        "eslint-config-recommended": "^4.1.0",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-json": "^3.1.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-unused-imports": "^2.0.0",
-        "mocha": "^8.3.2",
-        "typescript": "^4.2.3"
-    }
+	"name": "quint-vscode",
+	"displayName": "Quint",
+	"description": "Language support for Quint specifications",
+	"version": "0.1.0",
+	"publisher": "informal",
+	"engines": {
+		"vscode": "^1.43.0"
+	},
+	"categories": [
+		"Programming Languages"
+	],
+	"bugs": {
+		"url": "https://github.com/informalsystems/quint/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/informalsystems/quint.git"
+	},
+	"activationEvents": [
+		"onLanguage:quint"
+	],
+	"main": "./client/out/extension",
+	"contributes": {
+		"languages": [
+			{
+				"id": "quint",
+				"aliases": [
+					"Quint",
+					"quint"
+				],
+				"extensions": [
+					".qnt"
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "quint",
+				"scopeName": "source.quint",
+				"path": "./syntaxes/quint.tmLanguage.json"
+			}
+		]
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -b",
+		"watch": "tsc -b -w",
+		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
+		"test": "sh ./scripts/e2e.sh",
+		"format": "eslint --fix '**/*.ts'"
+	},
+	"devDependencies": {
+		"@types/mocha": "^8.2.2",
+		"@types/node": "^12.12.0",
+		"@typescript-eslint/eslint-plugin": "^5.30.6",
+		"@typescript-eslint/parser": "^5.30.6",
+		"eslint": "^8.27.0",
+		"eslint-config-recommended": "^4.1.0",
+		"eslint-plugin-import": "^2.26.0",
+		"eslint-plugin-json": "^3.1.0",
+		"eslint-plugin-node": "^11.1.0",
+		"eslint-plugin-promise": "^6.1.1",
+		"eslint-plugin-unused-imports": "^2.0.0",
+		"mocha": "^8.3.2",
+		"typescript": "^4.2.3"
+	},
+	"__metadata": {
+		"id": "b64283c0-9b4d-474c-a8df-6d3266bae7bd",
+		"publisherDisplayName": "Informal Systems",
+		"publisherId": "28b3f43c-0c1b-4c12-aa64-8dabbb7fe4cd",
+		"isPreReleaseVersion": false
+	}
 }


### PR DESCRIPTION
Hello :octocat: 

This updates the documentation for the extension (with GIFs!) and its developer instructions (`CONTRIBUTING.md` and `Makefile`).

Also, I changed the CI configs so the `vscode` jobs are using the unpublished version of `quint` so we are ensured that changes to `quint` are not breaking the extension.