### PR TITLE
Update `inferTypes` parameters to match  `inferEffects`

### DIFF
--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -165,7 +165,7 @@ export function typecheck(parsed: ParsedStage): CLIProcedure<TypecheckedStage> {
   const definitionsTable = table
   const errorLocator = mkErrorMessage(sourceMap)
 
-  const [typeErrMap, types] = inferTypes(module, definitionsTable)
+  const [typeErrMap, types] = inferTypes(definitionsTable, module)
   const typeErrors: ErrorMessage[] = Array.from(typeErrMap, errorLocator)
   // TODO add once logging functionality is added
   // if (typeErrors.length === 0) console.log("type inference succeeded")

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -99,7 +99,7 @@ export function
     .chain(parseData => {
       const { module, table, sourceMap } = parseData
       // in the future, we will be using types and effects
-      const [typeErrors, _types] = inferTypes(module, table)
+      const [typeErrors, _types] = inferTypes(table, module)
       const [effectsErrors, _effects] = inferEffects(table, module)
       // since the type checker and effects checker are incomplete,
       // collect the errors, but do not stop immediately on error

--- a/quint/src/types/inferrer.ts
+++ b/quint/src/types/inferrer.ts
@@ -30,7 +30,7 @@ import { solveConstraint } from './constraintSolver'
  *          ids to the corresponding error for any problematic expressions.
  */
 export function inferTypes(
-  quintModule: QuintModule, table: LookupTableByModule
+  table: LookupTableByModule, quintModule: QuintModule
 ): [Map<bigint, ErrorTree>, Map<bigint, TypeScheme>] {
   const visitor = new ConstraintGeneratorVisitor(solveConstraint, table)
   walkModule(visitor, quintModule)

--- a/quint/test/types/inferrer.test.ts
+++ b/quint/test/types/inferrer.test.ts
@@ -39,7 +39,7 @@ describe('inferTypes', () => {
       'def d(S) = S.map(p => p + 10)',
     ])
 
-    const [errors, types] = inferTypes(quintModule, definitionsTable)
+    const [errors, types] = inferTypes(definitionsTable, quintModule)
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
 
     const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
@@ -73,7 +73,7 @@ describe('inferTypes', () => {
       'def b(g, q) = g(q) + g(not(q))',
     ])
 
-    const [errors, types] = inferTypes(quintModule, definitionsTable)
+    const [errors, types] = inferTypes(definitionsTable, quintModule)
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
 
     const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
@@ -99,7 +99,7 @@ describe('inferTypes', () => {
       'val a = e({ f1: 2 }).fieldNames()',
     ])
 
-    const [errors, types] = inferTypes(quintModule, definitionsTable)
+    const [errors, types] = inferTypes(definitionsTable, quintModule)
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
 
     const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
@@ -134,7 +134,7 @@ describe('inferTypes', () => {
       'def e(p, q) = (p._1, q._2)',
     ])
 
-    const [errors, types] = inferTypes(quintModule, definitionsTable)
+    const [errors, types] = inferTypes(definitionsTable, quintModule)
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
 
     const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
@@ -155,7 +155,7 @@ describe('inferTypes', () => {
       'def e(p): (int) => int = p',
     ])
 
-    const [errors, types] = inferTypes(quintModule, definitionsTable)
+    const [errors, types] = inferTypes(definitionsTable, quintModule)
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
 
     const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
@@ -170,7 +170,7 @@ describe('inferTypes', () => {
       'def e(p): (t) => t = p + 1',
     ])
 
-    const [errors] = inferTypes(quintModule, definitionsTable)
+    const [errors] = inferTypes(definitionsTable, quintModule)
     assert.sameDeepMembers([...errors.entries()], [
       [3n, {
         location: 'Checking type annotation (t) => t',
@@ -188,7 +188,7 @@ describe('inferTypes', () => {
       'def a = 1.map(p => p + 10)',
     ])
 
-    const [errors] = inferTypes(quintModule, definitionsTable)
+    const [errors] = inferTypes(definitionsTable, quintModule)
 
     assert.sameDeepMembers([...errors.entries()], [
       [6n, {

--- a/vscode/quint-vscode/server/src/server.ts
+++ b/vscode/quint-vscode/server/src/server.ts
@@ -296,7 +296,7 @@ function checkEffects(
 function checkTypes(
   textDocument: TextDocument, quintModule: QuintModule, sourceMap: Map<bigint, Loc>, table: LookupTableByModule
 ): Diagnostic[] {
-  const [errors, inferredTypes] = inferTypes(quintModule, table)
+  const [errors, inferredTypes] = inferTypes(table, quintModule)
   const diagnostics: Diagnostic[] = []
   const types: Map<Loc, string> = new Map<Loc, string>()
   errors.forEach((error, id) => {


### PR DESCRIPTION
Hello :octocat: 

This is a small refactor on the order of parameters for `inferTypes` since they differ from `inferEffects` for no reason. Fixes https://github.com/informalsystems/quint/issues/336.