### PR TITLE
Promote `assert` to be an action operator 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- `assert` is now an action operator, not a run operator (#542)
+
 ## v0.5.2 -- 2023-01-17
 
 ### Added

--- a/doc/lang.md
+++ b/doc/lang.md
@@ -57,10 +57,10 @@ TLA+](https://lamport.azurewebsites.net/tla/summary.pdf).
     - [Operators on actions](#operators-on-actions)
       - [Delayed assignment](#delayed-assignment)
       - [Non-deterministic choice](#non-deterministic-choice-1)
+      - [Assert](#assert)
     - [Runs](#runs)
       - [Then](#then)
       - [Repeated](#repeated)
-      - [Assert](#assert)
     - [Temporal operators](#temporal-operators)
       - [Always](#always)
       - [Eventually](#eventually)
@@ -1680,6 +1680,21 @@ languages.
 
 See the discussion in: [Non-deterministic choice](#nondeterministic).
 
+#### Assert
+
+The operator `assert` has the following syntax:
+
+```scala
+assert(condition)
+```
+
+This operator always evaluates to `condition`, and it does not change the state
+variables. If `condition` evaluates to `false` in a state, then the user should
+receive a message about a runtime error. How exactly this is reported depends
+on the tool.
+
+*Mode:* Action.
+
 ### Runs
 
 A run represents a finite execution. In the simplest case, it represents
@@ -1789,20 +1804,6 @@ a.repeated(i).then((a.orKeep(vars)).repeated(j - i))
 ```
 
 See the description of [orKeep](#OrKeep) below.
-
-*Mode:* Run.
-
-#### Assert
-
-The operator `assert` has the following syntax:
-
-```scala
-assert(condition)
-```
-
-This operator is always enabled and it does not change the state. If
-`condition` evaluates to `false` in a state, then the run should be marked as
-"failed". How exactly this is reported depends on the tool.
 
 *Mode:* Run.
 


### PR DESCRIPTION
Closes #542. `assert` is now an action operator, not a run operator. I did not have to do much except moving the description in the manual.

As far as I understand, the mode checker does not enforce modes for some operators, e.g., I could do the following in REPL, which I expected the mode checker to complain about:

```
pure def a = assert(false)
```

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
