### PR TITLE
Introduce the testing framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- command `test` to run unit tests (#634)
+
 ### Changed
 
 - `docs` subcommand now outputs generated docs to stdout (#617)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ distributed systems and blockchain protocols. It combines the robust theoretical
 basis of the [Temporal Logic of Actions][TLA] (TLA) with state-of-the-art static
 analysis and development tooling.
 
+This is how typical Quint code looks:
+
+```scala
+  // `validateBalance` should only be called upon genesis state.
+  pure def validateBalance(ctx: BankCtx, addr: Addr): bool = and {
+    ctx.accounts.contains(addr),
+    val coins = getAllBalances(ctx, addr)
+    coins.keys().forall(denom => coins.get(denom) > 0),
+  }
+```
+
+If you would like to see the same code in TLA<sup>+</sup>, here is how it looks:
+
+```tla
+\* `validateBalance` should only be called upon genesis state.
+validateBalance(ctx, addr) ==
+  /\ addr \in ctx.accounts
+  /\ LET coins == getAllBalances(ctx, addr) IN
+     \A denom \in DOMAIN coins:
+       coins[denom] > 0
+```
+
 Quint is inspired by [TLA+][] but provides an alternative surface syntax for
 specifying systems in TLA. The most important feature of our syntax is that it
 is minimal and regular, making Quint an easy target for advanced developer

--- a/doc/quint.md
+++ b/doc/quint.md
@@ -16,9 +16,9 @@ The main commands of `quint` are as follows:
  - [x] `repl` starts the REPL (Read-Eval-Print loop) for Quint
  - [x] `parse` parses a Quint specification and resolves names
  - [x] `typecheck` infers types in a Quint specification
- - [ ] `docs` produces documentation
+ - [x] `test` tests a Quint specification similar to property-based testing
  - [ ] `run` executes a Quint specification via random simulation
- - [ ] `test` tests a Quint specification similar to property-based testing
+ - [ ] `docs` produces documentation
  - [ ] `lint` checks a Quint specification for known deficiencies
  - [ ] `indent` indents a Quint specification
  - [ ] `to-apalache` translates a Quint specification to Apalache IR
@@ -116,7 +116,7 @@ the following is written:
 
    ```json
    {
-     "status": "typed",
+     "status": "typechecking",
      "module": <IR>,
      "types": { <typemap> }
      "effects": { <effectmap> }
@@ -212,12 +212,10 @@ of an output file.
 
    ```json
    {
-     "status": "tested",
-     "tests": {
-       "successful": [ <names of the successful tests> ],
-       "failed": [ <names of the failed tests> ],
-       "ignored": [ <names of the ignored tests> ],
-     }
+     "stage": "testing",
+     "passed": [ <names of the successful tests> ],
+     "failed": [ <names of the failed tests> ],
+     "ignored": [ <names of the ignored tests> ],
    }
    ```
 
@@ -226,8 +224,8 @@ of an output file.
 
    ```json
    {
-     "result": "error",
-     "messages": [ <errors and warnings> ]
+     "stage": "testing",
+     "errors": [ <errors and warnings> ]
    }
    ```
 

--- a/doc/quint.md
+++ b/doc/quint.md
@@ -116,7 +116,7 @@ the following is written:
 
    ```json
    {
-     "status": "typechecking",
+     "stage": "typechecking",
      "module": <IR>,
      "types": { <typemap> }
      "effects": { <effectmap> }
@@ -143,7 +143,8 @@ the following is written:
 *This command is not implemented yet.*
 
 ```sh
-quint run [--seed=<seed>] [--timeout=sec] [--out=<out>.json] <spec>.qnt <name>
+quint run [--seed=<seed>] [--timeout=sec] [--out=<out>.json] [--main=<name>] \
+  [--match=regex] <spec>.qnt <name>
 ```
 
 This command produces a random execution of a Quint specification,
@@ -154,9 +155,13 @@ the run structure that is given in the definition called `<name>`.
 for the random number generator. This is useful for reproducibility of
 executions.
 
-**Option `--timeout`**. The optional parameter `--timeout` specifies the
-maximum time (in seconds) to spend on interpretation. Once the time limit has
-been reached, the execution stops and outputs whatever it has computed.
+**Option `--main`**. The name of the main module, which will be run as a
+state machine. By default, this name is extracted from the filename.
+
+**Option `--timeout`**. The optional parameter `--timeout`
+specifies the maximum time (in seconds) to spend on interpretation. Once the
+time limit has been reached, the execution stops and outputs whatever it has
+computed.
 
 **Option `--out`**. The optional parameter `--out` specifies the name
 of an output file.
@@ -181,8 +186,8 @@ of an output file.
 *This command is not implemented yet.*
 
 ```sh
-quint test [--seed=<seed>] \
-  [--timeout=sec] [--tests=<test1>,...,<testN>] [--out=<out>.json] <spec>.qnt
+quint test [--seed=<seed>] [--timeout=sec] [--main=<name>] \
+  [--match=regex] [--out=<out>.json] <spec>.qnt
 ```
 
 This command receives a Quint specification whose name is given with
@@ -194,14 +199,16 @@ the definitions whose names start with `Test`.
 for the random number generator. This is useful for reproducibility of
 executions.
 
-**Option `--timeout`**. The optional parameter `--timeout` specifies the
-maximum time (in seconds) to spend on interpretation. Once the time limit has
-been reached, the execution stops and outputs whatever it has computed.
+**Option `--main`**. The name of the main module, which will be run as a
+state machine. By default, this name is extracted from the filename.
 
-**Option `--tests`**. The optional parameter `--tests` specifies a list of
-tests to be run. Note that the properties are checked against the sampled
-executions.  *It is not a complete verification of the specification
-properties.*
+**Option `--match`**. A regular expression that filters definitions to be
+used as tests. The default value is `.*Test`.
+
+**(Not implemented) Option `--timeout`**. The optional parameter `--timeout`
+specifies the maximum time (in seconds) to spend on interpretation. Once the
+time limit has been reached, the execution stops and outputs whatever it has
+computed.
 
 **Option `--out`**. The optional parameter `--out` specifies the name
 of an output file.
@@ -216,6 +223,7 @@ of an output file.
      "passed": [ <names of the successful tests> ],
      "failed": [ <names of the failed tests> ],
      "ignored": [ <names of the ignored tests> ],
+     "errors": [ <errors and warnings> ]
    }
    ```
 

--- a/examples/language-features/counters.qnt
+++ b/examples/language-features/counters.qnt
@@ -66,4 +66,27 @@ module counters {
       Next,
     }).repeated(10))
   }
+
+  // this test should not fail
+  run passingTest = {
+    Init.then(
+      all {
+        assert(n > 0),
+        Next,
+      }.repeated(10)
+    )
+  }
+
+  // this test should fail
+  run failingTest = {
+    Init.then(
+      all {
+        assert(n == 0),
+        Next,
+      }.repeated(10)
+    )
+  }
+
+  // this is just a value, and it should be ignored as a test
+  val ignoredTest = 1
 }

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -237,9 +237,14 @@ true
 
 ### Tests works as expected
 
+The command `test` finds failing tests and prints error messages.
+
 <!-- !test in test runs -->
 ```
-quint test --main counters --seed 1 ../examples/language-features/counters.qnt 2>&1 | sed 's/([0-9]*ms)/(duration)/g'
+quint test --main counters --seed 1 \
+  ../examples/language-features/counters.qnt 2>&1 | \
+  sed 's/([0-9]*ms)/(duration)/g' | \
+  sed 's#^.*counters.qnt#      HOME/counters.qnt#g'
 ```
 
 <!-- !test out test runs -->
@@ -252,6 +257,12 @@ quint test --main counters --seed 1 ../examples/language-features/counters.qnt 2
   1 passing (duration)
   1 failed
   1 ignored
+
+  1) failingTest:
+      HOME/counters.qnt:84:9 - error: Assertion failed
+      84:         assert(n == 0),
+                  ^^^^^^^^^^^^^^
+      
 
 ```
 

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -251,7 +251,7 @@ quint test --main counters --seed 1 \
 ```
 
   counters
-    ok  passingTest
+    ok passingTest
     1) failingTest
 
   1 passing (duration)

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -235,3 +235,23 @@ true
 >>> 
 ```
 
+### Tests works as expected
+
+<!-- !test in test runs -->
+```
+quint test --main counters --seed 1 ../examples/language-features/counters.qnt 2>&1 | sed 's/([0-9]*ms)/(duration)/g'
+```
+
+<!-- !test out test runs -->
+```
+
+  counters
+    ok  passingTest
+    1) failingTest
+
+  1 passing (duration)
+  1 failed
+  1 ignored
+
+```
+

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -12,6 +12,7 @@
         "@sweet-monads/either": "^3.0.1",
         "@sweet-monads/maybe": "^3.1.0",
         "@types/line-column": "^1.0.0",
+        "@types/seedrandom": "^3.0.4",
         "antlr4ts": "^0.5.0-alpha.4",
         "chalk": "^4.1.2",
         "eol": "^0.9.1",
@@ -20,6 +21,7 @@
         "line-column": "^1.0.2",
         "lodash": "^4.17.21",
         "lodash.isequal": "^4.5.0",
+        "seedrandom": "^3.0.5",
         "yargs": "^17.2.1"
       },
       "bin": {
@@ -860,6 +862,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
+    },
+    "node_modules/@types/seedrandom": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.4.tgz",
+      "integrity": "sha512-/rWdxeiuZenlawrHU+XV6ZHMTKOqrC2hMfeDfLTIWJhDZP5aVqXRysduYHBbhD7CeJO6FJr/D2uBVXB7GT6v7w=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -7339,6 +7346,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -9089,6 +9101,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
+    },
+    "@types/seedrandom": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.4.tgz",
+      "integrity": "sha512-/rWdxeiuZenlawrHU+XV6ZHMTKOqrC2hMfeDfLTIWJhDZP5aVqXRysduYHBbhD7CeJO6FJr/D2uBVXB7GT6v7w=="
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -13767,6 +13784,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "semver": {
       "version": "7.3.8",

--- a/quint/package.json
+++ b/quint/package.json
@@ -77,6 +77,7 @@
     "@sweet-monads/either": "^3.0.1",
     "@sweet-monads/maybe": "^3.1.0",
     "@types/line-column": "^1.0.0",
+    "@types/seedrandom": "^3.0.4",
     "antlr4ts": "^0.5.0-alpha.4",
     "chalk": "^4.1.2",
     "eol": "^0.9.1",
@@ -85,6 +86,7 @@
     "line-column": "^1.0.2",
     "lodash": "^4.17.21",
     "lodash.isequal": "^4.5.0",
+    "seedrandom": "^3.0.5",
     "yargs": "^17.2.1"
   },
   "scripts": {

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -66,21 +66,25 @@ const testCmd = {
   desc: 'Run tests against a Quint specification',
   builder: (yargs: any) =>
     yargs
+      .option('main', {
+        desc: 'name of the main module (by default, computed from filename)',
+        type: 'string',
+      })
       .option('out', {
         desc: 'output file',
         type: 'string',
       })
       .option('seed', {
         desc: 'random seed to use for non-deterministic choice',
-        type: 'number',
+        type: 'string',
       })
       .option('timeout', {
         desc: 'timeout in seconds',
         type: 'number',
       })
-      .option('tests', {
-        desc: 'names of tests to run',
-        type: 'array',
+      .option('match', {
+        desc: 'a string or regex that selects names to use as tests',
+        type: 'string',
       }),
   handler: (args: any) =>
     outputResult(load(args).chain(parse).chain(typecheck).chain(runTests)),

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -78,10 +78,13 @@ const testCmd = {
         desc: 'random seed to use for non-deterministic choice',
         type: 'string',
       })
-      .option('timeout', {
-        desc: 'timeout in seconds',
-        type: 'number',
-      })
+// Timeouts are postponed for:
+// https://github.com/informalsystems/quint/issues/633
+//
+//      .option('timeout', {
+//        desc: 'timeout in seconds',
+//        type: 'number',
+//      })
       .option('match', {
         desc: 'a string or regex that selects names to use as tests',
         type: 'string',

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -12,7 +12,9 @@
 
 import yargs from 'yargs/yargs'
 
-import { docs, load, outputResult, parse, runRepl, typecheck } from './cliCommands'
+import {
+  docs, load, outputResult, parse, runRepl, runTests, typecheck
+} from './cliCommands'
 
 // construct parsing commands with yargs
 const parseCmd = {
@@ -58,6 +60,32 @@ const replCmd = {
   handler: runRepl,
 }
 
+// construct test commands with yargs
+const testCmd = {
+  command: 'test <input>',
+  desc: 'Run tests against a Quint specification',
+  builder: (yargs: any) =>
+    yargs
+      .option('out', {
+        desc: 'output file',
+        type: 'string',
+      })
+      .option('seed', {
+        desc: 'random seed to use for non-deterministic choice',
+        type: 'number',
+      })
+      .option('timeout', {
+        desc: 'timeout in seconds',
+        type: 'number',
+      })
+      .option('tests', {
+        desc: 'names of tests to run',
+        type: 'array',
+      }),
+  handler: (args: any) =>
+    outputResult(load(args).chain(parse).chain(typecheck).chain(runTests)),
+}
+
 // construct documenting commands with yargs
 const docsCmd = {
   command: 'docs <input>',
@@ -75,6 +103,7 @@ yargs(process.argv.slice(2))
   .command(parseCmd)
   .command(typecheckCmd)
   .command(replCmd)
+  .command(testCmd)
   .command(docsCmd)
   .demandCommand(1)
   .strict()

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -71,7 +71,7 @@ const testCmd = {
         type: 'string',
       })
       .option('out', {
-        desc: 'output file',
+        desc: 'output file (suppresses all console output)',
         type: 'string',
       })
       .option('seed', {

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -271,7 +271,7 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
       // output the status for every test
       results.forEach(res => {
         if (res.status === 'passed') {
-          out(`    ${chalk.green('ok ')} ${res.name}`)
+          out('    ' + chalk.green('ok ') + res.name)
         }
         if (res.status === 'failed') {
           const errNo = namedErrors.length + 1

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -304,14 +304,22 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
       }
 
       // output errors, if there are any
-      if (isConsole) {
+      if (isConsole && namedErrors.length > 0) {
         const code = prev.sourceCode!
         const finder = lineColumn(code)
+        out('')
         namedErrors.forEach(([name, err], index) => {
           const details = formatError(code, finder, err)
-          out(`  ${index + 1}) ${name}`)
-          details.split('\n').forEach(line => {
-            out(chalk.red('    ' + line))
+          // output the header
+          out(`  ${index + 1}) ${name}:`)
+          const lines = details.split('\n')
+          // output the first line in red
+          if (lines.length > 0) {
+            out(chalk.red('      ' + lines[0]))
+          }
+          // and the rest in gray
+          lines.slice(1).forEach(line => {
+            out(chalk.gray('      ' + line))
           })
         })
         out('')

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -19,7 +19,7 @@ import { Either, left, right } from '@sweet-monads/either'
 
 import { IrErrorMessage, QuintEx } from './quintIr'
 import {
-  CompilationContext, compile, contextLookup, lastTraceName
+  CompilationContext, compileFromCode, contextLookup, lastTraceName
 } from './runtime/compile'
 import { formatError } from './errorReporter'
 import {
@@ -501,7 +501,7 @@ ${textToAdd}
     const [moduleText, lineOffset] =
       prepareParserInput(`  action __input =\n${newInput}`)
     // compile the expression or definition and evaluate it
-    const context = compile(moduleText, '__repl__')
+    const context = compileFromCode(moduleText, '__repl__')
     if (context.syntaxErrors.length > 0 ||
         context.compileErrors.length > 0 || context.analysisErrors.length > 0) {
       printErrors(moduleText, context, lineOffset)
@@ -552,7 +552,7 @@ ${textToAdd}
     // embed expression text into a module at the top level
     const [moduleText, lineOffset] = prepareParserInput(newInput)
     // compile the module and add it to history if everything worked
-    const context = compile(moduleText, '__repl__')
+    const context = compileFromCode(moduleText, '__repl__')
     if (context.values.size === 0 ||
         context.compileErrors.length > 0 || context.syntaxErrors.length > 0) {
       printErrors(moduleText, context, lineOffset)

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -14,8 +14,8 @@ import { readFileSync, writeFileSync } from 'fs'
 import lineColumn from 'line-column'
 import chalk from 'chalk'
 
-import { Maybe, just, none } from '@sweet-monads/maybe'
-import { Either, left, right } from '@sweet-monads/either'
+import { just } from '@sweet-monads/maybe'
+import { left, right } from '@sweet-monads/either'
 
 import { IrErrorMessage, QuintEx } from './quintIr'
 import {

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -14,7 +14,7 @@ import {
   ErrorMessage, Loc, parsePhase1, parsePhase2
 } from '../quintParserFrontend'
 import { Computable, ComputableKind, kindName } from './runtime'
-import { QuintModule, IrErrorMessage } from '../quintIr'
+import { IrErrorMessage, QuintModule } from '../quintIr'
 import { CompilerVisitor } from './impl/compilerImpl'
 import { walkDefinition } from '../IRVisitor'
 import { treeFromModule } from '../scoping'
@@ -100,7 +100,6 @@ export function
     return right(value)
   }
 }
-
 
 /**
  * Compile Quint modules to JS runtime objects from the parsed and type-checked

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -13,13 +13,13 @@ import { Either, left, right } from '@sweet-monads/either'
 import {
   ErrorMessage, Loc, parsePhase1, parsePhase2
 } from '../quintParserFrontend'
-import { ErrorTree, errorTreeToString } from '../errorTree'
 import { Computable, ComputableKind, kindName } from './runtime'
-import { IrErrorMessage } from '../quintIr'
+import { QuintModule, IrErrorMessage } from '../quintIr'
 import { CompilerVisitor } from './impl/compilerImpl'
 import { walkDefinition } from '../IRVisitor'
 import { treeFromModule } from '../scoping'
 import { LookupTableByModule } from '../lookupTable'
+import { TypeScheme } from '../types/base'
 import { QuintAnalyzer } from '../quintAnalyzer'
 import { mkErrorMessage } from '../cliCommands'
 
@@ -101,18 +101,69 @@ export function
   }
 }
 
+
 /**
- * Parse a string that contains a Quint module and compile it to executable
+ * Compile Quint modules to JS runtime objects from the parsed and type-checked
+ * data structures. This is a user-facing function. In case of an error, the
+ * error messages are passed to an error handler and the function returns
+ * undefined.
+ *
+ * @param modules Quint modules in the intermediate representation
+ * @param sourceMap source map as produced by the parser
+ * @param lookupTable lookup table as produced by the parser
+ * @param types type table as produced by the type checker
+ * @param mainName the name of the module that may contain state varibles
+ * @returns the compilation context
+ */
+export function
+  compile(modules: QuintModule[],
+          sourceMap: Map<bigint, Loc>,
+          lookupTable: LookupTableByModule,
+          types: Map<bigint, TypeScheme>,
+          mainName: string): CompilationContext {
+  // Push back the main module to the end
+  const main = modules.find(m => m.name === mainName)
+  // when the main module is not found, we will report an error
+  const mainNotFound =
+    main ? [] : [{
+      explanation: `Main module ${mainName} not found`,
+      refs: [],
+    }]
+  const reorderedModules =
+    modules.filter(m => m.name !== mainName).concat(main ? [main] : [])
+  // Compile all modules
+  const visitor = new CompilerVisitor(types)
+  reorderedModules.forEach(module => {
+    visitor.switchModule(module.id,
+                         lookupTable.get(module.name)!,
+                         treeFromModule(module))
+    module.defs.forEach(def => walkDefinition(visitor, def))
+  })
+  return {
+    lookupTable: lookupTable,
+    values: visitor.getContext(),
+    vars: visitor.getVars(),
+    shadowVars: visitor.getShadowVars(),
+    syntaxErrors: [],
+    analysisErrors: [],
+    compileErrors: visitor.getCompileErrors().concat(mainNotFound),
+    runtimeErrors: visitor.getRuntimeErrors(),
+    sourceMap: sourceMap,
+  }
+}
+
+/**
+ * Parse a string that contains Quint modules and compile it to executable
  * objects. This is a user-facing function. In case of an error, the error
  * messages are passed to an error handler and the function returns undefined.
  *
  * @param code text that stores one or several Quint modules,
  *        which should be parseable without any context
  * @param mainName the name of the module that may contain state varibles
- * @returns a mapping from names to computable values
+ * @returns the compilation context
  */
 export function
-  compile(code: string, mainName: string): CompilationContext {
+  compileFromCode(code: string, mainName: string): CompilationContext {
   // parse the module text
   return parsePhase1(code, '<input>')
     // On errors, we'll produce the computational context up to this point
@@ -126,36 +177,15 @@ export function
       modules.forEach(module => analyzer.analyze(module))
       // since the type checker and effects checker are incomplete,
       // collect the errors, but do not stop immediately on error
-      const [analysisErrors, result] = analyzer.getResult()
-      // Push back the main module to the end
-      const main = modules.find(m => m.name === mainName)
-      // when the main module is not found, we will report an error
-      const mainNotFound =
-        main ? [] : [{
-          explanation: `Main module ${mainName} not found`,
-          refs: [],
-        }]
-      const reorderedModules =
-        modules.filter(m => m.name !== mainName).concat(main ? [main] : [])
-      // Compile all modules
-      const visitor = new CompilerVisitor(result.types)
-      reorderedModules.forEach(module => {
-        visitor.switchModule(module.id, table.get(module.name)!, treeFromModule(module))
-        module.defs.forEach(def => walkDefinition(visitor, def))
-      })
+      const [analysisErrors, analysisResult] = analyzer.getResult()
+      const ctx =
+        compile(modules, sourceMap, table, analysisResult.types, mainName)
       const errorLocator = mkErrorMessage(sourceMap)
       return right({
-        lookupTable: table,
-        values: visitor.getContext(),
-        vars: visitor.getVars(),
-        shadowVars: visitor.getShadowVars(),
-        syntaxErrors: [],
+        ...ctx,
         analysisErrors: Array.from(analysisErrors, errorLocator),
-        compileErrors: visitor.getCompileErrors().concat(mainNotFound),
-        runtimeErrors: visitor.getRuntimeErrors(),
-        sourceMap: sourceMap,
       })
     }
-      // Wether we end up with a right or a left, we will have a CompilationContext
-    ).value
+  // we produce CompilationContext in any case
+  ).value
 }

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -65,10 +65,8 @@ compileAndTest(modules: QuintModule[],
       .map(comp => {
         const result = comp.eval()
         if (result.isNone()) {
-          // produce errors
-          const errors = ctx.runtimeErrors
-          // we do not want to see the same errors again
-          ctx.runtimeErrors.length = 0
+          // copy the runtime errors and clean them from the context
+          const errors = ctx.runtimeErrors.splice(0)
           return { name, status: 'failed', errors }
         }
   

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -1,0 +1,92 @@
+/*
+ * Unit-testing framework for the JS runtime.
+ *
+ * Igor Konnov, 2023
+ *
+ * Copyright (c) Informal Systems 2022. All rights reserved.
+ * Licensed under the Apache 2.0.
+ * See License.txt in the project root for license information.
+ */
+
+import { Either, left, merge } from '@sweet-monads/either'
+
+import { Loc } from '../quintParserFrontend'
+import { IrErrorMessage, QuintModule, QuintOpDef } from '../quintIr'
+import { LookupTableByModule } from '../lookupTable'
+import { TypeScheme } from '../types/base'
+
+import { compile, contextLookup } from './compile'
+
+/**
+ * Evaluation result.
+ * The implementation details are hidden behind this interface.
+ */
+export interface TestResult {
+  /**
+   * The test name.
+   */
+  name: string
+  /**
+   * The test status.
+   */
+  status: 'passed' | 'failed' | 'ignored'
+  /**
+   * When status === 'failed', errors contain the explanatory error messages.
+   */
+  errors: IrErrorMessage[]
+}
+
+/**
+ * Run a test suite of a single module.
+ *
+ * @param modules Quint modules in the intermediate representation
+ * @param mainName the module that should be used as a state machine
+ * @param sourceMap source map as produced by the parser
+ * @param lookupTable lookup table as produced by the parser
+ * @param types type table as produced by the type checker
+ * @param testMatch test name matcher
+ * @returns the results of running the tests
+ */
+export function
+compileAndTest(modules: QuintModule[],
+         main: QuintModule,
+         sourceMap: Map<bigint, Loc>,
+         lookupTable: LookupTableByModule,
+         types: Map<bigint, TypeScheme>,
+         testMatch: (n: string) => boolean): Either<string, TestResult[]> {
+  const ctx =
+    compile(modules, sourceMap, lookupTable, types, main.name)
+  const testDefs =
+    main.defs.filter(d => d.kind === 'def' && testMatch(d.name)) as QuintOpDef[]
+
+  return merge(testDefs.map(def => {
+    const name = def.name
+    return contextLookup(ctx, main.name, name, 'callable')
+      .map(comp => {
+        const result = comp.eval()
+        if (!result.isNone()) {
+          const ex = result.value.toQuintEx()
+          if (ex.kind !== 'bool') {
+            return { name, status: 'ignored', errors: [] }
+          } else {
+            if (ex.value) {
+              return { name, status: 'passed', errors: [] }
+            } else {
+              const e = {
+                explanation: `${name} returns false`,
+                refs: [def.id],
+              }
+              return { name, status: 'failed', errors: [e] }
+            }
+          }
+        } else {
+          // produce errors
+          const errors = ctx.runtimeErrors
+          // we do not want to see the same errors again
+          ctx.runtimeErrors.length = 0
+          return { name, status: 'failed', errors }
+        }
+      })
+  }))
+}
+

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -106,7 +106,7 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('computes addition', () => {
-      assertResultAsString('2 + 3', '4')
+      assertResultAsString('2 + 3', '5')
     })
 
     it('computes subtraction', () => {

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -4,7 +4,9 @@ import { Either, left, right } from '@sweet-monads/either'
 import { Maybe, just } from '@sweet-monads/maybe'
 import { expressionToString } from '../../src/IRprinting'
 import { ComputableKind, fail, kindName, EvalResult } from '../../src/runtime/runtime'
-import { CompilationContext, compile, contextLookup } from '../../src/runtime/compile'
+import {
+  CompilationContext, compileFromCode, contextLookup
+} from '../../src/runtime/compile'
 import { RuntimeValue } from '../../src/runtime/impl/runtimeValue'
 import { dedent } from '../textUtils'
 
@@ -12,7 +14,7 @@ import { dedent } from '../textUtils'
 // compare the result. This is the easiest path to test the results.
 function assertResultAsString(input: string, expected: string | undefined) {
   const moduleText = `module __runtime { val __expr = ${input} }`
-  const context = compile(moduleText, '__runtime')
+  const context = compileFromCode(moduleText, '__runtime')
   contextLookup(context, '__runtime', '__expr', 'callable')
     .mapLeft(msg => assert(false, msg))
     .mapRight(value => {
@@ -30,7 +32,7 @@ function assertResultAsString(input: string, expected: string | undefined) {
 // Compile an input and evaluate a callback in the context
 function evalInContext<T>(input: string, callable: (ctx: CompilationContext) => Either<string, T>) {
   const moduleText = `module __runtime { ${input} }`
-  const context = compile(moduleText, '__runtime')
+  const context = compileFromCode(moduleText, '__runtime')
   return callable(context)
 }
 

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -106,7 +106,7 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('computes addition', () => {
-      assertResultAsString('2 + 3', '5')
+      assertResultAsString('2 + 3', '4')
     })
 
     it('computes subtraction', () => {


### PR DESCRIPTION
Closes #628.

This PR introduces the command `test` that mimics the behavior of a unit-testing framework, e.g., of mocha. This command should let us integrate basic tests for protocols in the CI.

- [x] Tests added for any new code
- [ ] Ran `npm run format` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
