### PR TITLE
Release VSCode extension v0.1.2

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Quint VSCode extension will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## v0.1.2 -- 2023-01-24
 
 ### Added
 

--- a/vscode/quint-vscode/package-lock.json
+++ b/vscode/quint-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quint-vscode",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-vscode",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "quint-vscode",
 	"displayName": "Quint",
 	"description": "Language support for Quint specifications",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"publisher": "informal",
 	"engines": {
 		"vscode": "^1.43.0"

--- a/vscode/quint-vscode/server/package-lock.json
+++ b/vscode/quint-vscode/server/package-lock.json
@@ -1,20 +1,21 @@
 {
 	"name": "quint-lsp-server",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-lsp-server",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"license": "Apache 2.0",
 			"dependencies": {
-				"@informalsystems/quint": "^0.5.2",
+				"@informalsystems/quint": "^0.5.4",
 				"vscode-languageserver": "^7.0.0",
 				"vscode-languageserver-textdocument": "^1.0.1"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.2.18",
+				"@types/lodash": "^4.14.191",
 				"@types/mocha": "^8.2.2",
 				"@types/node": "^12.12.0",
 				"@typescript-eslint/eslint-plugin": "^5.30.6",
@@ -386,9 +387,9 @@
 			"dev": true
 		},
 		"node_modules/@informalsystems/quint": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.5.2.tgz",
-			"integrity": "sha512-wbls95Euu3kcww9GKKABwtpyZDMKaXfWlGZNSAL6035ts8oDHuB3Y4agkb1/xQAK72YH7xXSg1cbc8vhWvUgGw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.5.4.tgz",
+			"integrity": "sha512-pvmjHnNHeH5V1zLSBKf+BTj76QKx66WhVkmiuHfweIJxLo7VOFd7S67XJkJLZ70vlvzAmfixG8p35kjtaon4dg==",
 			"dependencies": {
 				"@sweet-monads/either": "^3.0.1",
 				"@sweet-monads/maybe": "^3.1.0",
@@ -619,6 +620,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/line-column/-/line-column-1.0.0.tgz",
 			"integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w=="
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.191",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+			"integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+			"dev": true
 		},
 		"node_modules/@types/mocha": {
 			"version": "8.2.3",
@@ -6743,9 +6750,9 @@
 			"dev": true
 		},
 		"@informalsystems/quint": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.5.2.tgz",
-			"integrity": "sha512-wbls95Euu3kcww9GKKABwtpyZDMKaXfWlGZNSAL6035ts8oDHuB3Y4agkb1/xQAK72YH7xXSg1cbc8vhWvUgGw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.5.4.tgz",
+			"integrity": "sha512-pvmjHnNHeH5V1zLSBKf+BTj76QKx66WhVkmiuHfweIJxLo7VOFd7S67XJkJLZ70vlvzAmfixG8p35kjtaon4dg==",
 			"requires": {
 				"@sweet-monads/either": "^3.0.1",
 				"@sweet-monads/maybe": "^3.1.0",
@@ -6939,6 +6946,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/line-column/-/line-column-1.0.0.tgz",
 			"integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w=="
+		},
+		"@types/lodash": {
+			"version": "4.14.191",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+			"integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+			"dev": true
 		},
 		"@types/mocha": {
 			"version": "8.2.3",

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "quint-lsp-server",
 	"description": "LSP server for Quint in node.",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"author": "Informal Systems",
 	"license": "Apache 2.0",
 	"engines": {
@@ -12,7 +12,7 @@
 		"url": "https://github.com/informalsystems/quint"
 	},
 	"dependencies": {
-		"@informalsystems/quint": "^0.5.2",
+		"@informalsystems/quint": "^0.5.4",
 		"vscode-languageserver": "^7.0.0",
 		"vscode-languageserver-textdocument": "^1.0.1"
 	},


### PR DESCRIPTION
## v0.1.2 -- 2023-01-24

### Added

- Support for "Go to definition" (#546).