### PR TITLE
Add integration tests with Apalache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,14 @@ jobs:
         # See https://github.com/anko/txm/issues/10
         run: cd ./quint && txm io-cli-tests.md
         if: matrix.operating-system != 'windows-latest'
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin" # See 'Supported distributions' for available options
+          java-version: "19"
+      - name: Apalache integration tests
+        run: cd ./quint && npm run apalache-integration
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   quint-antlr-grammar:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,9 @@ jobs:
         run: cd ./quint && npm run apalache-integration
         env:
           GH_TOKEN: ${{ github.token }}
+        # This tests fail on windows currently
+        # See https://github.com/anko/txm/issues/10
+        if: matrix.operating-system != 'windows-latest'
 
   quint-antlr-grammar:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ client/server
 .local-pack
 .yalc
 *.vsix
+_build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # @file
 # @version 0.1
 
-.PHONY: vscode quint local tutorials all
+.PHONY: vscode quint local tutorials all apalache
 
 all: vscode
 
@@ -32,5 +32,16 @@ local: quint
 # Generate the tutorials
 tutorials:
 	$(MAKE) -C tutorials
+
+BUILD_DIR := quint/_build
+quint/_build:
+	mkdir $@
+
+# Download the latest Apalache for quint integration tests
+apalache: | $(BUILD_DIR)
+	# remove the previously downloaded archive in case it exists (required by gh)
+	rm -f $(BUILD_DIR)/apalache.tgz
+	gh release download --repo informalsystems/apalache --pattern apalache.tgz --dir $(BUILD_DIR)
+	tar -xvzf $(BUILD_DIR)/apalache.tgz --directory $(BUILD_DIR) > /dev/null
 
 # end

--- a/quint/README.md
+++ b/quint/README.md
@@ -124,6 +124,23 @@ npm install <dep> --save-dev
 [yalc]: https://www.npmjs.com/package/yalc
 [txm]: https://www.npmjs.com/package/txm
 
+#### Integration with Apalache
+
+We maintain a set of integration tests against the latest release of Apalache.
+These tests are meant to catch any breaking changes requiring updates to
+Apalache's support for quint.
+
+Generally, you should not have to run these tests locally, leaving the
+validation to our CI. But should you need to run these tests locally, you can do
+so with
+
+```sh
+npm run apalache-integration
+```
+
+It is required that you have a Java version meeting [Apalache's minimum
+requirements](https://apalache.informal.systems/docs/apalache/installation/jvm.html).
+
 ### Parser
 
 We use the `antlr4ts` parser generator to compile the BNF like notation specified

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -1,0 +1,20 @@
+# Integration tests against Apalache
+
+
+All of the test inputs in the following test cases are commands executed by `bash`.
+
+<!-- !test program
+PATH=_build/apalache/bin:$PATH bash -
+-->
+
+
+<!-- !test in can check booleans.qnt -->
+```
+quint typecheck --out _build/booleans.qnt.json ../examples/language-features/booleans.qnt
+apalache-mc check _build/booleans.qnt.json | grep -o "EXITCODE: OK"
+```
+
+<!-- !test out can check booleans.qnt -->
+```
+EXITCODE: OK
+```

--- a/quint/package.json
+++ b/quint/package.json
@@ -95,6 +95,7 @@
     "test": "mocha -r ts-node/register test/*.test.ts test/**/*.test.ts",
     "coverage": "nyc npm run test",
     "integration": "txm cli-tests.md && txm io-cli-tests.md",
+    "apalache-integration": "make -C .. apalache && txm apalache-tests.md",
     "generate": "npm run compile && npm link && npm run antlr && npm run api-docs && npm run update-fixtures",
     "antlr": "antlr4ts -visitor ./src/generated/Quint.g4 && antlr4ts -visitor ./src/generated/Effect.g4",
     "api-docs": "quint docs ./src/builtin.qnt > ../doc/builtin.md",


### PR DESCRIPTION
Closes #635

Adds basic integration tests with Apalache, to ensure we can catch any breakage
in our integration with the model checker.

The approach here is dead simple:

We add a phony make target that will always fetch the latest Apalache release,
then a suite for txm tests that will parse specs with quint and then feed the
JSON IR to Apalache.

As per our discussions, ultimately this will be supplanted with a quint
subcommand that routes invocations thru apalache's server-mode. For now, we just
want to catch breakage.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `npm run format` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [-] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

 
