### PR TITLE
add a few productivity hacks to repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A few productivity hacks in REPL (#557)
 - Operator `fail` (#552)
 
 ## v0.5.2 -- 2023-01-17

--- a/examples/counters.qnt
+++ b/examples/counters.qnt
@@ -4,25 +4,25 @@ module counters {
 
   // initialize the state machine
   action Init = {
-    n <- 1
+    n' = 1
   }
 
   // divide n by 2, when n is even
   action OnEven = all {
     n % 2 == 0,
-    n <- n / 2,
+    n' = n / 2,
   }
 
   // double n, when n is divisible by 3
   action OnDivByThree = all {
     n % 3 == 0,
-    n <- 2 * n
+    n' = 2 * n
   }
 
   // increment n, when n is positive
   action OnPositive = all {
     n > 0,
-    n <- n + 1
+    n' = n + 1
   }
 
   // The state machine is composed of three actions:
@@ -37,11 +37,11 @@ module counters {
 
   // the run, where n goes via 1, 2, 3, 6, 3
   run run1 = {
-    (n <- 1)
-      .then(n <- 2)
-      .then(n <- 3)
-      .then(n <- 6)
-      .then(n <- 3)
+    (n' = 1)
+      .then(n' = 2)
+      .then(n' = 3)
+      .then(n' = 6)
+      .then(n' = 3)
   }
 
   // the run that initialized with Init and

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -177,8 +177,13 @@ bash -
 <!-- !test check tuples - Types & Effects-->
     quint typecheck ../examples/tuples.qnt
 
-
 ### OK on typecheck clockSync3
 
 <!-- !test check typecheck clockSync3.qnt -->
     quint typecheck ../examples/ClockSync/clockSync3.qnt
+
+### OK on typecheck counters
+
+<!-- !test check counters - Types & Effects-->
+    quint typecheck ../examples/counters.qnt
+

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -125,3 +125,50 @@ quint typecheck --out test-out.json ./testFixture/TrivialTypeError.qnt ; ret=$?;
 <!-- !test err typecheck failure quiet with out flag -->
 ```
 ```
+
+## Use of the `--required` flag
+
+### Repl loads a file with -r
+
+<!-- !test in repl loads a file -->
+```
+echo "import counters.*" | quint -r ../examples/counters.qnt 2>&1 | tail -n +3
+```
+
+<!-- !test out repl loads a file -->
+```
+true
+>>> 
+>>> 
+```
+
+### Repl loads a file and a module with -r
+
+<!-- !test in repl loads a file and a module -->
+```
+echo "Init" | quint -r ../examples/counters.qnt::counters 2>&1 | tail -n +3
+```
+
+<!-- !test out repl loads a file and a module -->
+```
+true
+
+>>> true
+>>> 
+```
+
+### Repl loads a file with .load
+
+<!-- !test in repl loads a file with .load -->
+```
+echo ".load ../examples/counters.qnt counters" \
+  | quint 2>&1 | tail -n +3
+```
+
+<!-- !test out repl loads a file with .load -->
+```
+>>> true
+
+>>> >>> 
+```
+

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -48,7 +48,13 @@ const typecheckCmd = {
 const replCmd = {
   command: ['repl', '*'],
   desc: 'run REPL',
-  builder: (yargs: any) => yargs,
+  builder: (yargs: any) =>
+    yargs
+      .option('require', {
+        desc: 'filename[::module]. Preload the file and, optionally, import the module',
+        alias: 'r',
+        type: 'string',
+      }),
   handler: runRepl,
 }
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -21,7 +21,7 @@ import { ErrorTree, errorTreeToString } from './errorTree'
 import { Either, left, right } from '@sweet-monads/either'
 import { Effect } from './effects/base'
 import { LookupTableByModule } from './lookupTable'
-import { quintRepl } from './repl'
+import { ReplOptions, quintRepl } from './repl'
 import { OpQualifier, QuintModule } from './quintIr'
 import { TypeScheme } from './types/base'
 import { inferTypes } from './types/inferrer'
@@ -195,7 +195,19 @@ export function typecheck(parsed: ParsedStage): CLIProcedure<TypecheckedStage> {
  * @param _argv parameters as provided by yargs
  */
 export function runRepl(_argv: any) {
-  quintRepl(process.stdin, process.stdout)
+  let filename: string | undefined = undefined
+  let moduleName: string | undefined = undefined
+  if (_argv.require) {
+    const m = /^(.*?)(?:|::([a-zA-Z_]\w*))$/.exec(_argv.require)
+    if (m) {
+      [ filename, moduleName ] = m.slice(1, 3)
+    }
+  }
+  const options: ReplOptions = {
+    preloadFilename: filename,
+    importModule: moduleName,
+  }
+  quintRepl(process.stdin, process.stdout, options)
 }
 
 /**

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -38,7 +38,7 @@ const withIO = async(inputText: string): Promise<string> => {
   // whatever is written on the input goes to the output
   input.pipe(output)
 
-  const rl = quintRepl(input, output, () => {})
+  const rl = quintRepl(input, output, {}, () => {})
 
   // Emit the input line-by-line, as nodejs is printing prompts.
   // TODO: is it a potential source of race conditions in unit tests?


### PR DESCRIPTION
I have added a few productivity tricks to running REPL for loading files:

 - CLI:
   - `quint -r filename.qnt` loads `filename.qnt` right after the start
   - `quint -r filename.qnt::myModule` loads `filename.qnt` right after the start and imports `myModule`
 - REPL:
   - `.load filename.qnt myModule` loads `filename.qnt` and imports `myModule` (I believe this should be replaced with an import from a file in the future)
   - `.reload` clears the history, loads the previously loaded file and imports `myModule` (if it was previously imported).

These hacks should help us in automation of follow-up tutorials.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
