### PR TITLE
Finish off automation of VSCode release prep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ executable and the VSCode plugin.
 ### quint executable
 
 - Prepare a release by running
-  [./quint/scripts/prepare-release.sh](./quint/scripts/prepare-release.sh).
+  [./quint/scripts/prepare-release.sh](./quint/scripts/prepare-release.sh) with
+  an argument to indicate the version increment: `patch`, `minor`, or `major`.
 - Get the release PR reviewed and merged
 - Checkout the release commit
 - Run the release script [./quint/scripts/release.sh](./quint/scripts/release.sh).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,5 +189,10 @@ executable and the VSCode plugin.
   
 ### VSCode Plugin
 
-To initiate a release of the VSCode plugin, run the script
-[./vscode/quint-vscode/scripts/prepare-release.sh](./vscode/quint-vscode/scripts/prepare-release.sh).
+- Prepare a release of the VSCode plugin by running the script
+  [./vscode/quint-vscode/scripts/prepare-release.sh](./vscode/quint-vscode/scripts/prepare-release.sh)
+  with an argument to indicate the version increment: `patch`, `minor`, or
+  `major`.
+- Get the release PR reviewed and merged
+- Checkout the release commit
+- Publish the plugin to the VSCode marketplace with `vsce publish`

--- a/quint/scripts/prepare-release.sh
+++ b/quint/scripts/prepare-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-set -x
+# set -x
 
 gh --version || (echo "gh must be installed: https://github.com/cli/cli#installation" && exit 1)
 npm --version || (echo "npm must be installed" && exit 1)
@@ -13,9 +13,9 @@ ROOT_DIR="$SCRIPT_DIR"/../..
 CHANGELOG="${ROOT_DIR}/CHANGELOG.md"
 cd "$SCRIPT_DIR"/..
 
-if [[ -z "$1" ]]
+if [[ -z "${1-}" ]]
 then
-    echo "An argument valid for 'npm version <arg>' must be supplied."
+    echo "ERROR: An argument valid for 'npm version <arg>' must be supplied."
     echo "See 'npm version --help'."
     exit 1
 fi

--- a/quint/scripts/release.sh
+++ b/quint/scripts/release.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-version=$(npm pkg get version | sed 's/"//g')
+set -euo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+QUINT_DIR="$( cd "$SCRIPT_DIR"/.. && pwd )"
+
+version=$(cd "$QUINT_DIR" && (npm pkg get version | sed 's/"//g'))
 commit_message=$(git log -1 --pretty=%B)
 expected_message="Release v${version}"
 

--- a/vscode/quint-vscode/scripts/prepare-release.sh
+++ b/vscode/quint-vscode/scripts/prepare-release.sh
@@ -1,51 +1,97 @@
 #!/usr/bin/env bash
 
-if [[ -z "${QUINT_VERSION}" ]]; then
-   echo "QUINT_VERSION environment variable is not set. Please set it to the version of the quint dependency you want to use."
-   exit 1
-fi
-
 set -euo pipefail
+# set -x
 
-function pause(){
-   read -p "$*"
-}
+# Throughout this script, we run many commands in subshells (i.e., wrapped in
+# parens) so that the directory changes needed for the command don't persist
+# further in the script.
 
 # Ensure that the script works when called from any directory
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR/..;
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
+ROOT_DIR=$(cd "$DIR"/../../../ && pwd)
+QUINT_DIR="$ROOT_DIR"/quint
+PLUGIN_DIR="$ROOT_DIR"/vscode/quint-vscode
+SERVER_DIR="$PLUGIN_DIR"/server
+PLUGIN_CHANGELOG="$PLUGIN_DIR"/CHANGELOG.md
+
+if [[ -z "${1-}" ]]
+then
+    echo "ERROR: An argument valid for 'npm version <arg>' must be supplied."
+    echo "See 'npm version --help'."
+    exit 1
+fi
+bump_increment="$1"
 
 git checkout main;
 git pull origin main;
 
-echo "Ensure that the quint dependency is correct, currently: $QUINT_VERSION. Set the QUINT_VERSION environment variable to update it."
-pause 'Press [Enter] key to continue...'
+QUINT_VERSION=$(cd "$QUINT_DIR" && npm pkg get version | sed 's/"//g')
 
-echo "Ensure that the VSCode version was bumped."
-echo "Extension: $(cat package.json | jq .version | xargs)."
-echo "Server: $(cat server/package.json | jq .version | xargs)."
-echo "You can run npm version <major|minor|patch> to bump the correct level. Remember to bump the server as well."
-pause 'Press [Enter] key to continue...'
+# See https://stackoverflow.com/a/1885534/1187277
+read -p "Prepare [${bump_increment}] release for vscode plugin targeting quint version [$QUINT_VERSION]? [yY]" -n 1 -r
+echo
+if ! [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Canceling release"
+    exit 1
+fi
 
-echo "Ensure that CHANGELOG.md is updated: There is an entry for this release and no UNRELEASED header."
-pause 'Press [Enter] key to continue...'
+# Bump plugin version
+(cd "$PLUGIN_DIR" && npm version "$bump_increment")
+(cd "$SERVER_DIR" && npm version "$bump_increment")
+version=$(cd "$PLUGIN_DIR" && npm pkg get version | sed 's/"//g')
 
-cd server;
-yalc remove @informalsystems/quint;
-npm install @informalsystems/quint@$QUINT_VERSION;
-cd ..;
-npm install;
-npm run compile;
+# Update changelog
+TMP_CHANGES=$(mktemp)
+trap 'rm "$TMP_CHANGES"' EXIT
 
-version=$(cat package.json | jq .version | xargs)
-git checkout -b vscode-release/$version;
-git add CHANGELOG.md;
-git add package.json;
-git add package-lock.json;
-git add server/package.json;
-git add server/package-lock.json;
-git commit -S -m "Release VSCode extension v$version"
+(
+cd "$PLUGIN_DIR"
+release_date=$(printf '%(%Y-%m-%d)T\n' -1)
+version_heading="## v${version} -- ${release_date}"
 
-echo "All good!"
-echo "Now check that everything is alright, push, and open a PR."
-echo "When the PR is merged, run vsce publish on an updated main branch."
+# Update the changelog
+sed -i "s/## UNRELEASED/## UNRELEASED\n\
+\n\
+### Added\n\
+### Changed\n\
+### Deprecated\n\
+### Removed\n\
+### Fixed\n\
+### Security\n\
+\n\
+${version_heading}/" "$PLUGIN_CHANGELOG"
+)
+
+# Get the release notes for the version by printing all lines between lines
+# starting with the version header and ending with the next version header,
+# inclusive. We then drop the last line to remove the subsequent version header.
+# It's saved to a temp file for later use.
+sed -n "/## v$version/,/## v/p" "$PLUGIN_CHANGELOG" | head -n -1 > "$TMP_CHANGES"
+
+# Ensure we can build package?
+# TODO: I'm not sure why we build/install here
+(
+    cd "$SERVER_DIR"
+    yalc remove @informalsystems/quint
+    npm install "@informalsystems/quint@${QUINT_VERSION}"
+)
+
+(
+    cd "$PLUGIN_DIR"
+    npm install
+    npm run compile
+)
+
+pr_title="VSCode Release v$version"
+release_branch="vscode-release/${version}"
+git checkout -b "$release_branch"
+git add "$PLUGIN_DIR"/{CHANGELOG.md,package.json,package-lock.json}
+git add "$SERVER_DIR"/{package.json,package-lock.json}
+git commit -S -m "$pr_title"
+git push origin "$release_branch"
+
+gh pr create --title "$pr_title" --body-file "$TMP_CHANGES"
+git checkout main
+git branch -D "$release_branch"

--- a/vscode/quint-vscode/scripts/prepare-release.sh
+++ b/vscode/quint-vscode/scripts/prepare-release.sh
@@ -71,7 +71,7 @@ ${version_heading}/" "$PLUGIN_CHANGELOG"
 sed -n "/## v$version/,/## v/p" "$PLUGIN_CHANGELOG" | head -n -1 > "$TMP_CHANGES"
 
 # Ensure we can build package?
-# TODO: I'm not sure why we build/install here
+# Ensure we can build the project
 (
     cd "$SERVER_DIR"
     yalc remove @informalsystems/quint


### PR DESCRIPTION
Closes #655 

Expands and tweaks the existing VSCode release prep script to make the process
of preparing the release commit fully automated. It basically just follows the
example from other parts of #470.

The script was used to prepare #654

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Documentation added for any new functionality