### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.5.5 -- 2023-02-03
+
+### Added
 
  - Change the grammar to support multiple modules (#547)
  - Change static analysis to support multiple modules (#559)

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Apache 2.0",
       "dependencies": {
         "@sweet-monads/either": "^3.0.1",

--- a/quint/package.json
+++ b/quint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Core tool for the Quint specification language",
   "keywords": [
     "temporal",


### PR DESCRIPTION
## v0.5.5 -- 2023-02-03

### Added

 - Change the grammar to support multiple modules (#547)
 - Change static analysis to support multiple modules (#559)
 - Add an example that specifies the Solidity Coin contract (#576)
 - A work-in-progress example on Solidity's Simple Auction (#573)
 - Parse `100_000_000` and `0xabcd`, `0xAB_CD` as integers (#580)

### Fixed

 - The parser complains about junk in the end of file (#603)
 - Fix a confusing error message in assignments (#606)
 - REPL compiles unsupported operators and issues runtime errors (#604)

