### PR TITLE
add better error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
  - The parser complains about junk in the end of file (#603)
+ - Fix a confusing error message in assignments (#606)
 
 ## v0.5.4 -- 2023-01-24
 

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -2,9 +2,9 @@
  * Compiler of Quint expressions and definitions to Computable values
  * that can be evaluated in the runtime.
  *
- * Igor Konnov, 2022
+ * Igor Konnov, 2022-2023
  *
- * Copyright (c) Informal Systems 2022. All rights reserved.
+ * Copyright (c) Informal Systems 2022-2023. All rights reserved.
  * Licensed under the Apache 2.0.
  * See License.txt in the project root for license information.
  */
@@ -186,26 +186,9 @@ export class CompilerVisitor implements IRVisitor {
         break
       }
 
-      case 'assign': {
-        if (this.compStack.length < 2) {
-          this.addCompileError(app.id, 'Assignment <- needs two arguments')
-          return
-        }
-        const [register, rhs] = this.compStack.splice(-2)
-        const name = (register as Register).name
-        const nextvar = this.contextGet(name, ['nextvar']) as Register
-        if (nextvar) {
-          this.compStack.push(rhs)
-          this.applyFun(app.id, 1, (value) => {
-            nextvar.registerValue = just(value)
-            return just(rv.mkBool(true))
-          })
-        } else {
-          this.addCompileError(app.id, `${name} not found in ${name} <- ...`)
-          this.compStack.push(fail)
-        }
+      case 'assign':
+        this.translateAssign(app.id)
         break
-      }
 
       case 'eq':
         this.applyFun(app.id, 2, (x, y) => just(rv.mkBool(x.equals(y))))
@@ -828,6 +811,35 @@ export class CompilerVisitor implements IRVisitor {
       this.compStack.push(mkCallable(registers, lambdaBody))
     } else {
       this.addCompileError(lam.id, 'Compilation of lambda failed')
+    }
+  }
+
+  private translateAssign(sourceId: bigint): void {
+    if (this.compStack.length < 2) {
+      this.addCompileError(sourceId,
+        `Assignment '=' needs two arguments`)
+      return
+    }
+    const [register, rhs] = this.compStack.splice(-2)
+    const name = (register as Register).name
+    if (name === undefined) {
+      this.addCompileError(sourceId,
+        `Assignment '=' applied to a non-variable`)
+      this.compStack.push(fail)
+      return
+    }
+
+    const nextvar = this.contextGet(name, ['nextvar']) as Register
+    if (nextvar) {
+      this.compStack.push(rhs)
+      this.applyFun(sourceId, 1, (value) => {
+        nextvar.registerValue = just(value)
+        return just(rv.mkBool(true))
+      })
+    } else {
+      this.addCompileError(sourceId,
+        `Undefined next variable in ${name} = ...`)
+      this.compStack.push(fail)
     }
   }
 


### PR DESCRIPTION
Closes #444. Add a less confusing error messaging for the example:

```
val x = 1
x' = 2
```

It's actually surprising that this code made it to REPL without an error by the mode checker. I guess, this is one of the known issues, @bugarela? 

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
