### PR TITLE
Fix: REPL Output Color In Dark Terminal

### DIFF
--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -356,7 +356,7 @@ function chalkQuintEx(ex: QuintEx): string {
       switch (ex.opcode) {
         case 'Set': {
           const as = ex.args.map(chalkQuintEx).join(', ')
-          return chalk.green('Set') + chalk.black(`(${as})`)
+          return chalk.green('Set') + `(${as})`
         }
 
         case 'Map': {
@@ -370,17 +370,17 @@ function chalkQuintEx(ex: QuintEx): string {
             }
           })
           const as = ps.join(', ')
-          return chalk.green('Map') + chalk.black(`(${as})`)
+          return chalk.green('Map') + `(${as})`
         }
 
         case 'Tup': {
           const as = ex.args.map(chalkQuintEx).join(', ')
-          return chalk.black(`(${as})`)
+          return `(${as})`
         }
 
         case 'List': {
           const as = ex.args.map(chalkQuintEx).join(', ')
-          return chalk.black(`[${as}]`)
+          return `[${as}]`
         }
 
         case 'Rec': {


### PR DESCRIPTION
![repl color output (1)](https://user-images.githubusercontent.com/101010359/215876570-541fabb7-5cd6-4f84-9a8b-d3126a165fd2.jpg)

removed the chalk.black so that the terminal would use the default foreground

resolves #574