### PR TITLE
Make runs work with effects

### DIFF
--- a/quint/src/effects/builtinSignatures.ts
+++ b/quint/src/effects/builtinSignatures.ts
@@ -124,8 +124,8 @@ const temporalOperators = [
 const otherOperators = [
   { name: 'assign', effect: '(Read[r1], Read[r2]) => Read[r2] & Update[r1]' },
   { name: 'then', effect: '(Read[r1] & Update[u], Read[r2] & Update[u]) => Read[r] & Update[u]' },
-  { name: 'times',
-    effect: '(Pure, Read[r] & Update[u]) => Read[r] & Update[u]' },
+  { name: 'repeated',
+    effect: '(Read[r] & Update[u], Pure) => Read[r] & Update[u]' },
   { name: 'assert', effect: '(Read[r]) => Read[r]' },
   { name: 'ite', effect: '(Read[r1], Read[r2] & Update[u], Read[r3] & Update[u]) => Read[r1, r2, r3] & Update[u]' },
 ]

--- a/quint/src/effects/modeChecker.ts
+++ b/quint/src/effects/modeChecker.ts
@@ -170,7 +170,7 @@ function collectVariables(v: Variables): Variables[] {
 }
 
 const modeOrder =
-  ['pureval', 'puredef', 'val', 'def', 'nondet', 'action', 'temporal']
+  ['pureval', 'puredef', 'val', 'def', 'nondet', 'action', 'temporal', 'run']
 
 function commonMode(m1: OpQualifier, m2: OpQualifier): OpQualifier {
   const p1 = modeOrder.findIndex(elem => elem === m1)


### PR DESCRIPTION
Hello :octocat: 

This fixes an outdated builtin signature and adds a tweak to the mode checker in order to make run definitions work with the effect checker. We still don't check effects for runs, but this gets rid of the errors.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
