### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## v0.5.1 -- 2023-01-13
 
 ### Fixed
 
@@ -14,11 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved how documentation is produced for VSCode compatibility (#485)
 - Enable access to builtin documentation parsed from `builtin.qnt` (#485)
 - The effect and mode checkers no longer complain about runs (#505)
+- Fixed missing lodash dependency (#484)
 
 ### Added
 
-- Fixed missing lodash dependency (#484)
-- A tutorial on integers (#484)
+- A tutorial on integers (#495)
 
 ## v0.5.0 -- 2022-12-22
 

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache 2.0",
       "dependencies": {
         "@sweet-monads/either": "^3.0.1",

--- a/quint/package.json
+++ b/quint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core tool for the Quint specification language",
   "keywords": [
     "temporal",


### PR DESCRIPTION
## v0.5.1 -- 2023-01-13

### Fixed

- Fixed REPL output for maps (#497)
- REPL reporting a runtime error on `0^0` (#492)
- Improved how documentation is produced for VSCode compatibility (#485)
- Enable access to builtin documentation parsed from `builtin.qnt` (#485)
- The effect and mode checkers no longer complain about runs (#505)
- Fixed missing lodash dependency (#484)

### Added

- A tutorial on integers (#484)
