### PR TITLE
add the operator 'fail'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Operator `fail` (#552)
+
 ## v0.5.2 -- 2023-01-17
 
 ### Added

--- a/doc/lang.md
+++ b/doc/lang.md
@@ -61,6 +61,7 @@ TLA+](https://lamport.azurewebsites.net/tla/summary.pdf).
       - [Then](#then)
       - [Repeated](#repeated)
       - [Assert](#assert)
+      - [Fail](#fail)
     - [Temporal operators](#temporal-operators)
       - [Always](#always)
       - [Eventually](#eventually)
@@ -1803,6 +1804,21 @@ assert(condition)
 This operator is always enabled and it does not change the state. If
 `condition` evaluates to `false` in a state, then the run should be marked as
 "failed". How exactly this is reported depends on the tool.
+
+*Mode:* Run.
+
+#### Fail
+
+The operator `fail` has the following syntax:
+
+```scala
+A.fail()
+fail(A)
+```
+
+This operator returns `true` if and only if action `A` returns `false`.
+The operator `fail` is useful for writing runs that expect an action
+to be disabled.
 
 *Mode:* Run.
 

--- a/examples/ERC20/erc20.qnt
+++ b/examples/ERC20/erc20.qnt
@@ -2,10 +2,10 @@ module erc20 {
   type ADDR = str
 
   type TX =
-    | { tag: "none", id: int, fail: bool }
-    | { tag: "transfer", id: int, fail: bool, sender: ADDR, toAddr: ADDR, value: int }
-    | { tag: "approve", id: int, fail: bool, sender: ADDR, spender: ADDR, value: int }
-    | { tag: "transferFrom", id: int, fail: bool, sender: ADDR, fromAddr: ADDR, toAddr: ADDR, value: int }
+    | { tag: "none", id: int, failed: bool }
+    | { tag: "transfer", id: int, failed: bool, sender: ADDR, toAddr: ADDR, value: int }
+    | { tag: "approve", id: int, failed: bool, sender: ADDR, spender: ADDR, value: int }
+    | { tag: "transferFrom", id: int, failed: bool, sender: ADDR, fromAddr: ADDR, toAddr: ADDR, value: int }
 
   const ADDR: Set[ADDR]
   const AMMOUNTS: Set[int]
@@ -22,7 +22,7 @@ module erc20 {
     allowance' = tuples(ADDR, ADDR).mapBy(_ => 0),
     pendingTransactions' = Set(),
     nextTxId' = 0,
-    lastTx' = { id: 0, tag: "none", fail: false }
+    lastTx' = { id: 0, tag: "none", failed: false }
   }
 
   /* EIP-20:
@@ -36,11 +36,11 @@ module erc20 {
   Transfer event.
   */
   action SubmitTransfer(sender, toAddr, value) = {
-    val newTx = { id: nextTxId, tag: "transfer", fail: false,
+    val newTx = { id: nextTxId, tag: "transfer", failed: false,
                   sender: sender, toAddr: toAddr, value: value }
     all {
       pendingTransactions' = pendingTransactions.union(Set(newTx)),
-      lastTx' = { id: 0, tag: "none", fail: false },
+      lastTx' = { id: 0, tag: "none", failed: false },
       nextTxId' = nextTxId + 1,
       balanceOf' = balanceOf,
       allowance' = allowance,
@@ -53,14 +53,14 @@ module erc20 {
     pendingTransactions' = pendingTransactions.exclude(Set(tx)),
     allowance' = allowance,
     nextTxId' = nextTxId,
-    val fail = or {
+    val failed = or {
      tx.value < 0,
      tx.value > balanceOf.get(tx.sender),
      tx.sender == tx.toAddr
     }
     all {
-      lastTx' = tx.with("fail", fail),
-      if (fail)
+      lastTx' = tx.with("failed", failed),
+      if (failed)
         balanceOf' = balanceOf
       else
         balanceOf' = balanceOf
@@ -83,11 +83,11 @@ module erc20 {
   Transfer event.
   */
   action SubmitTransferFrom(sender, fromAddr, toAddr, value) = {
-    val newTx = { id: nextTxId, tag: "transferFrom", fail: false, sender: sender,
+    val newTx = { id: nextTxId, tag: "transferFrom", failed: false, sender: sender,
                   fromAddr: fromAddr, toAddr: toAddr, value: value }
     all {
       pendingTransactions' = pendingTransactions.union(Set(newTx)),
-      lastTx' = { id: 0, tag: "none", fail: false },
+      lastTx' = { id: 0, tag: "none", failed: false },
       nextTxId' = nextTxId + 1,
       balanceOf' = balanceOf,
       allowance' = allowance,
@@ -99,15 +99,15 @@ module erc20 {
     tx.tag == "transferFrom",
     pendingTransactions' = pendingTransactions.exclude(Set(tx)),
     nextTxId' = nextTxId,
-    val fail = or {
+    val failed = or {
      tx.value < 0,
      tx.value > balanceOf.get(tx.fromAddr),
      tx.value > allowance.get((tx.fromAddr, tx.sender)),
      tx.fromAddr == tx.toAddr
     }
     all {
-      lastTx' = tx.with("fail", fail),
-      if (fail)
+      lastTx' = tx.with("failed", failed),
+      if (failed)
         all {
           balanceOf' = balanceOf,
           allowance' = allowance,
@@ -128,11 +128,11 @@ module erc20 {
   with _value.
   */
   action SubmitApprove(sender, spender, value) = {
-    val newTx = { id: nextTxId, tag: "approve", fail: false,
+    val newTx = { id: nextTxId, tag: "approve", failed: false,
                   sender: sender, spender: spender, value: value }
     all {
       pendingTransactions' = pendingTransactions.union(Set(newTx)),
-      lastTx' = { id: 0, tag: "none", fail: false },
+      lastTx' = { id: 0, tag: "none", failed: false },
       nextTxId' = nextTxId + 1,
       balanceOf' = balanceOf,
       allowance' = allowance,
@@ -145,13 +145,13 @@ module erc20 {
     pendingTransactions' = pendingTransactions.exclude(Set(tx)),
     nextTxId' = nextTxId,
     balanceOf' = balanceOf,
-    val fail = or {
+    val failed = or {
      tx.value < 0,
      tx.sender > tx.spender,
     }
     all {
-      lastTx' = tx.with("fail", fail),
-      if (fail)
+      lastTx' = tx.with("failed", failed),
+      if (failed)
         allowance' = allowance
       else
         allowance' = allowance.set((tx.sender, tx.spender), tx.value)
@@ -198,7 +198,7 @@ module erc20 {
   val NoTransferFrom =
     val example = all {
       lastTx.tag == "transferFrom",
-      not(lastTx.fail),
+      not(lastTx.failed),
       lastTx.value > 0,
     }
 
@@ -212,7 +212,7 @@ module erc20 {
   val NoApprove =
     val example = all {
       lastTx.tag == "approve",
-      not(lastTx.fail),
+      not(lastTx.failed),
       lastTx.value > 0,
     }
 
@@ -228,7 +228,7 @@ module erc20 {
     val badExample = all {
       lastTx.tag == "transferFrom",
       lastTx.value > 0,
-      not(lastTx.fail),
+      not(lastTx.failed),
       nondet tx = oneOf(pendingTransactions)
       all {
         tx.tag == "approve",

--- a/quint/src/builtin.qnt
+++ b/quint/src/builtin.qnt
@@ -852,6 +852,11 @@ module builtin {
   /// ```
   action repeated(a, n): (bool, int) => bool
 
+  /// `a.fail()` evaluates to `true` if and only if action `a` evaluates to `false`.
+  ///
+  /// This operator is good for writing tests that expect an action to fail.
+  action then(a, b): (bool, bool) => bool
+
   /// `assert(p)` is an action that is true when `p` is true.
   ///
   /// It does not change the state.

--- a/quint/src/definitionsCollector.ts
+++ b/quint/src/definitionsCollector.ts
@@ -84,6 +84,7 @@ export function defaultValueDefinitions(): ValueDefinition[] {
     { kind: 'def', identifier: 'next' },
     { kind: 'def', identifier: 'then' },
     { kind: 'def', identifier: 'repeated' },
+    { kind: 'def', identifier: 'fail' },
     { kind: 'def', identifier: 'assert' },
     { kind: 'def', identifier: 'orKeep' },
     { kind: 'def', identifier: 'mustChange' },

--- a/quint/src/effects/builtinSignatures.ts
+++ b/quint/src/effects/builtinSignatures.ts
@@ -126,6 +126,8 @@ const otherOperators = [
   { name: 'then', effect: '(Read[r1] & Update[u], Read[r2] & Update[u]) => Read[r] & Update[u]' },
   { name: 'repeated',
     effect: '(Read[r] & Update[u], Pure) => Read[r] & Update[u]' },
+  { name: 'fail',
+    effect: '(Read[r] & Update[u]) => Read[r] & Update[u]' },
   { name: 'assert', effect: '(Read[r]) => Read[r]' },
   { name: 'ite', effect: '(Read[r1], Read[r2] & Update[u], Read[r3] & Update[u]) => Read[r1, r2, r3] & Update[u]' },
 ]

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -741,6 +741,12 @@ export class CompilerVisitor implements IRVisitor {
         this.translateAllOrThen(app)
         break
 
+      case 'fail':
+        this.applyFun(app.id, 1, (result) => {
+          return just(rv.mkBool(!result.toBool()))
+        })
+        break
+
       case 'assert':
         this.applyFun(app.id, 1, (cond) => {
           if (!cond.toBool()) {

--- a/quint/src/types/builtinSignatures.ts
+++ b/quint/src/types/builtinSignatures.ts
@@ -120,6 +120,7 @@ const otherOperators = [
   { name: 'ite', type: '(bool, a, a) => a' },
   { name: 'then', type: '(bool, bool) => bool' },
   { name: 'repeated', type: '(bool, int) => bool' },
+  { name: 'fail', type: '(bool) => bool' },
   { name: 'assert', type: '(bool) => bool' },
 ]
 

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -917,14 +917,24 @@ describe('compiling specs to runtime values', () => {
       assertVarAfterRun('run1', 'n', '4', input)
     })
 
-    it('assert', () => {
+    it('fail', () => {
       const input = dedent(
         `var n: int
-        |run run1 = (n' = 1).then(assert(n < 3).repeated(3))
+        |run run1 = (n' = 1).fail()
         `)
 
       evalVarAfterRun('run1', 'n', input)
-        .mapLeft(m => assert.fail(`Expected an error, found: ${m}`))
+        .mapRight(m => assert.fail(`Expected the run to fail, found: ${m}`))
+    })
+
+    it('assert', () => {
+      const input = dedent(
+        `var n: int
+        |run run1 = (n' = 3).then(and { assert(n < 3), n' = n })
+        `)
+
+      evalVarAfterRun('run1', 'n', input)
+        .mapRight(m => assert.fail(`Expected an error, found: ${m}`))
     })
   })
 })


### PR DESCRIPTION
Closes #543. Introduce the operator `fail` that flips the result of a run from success to failure and vice versa. This operator is useful for writing tests that are expected to fail.

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
