### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.6.0 -- 2023-02-22
+
+### Added
 
 - command `test` to run unit tests (#634)
 - option `--with-lookup` of the command `parse` (#639)

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@sweet-monads/either": "^3.0.1",

--- a/quint/package.json
+++ b/quint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Core tool for the Quint specification language",
   "keywords": [
     "temporal",


### PR DESCRIPTION
## v0.6.0 -- 2023-02-22

### Added

- command `test` to run unit tests (#634)
- option `--with-lookup` of the command `parse` (#639)

### Changed

- `docs` subcommand now outputs generated docs to stdout (#617)
- Mode errors are better explained and include a fix suggestion (#619)
- Typechecking now reports errors when instance overrides are not compatible with
  the original definition (#622)

### Deprecated
### Removed

- REPL does not support nested modules any longer (#621)

### Fixed

- REPL avoid name clashes in different modules (#621)
- REPL session is now a proper Quint file (#621)
- A regression in REPL caused by multiple modules (#650)

### Security

### Documentation

- the [Prisoners puzzle](./examples/puzzles/prisoners) (#634)

