### PR TITLE
Remove errant commas from the emacs quint-mode

### DIFF
--- a/editor-plugins/emacs/quint-mode.el
+++ b/editor-plugins/emacs/quint-mode.el
@@ -22,7 +22,7 @@
 
 ;; define several category of keywords
 (defconst quint-types '("int" "str" "bool" "Set" "List"))
-(defconst quint-keywords '("Rec", "Tup", "not" "and" "or" "iff" "implies" "all" "any" "if" "else"))
+(defconst quint-keywords '("Rec" "Tup" "not" "and" "or" "iff" "implies" "all" "any" "if" "else"))
 (defconst quint-declarations '("module" "import" "const" "var" "def" "val" "pure"
                              "nondet" "action" "temporal" "assume" "type"))
 (defconst quint-constants '("Bool" "Int" "Nat" "false" "true"))


### PR DESCRIPTION
Some commas found there way into the quoted list. Not sure when these
slipped in, but no time recently!