### PR TITLE
fix syntax highlighting

### DIFF
--- a/editor-plugins/emacs/quint-mode.el
+++ b/editor-plugins/emacs/quint-mode.el
@@ -4,6 +4,7 @@
 ;; URL: https://github.com/informalsystems/quint
 ;; Version: 1.0.0
 ;; Created: 25 Feb 2022
+;; Updated 03 Feb 2023
 ;; Keywords: languages
 
 ;; This file is not part of GNU Emacs.
@@ -20,14 +21,8 @@
 ;;; Code:
 
 ;; define several category of keywords
-(defconst quint-types '("int" "str" "bool" "set" "seq"))
-(defconst quint-keywords '("Set", "Map", "List", "Rec", "Tup", "not" "and" "or" "iff" "implies" "exists" "guess" "forall" "in" "notin"
-      "union" "contains" "fold" "intersect" "exclude" "subseteq" "map" "applyTo" "filter"
-      "powerset" "flatten" "seqs" "chooseSome" "isFinite" "cardinality" "get" "put" "keys"
-      "mapBy" "setOfMaps" "set" "setBy" "fieldNames" "with" "tuples" "append" "concat" "head"
-      "tail" "length" "nth" "indices" "replaceAt" "slice" "select" "foldl" "foldr" "to" "always"
-      "eventually" "next" "orKeep" "mustChange" "enabled" "weakFair" "strongFair" "guarantees"
-      "existsConst" "forallConst" "chooseConst" "if" "else" "match" "all" "any"))
+(defconst quint-types '("int" "str" "bool" "Set" "List" "Map"))
+(defconst quint-keywords '("Rec", "Tup", "not" "and" "or" "iff" "implies" "all" "any" "if" "else"))
 (defconst quint-declarations '("module" "import" "const" "var" "def" "val" "pure"
                              "nondet" "action" "temporal" "assume" "type"))
 (defconst quint-constants '("Bool" "Int" "Nat" "false" "true"))

--- a/editor-plugins/emacs/quint-mode.el
+++ b/editor-plugins/emacs/quint-mode.el
@@ -21,7 +21,7 @@
 ;;; Code:
 
 ;; define several category of keywords
-(defconst quint-types '("int" "str" "bool" "Set" "List" "Map"))
+(defconst quint-types '("int" "str" "bool" "Set" "List"))
 (defconst quint-keywords '("Rec", "Tup", "not" "and" "or" "iff" "implies" "all" "any" "if" "else"))
 (defconst quint-declarations '("module" "import" "const" "var" "def" "val" "pure"
                              "nondet" "action" "temporal" "assume" "type"))

--- a/editor-plugins/highlight.js/quint.js
+++ b/editor-plugins/highlight.js/quint.js
@@ -1,0 +1,48 @@
+/*
+Language: Quint
+Requires:
+Author: Igor Konnov <igor@informal.systems>
+Contributors:
+Description: Quint is an executable specification language based on the Temporal Logic of Actions
+Website: https://github.com/informalsystems/quint
+*/
+function quintHljs(hljs) {
+  const n = {
+    keyword: [
+      'module', 'import', 'type', 'assume', 'const', 'var',
+      'val', 'def', 'pure', 'nondet', 'action', 'temporal', 'run',
+      'all', 'any', 'if', 'else'
+    ],
+    literal: [
+      'false', 'true', 'Bool', 'Nat', 'Int',
+    ],
+    operator: [
+      '=>', '<=', '>', '<', '=', '!=', '.', '*', '+', '-', '/', '%', '^',
+      'not', 'or', 'and', 'implies', 'iff',
+    ],
+    type: [ 'int', 'bool', 'str', 'Set', 'Map', 'List' ],
+    punctuation: [ ',', ';', '(', ')', '{', '}', '[', ']' ],
+  };
+
+  return {
+    name: 'Quint',
+    case_insensitive: false,
+    keywords: n,
+    contains: [
+      {
+        scope: 'string',
+        begin: '"',
+        end: '"'
+      },
+      {
+        scope: 'number',
+        begin: '-?(0x[0-9a-fA-F]([0-9a-fA-F]|_[0-9a-fA-F])*|0|[1-9]([0-9]|_[0-9])*)',
+      },
+      hljs.C_LINE_COMMENT_MODE,  // single line comments
+      hljs.C_BLOCK_COMMENT_MODE, // multiline comments
+    ],
+  };
+}
+
+hljs.registerLanguage('quint', quintHljs);
+

--- a/editor-plugins/highlight.js/testHighlightJs.html
+++ b/editor-plugins/highlight.js/testHighlightJs.html
@@ -1,0 +1,90 @@
+<html>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+    <script src="./quint.js"></script>
+    <script>
+        hljs.highlightAll();
+    </script>
+
+    <pre>
+        <code class="language-quint">
+/**
+ * This is a simple test of the syntax
+ * highlighting by highlight.js.
+ */
+module HighlightJS {
+    // single-line comments
+    type Addr = str
+    type UInt = int
+    type MyFlag = bool
+    type MySet = Set[int]
+    type MyList = List[int]
+    type MyMap = int -&gt; bool
+    type MyRec = { foo: int, bar: bool }
+    type MyTup = (int, bool)
+
+    pure val MAX_UINT = 2^256 - 1
+
+    pure def myAdd(x, y) = x + y
+    pure def mySub(x, y) = x - y
+    pure def myMul(x, y) = x * y
+    pure def myDiv(x, y) = x / y
+    pure def myMod(x, y) = x % y
+
+    pure def myEq(x, y) = (x == y)
+    pure def myNeq(x, y) = (x != y)
+    pure def myGt(x, y) = (x &gt; y)
+    pure def myGte(x, y) = (x &gt;= y)
+    pure def myLt(x, y) = (x &lt; y)
+    pure def myLte(x, y) = (x &lt;= y)
+
+    pure def myOr(x, y) = x or y
+    pure def myAnd(x, y) = x and y
+    pure def myImplies(x, y) = x implies y
+    pure def myIff(x, y) = x iff y
+    pure def myNot(x) = not(x)
+
+    const ADDR: Set[Addr]
+
+    var balances: Addr -&gt; UInt
+
+    def state = { balances: balances }
+
+    val totalSupply = ADDR.fold(0, (sum, a) =&gt; sum + balances.get(a))
+
+    action init: bool = {
+        nondet sender = oneOf(ADDR)
+        all {
+            balances' = ADDR.mapBy(a =&gt; 0)
+        }
+    }
+
+    action mint(sender: Addr, receiver: Addr, amount: UInt): bool = all {
+        require(sender == minter),
+        val newBal = balances.get(receiver) + amount
+        all {
+            require(isUInt(newBal)),
+            balances' = balances.set(receiver, newBal),
+        }
+    }
+
+    action step: bool = {
+        nondet sender = oneOf(ADDR)
+        nondet receiver = oneOf(ADDR)
+        nondet amount = 0.to(MAX_UINT).oneOf()
+        any {
+            mint(sender, receiver, amount),
+        }
+    }
+
+    temporal SampleInv: bool = always(isUInt(totalSupply))
+
+    // TESTS
+    run mintSendTest = {
+        init.then(mint("alice", "bob", 10))
+    }
+}
+        </code>
+    </pre>
+
+</html>

--- a/editor-plugins/vim/quint.vim
+++ b/editor-plugins/vim/quint.vim
@@ -33,7 +33,7 @@ syn match quintNumber '-\?\(0x[0-9a-fA-F]\([0-9a-fA-F]\|_[0-9a-fA-F]\)*\|0\|[1-9
 syn region quintString start='"' end='"'
 
 " types
-syn keyword quintType int str bool Set List Map Rec Tup
+syn keyword quintType int str bool Set List Rec Tup
 
 " typedefs
 syn keyword quintTypedef type

--- a/editor-plugins/vim/quint.vim
+++ b/editor-plugins/vim/quint.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: Quint
 " Maintainer: Igor Konnov, Informal Systems, igor at informal.systems
-" Latest Revision: 28 November 2022
+" Latest Revision: 03 February 2023
 "
 " How to install:
 " 1. Copy this file to ~/.vim/syntax/
@@ -29,11 +29,11 @@ syn region quintComment start="/\*" end="\*/" fold
 syn match quintIdent "[a-zA-Z_][a-zA-Z0-9_]*"
 
 " numbers and strings
-syn match quintNumber '-\?\d\+'
+syn match quintNumber '-\?\(0x[0-9a-fA-F]\([0-9a-fA-F]\|_[0-9a-fA-F]\)*\|0\|[1-9]([0-9]\|_[0-9])*\)'
 syn region quintString start='"' end='"'
 
 " types
-syn keyword quintType int str bool set list
+syn keyword quintType int str bool Set List Map Rec Tup
 
 " typedefs
 syn keyword quintTypedef type
@@ -43,27 +43,14 @@ syn keyword quintValue Bool Int Nat
 syn keyword quintBoolValue false true
 
 " conditionals
-syn keyword quintCond if else match
+syn keyword quintCond if else
 
 " declarations
-syn keyword quintDecl module import const var def val pure nondet action temporal assume
+syn keyword quintDecl module import const var val def pure nondet action temporal assume run
 
 " standard operators
 syn keyword quintStd Set List Map Rec Tup
-syn keyword quintStd not and or iff implies
-syn keyword quintStd exists guess forall in notin union
-syn match   quintStd "contains"   " use match, as 'contains' is a vim option
-syn match   quintStd "fold"       " use match, as 'fold' is a vim option
-syn keyword quintStd intersect exclude subseteq map applyTo filter
-syn keyword quintStd powerset flatten seqs chooseSome
-syn keyword quintStd isFinite cardinality get put keys mapBy setOfMaps
-syn keyword quintStd set setBy fieldNames with tuples append concat
-syn keyword quintStd head tail length nth indices replaceAt slice
-syn keyword quintStd select foldl foldr to
-syn keyword quintStd always eventually next orKeep mustChange
-syn keyword quintStd enabled weakFair strongFair guarantees
-syn keyword quintStd existsConst forallConst chooseConst
-syn keyword quintStd any all
+syn keyword quintStd not and or iff implies all any
 
 " curly braces
 syn region quintBlock start="{" end="}" fold transparent contains=ALLBUT,quintCurlyError
@@ -82,7 +69,7 @@ syn keyword quintOper "^" "-" "+" "*" "/" "%" "." " "<-" "<" ">" "<=" ">="
 syn keyword quintOper "==" "!=" "=>" "->"
 
 " delimiters
-syn match quintDelim "," ":" "|" "&"
+syn match quintDelim "," ":" ";"
 
 
 " highlighting instructions

--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -41,7 +41,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.quint",
-					"match": "\\b(module|extends|end|with|if|else|case)\\b"
+					"match": "\\b(module|import|if|else)\\b"
 				}
 			]
 		},
@@ -49,11 +49,11 @@
 			"patterns": [
 				{
 					"name": "storage.modifier.quint",
-					"match": "\\b(typedef|assume|const|var|val|def|pure|action|temporal)\\b"
+					"match": "\\b(type|assume|const|var|val|nondet|def|pure|action|temporal|run)\\b"
 				},
 				{
 					"name": "storage.type.quint",
-					"match": "\\b(rec|set|list|int|str|bool)\\b"
+					"match": "\\b(Tup|Rec|Set|List|Map|int|str|bool)\\b"
 				}
 			]
 		},
@@ -61,35 +61,11 @@
 			"patterns": [
 				{
 					"name": "keyword.operator.quint",
-					"match": "\\b(not|or|and|implies|iff|always|eventually|weakFair|strongFair|guarantees|next|unchanged|enabled|orKeep|mustChange)\\b"
+					"match": "\\b(not|or|and|implies|iff|all|any)\\b"
 				},
 				{
 					"name": "keyword.operator.quint",
-					"match": "\\b(guess|choose|forall|exists|map|filter|allLists|to)\\b"
-				},
-				{
-					"name": "keyword.operator.quint",
-					"match": "\\b(get|keys|mapOf|setOfMaps|update|updateAs|put)\\b"
-				},
-				{
-					"name": "keyword.operator.quint",
-					"match": "\\b(cardinality|isFinite|intersect|union|difference|powerset|chooseSome|fold)\\b"
-				},
-				{
-					"name": "keyword.operator.quint",
-					"match": "\\b(tuples|field|fieldNames|with|item)\\b"
-				},
-				{
-					"name": "keyword.operator.quint",
-					"match": "\\b(append|concat|head|tail|length|nth|indices|replaceAt|slice|select|foldl|foldr)\\b"
-				},
-				{
-					"name": "keyword.operator.quint",
-					"match": "\\b(all|any)\\b"
-				},
-				{
-					"name": "keyword.operator.quint",
-					"match": "(=>|<-|>|<|:=|=|!=|\\.|\\*|\\+|-|/|%|\\^|\\&|\\||subseteq|in|notin)"
+					"match": "(=>|<=|>|<|=|!=|\\.|\\*|\\+|-|/|%|\\^)"
 				}
 			]
 		},
@@ -108,7 +84,7 @@
 			"patterns": [
 				{
 					"name": "constant.numeric.quint",
-					"match": "-?\\d+"
+					"match": "-?(0x[0-9a-fA-F]([0-9a-fA-F]|_[0-9a-fA-F])*|0|[1-9]([0-9]|_[0-9])*)"
 				}
 			]
 		},
@@ -116,7 +92,7 @@
 			"patterns": [
 				{
 					"name": "constant.language.quint",
-					"match": "(false|true|Bool|Int|Nat|Str)"
+					"match": "(false|true|Bool|Int|Nat)"
 				}
 			]
 		},

--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -53,7 +53,7 @@
 				},
 				{
 					"name": "storage.type.quint",
-					"match": "\\b(Tup|Rec|Set|List|Map|int|str|bool)\\b"
+					"match": "\\b(Tup|Rec|Set|List|int|str|bool)\\b"
 				}
 			]
 		},

--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -41,7 +41,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.quint",
-					"match": "\\b(module|import|if|else)\\b"
+					"match": "\\b(module|import|if|else|not|or|and|implies|iff|all|any)\\b"
 				}
 			]
 		},
@@ -59,10 +59,6 @@
 		},
 		"operators": {
 			"patterns": [
-				{
-					"name": "keyword.operator.quint",
-					"match": "\\b(not|or|and|implies|iff|all|any)\\b"
-				},
 				{
 					"name": "keyword.operator.quint",
 					"match": "(=>|<=|>|<|=|!=|\\.|\\*|\\+|-|/|%|\\^)"


### PR DESCRIPTION
Closes #444 and many issues with syntax highlighting in vscode, vim, and emacs. Actually, we had a lot of keywords for operators that do not require any special treatment, they are just standard names.

On top of that, I have added a simple syntax schema for highlight.js with the intention to use it in the tutorials. You can see how it is supposed to work in `editor-plugins/highlight.js/testHighlightJs.html`. It needs integration in the tutorials though.