### PR TITLE
Add missing flag to `copyfiles`

### DIFF
--- a/quint/package.json
+++ b/quint/package.json
@@ -88,7 +88,7 @@
     "yargs": "^17.2.1"
   },
   "scripts": {
-    "compile": "tsc && copyfiles ./src/builtin.qnt ./dist/src/",
+    "compile": "tsc && copyfiles -u 1 ./src/builtin.qnt ./dist/src/",
     "test": "mocha -r ts-node/register test/*.test.ts test/**/*.test.ts",
     "coverage": "nyc npm run test",
     "integration": "txm cli-tests.md && txm io-cli-tests.md",


### PR DESCRIPTION
Hello :octocat: 

I had a false positive while testing this library and only now realize it is actually missing a flag. It is not trivial to test this in CI, as our test suite runs on top of the `ts` source files and not `dist` iiuc.

PS: I'm using the `copyfiles` lib instead of `cp` to provide support to all OS.