### PR TITLE
Fix effect checker performance killer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Modes for nested definitions are now properly checked (#661)
 - All basic operators can now be used with temporal formulas (#646)
+- Effect checking performance for large specs is massively improved (#669)
 
 ### Security
 

--- a/quint/src/effects/inferrer.ts
+++ b/quint/src/effects/inferrer.ts
@@ -197,14 +197,17 @@ export class EffectInferrer implements IRVisitor {
           .chain(s => {
             this.substitutions = s
 
-            paramsResult.map(effects => 
+            paramsResult.map(effects =>
               zip(effects, expr.args.map(a => a.id)).forEach(([effect, id]) => {
                 if (!effect || !id) {
-                  throw new Error('Invalid arrays')
+                  // Impossible: effects and expr.args are the same length
+                  throw new Error(`Expected ${expr.args.length} effects, but got ${effects.length}`)
                 }
+
                 const r = applySubstitution(s, effect).map(toScheme)
-              this.addToResults(id, r)
-            }))
+                this.addToResults(id, r)
+              })
+            )
 
             return applySubstitution(s, resultEffect)
           })

--- a/quint/src/effects/inferrer.ts
+++ b/quint/src/effects/inferrer.ts
@@ -19,12 +19,13 @@ import { expressionToString } from '../IRprinting'
 import { IRVisitor, walkModule } from '../IRVisitor'
 import { QuintApp, QuintBool, QuintEx, QuintInt, QuintLambda, QuintLet, QuintModule, QuintModuleDef, QuintName, QuintOpDef, QuintStr } from '../quintIr'
 import { Effect, EffectScheme, Signature, effectNames, toScheme, unify } from './base'
-import { Substitutions, applySubstitution, applySubstitutionToScheme, compose } from './substitutions'
+import { Substitutions, applySubstitution, compose } from './substitutions'
 import { Error, ErrorTree, buildErrorLeaf, buildErrorTree, errorTreeToString } from '../errorTree'
 import { ScopeTree, treeFromModule } from '../scoping'
 import { getSignatures } from './builtinSignatures'
 import { FreshVarGenerator } from '../FreshVarGenerator'
 import { effectToString } from './printing'
+import { zip } from 'lodash'
 
 export type EffectInferenceResult = [Map<bigint, ErrorTree>, Map<bigint, EffectScheme>]
 
@@ -192,14 +193,17 @@ export class EffectInferrer implements IRVisitor {
         const substitution = arrowEffect.chain(effect => unify(signature, effect))
 
         const resultEffectWithSubs = substitution
-          .chain(s => compose(s, this.substitutions))
+          .chain(s => compose(this.substitutions, s))
           .chain(s => {
             this.substitutions = s
 
-            this.effects.forEach((effect, id) => {
-              const r = applySubstitutionToScheme(s, effect)
+            paramsResult.map(effects => zip(effects, expr.args.map(a => a.id)).forEach(([effect, id]) => {
+              if (!effect || !id) {
+                throw new Error('Invalid arrays')
+              }
+              const r = applySubstitution(s, effect).map(toScheme)
               this.addToResults(id, r)
-            })
+            }))
 
             return applySubstitution(s, resultEffect)
           })

--- a/quint/src/effects/inferrer.ts
+++ b/quint/src/effects/inferrer.ts
@@ -197,11 +197,12 @@ export class EffectInferrer implements IRVisitor {
           .chain(s => {
             this.substitutions = s
 
-            paramsResult.map(effects => zip(effects, expr.args.map(a => a.id)).forEach(([effect, id]) => {
-              if (!effect || !id) {
-                throw new Error('Invalid arrays')
-              }
-              const r = applySubstitution(s, effect).map(toScheme)
+            paramsResult.map(effects => 
+              zip(effects, expr.args.map(a => a.id)).forEach(([effect, id]) => {
+                if (!effect || !id) {
+                  throw new Error('Invalid arrays')
+                }
+                const r = applySubstitution(s, effect).map(toScheme)
               this.addToResults(id, r)
             }))
 

--- a/quint/src/effects/substitutions.ts
+++ b/quint/src/effects/substitutions.ts
@@ -14,7 +14,7 @@
 
 import { Either, mergeInMany, right } from '@sweet-monads/either'
 import { ErrorTree, buildErrorTree } from '../errorTree'
-import { Effect, EffectScheme, Variables, unify, unifyVariables } from './base'
+import { Effect, Variables, unify, unifyVariables } from './base'
 import { effectToString, substitutionsToString } from './printing'
 import { simplify } from './simplification'
 
@@ -85,23 +85,6 @@ export function applySubstitution(subs: Substitutions, e: Effect): Either<ErrorT
   }
 
   return result.map(simplify)
-}
-
-/**
- * Applies substitutions to an effect scheme, replacing all *non-quantified* names with their
- * substitution values when they are defined.
- *
- * @param subs the substitutions to be applied
- * @param e the effect to be transformed
- *
- * @returns the effect resulting from the substitutions' application on the given
- *          effect, when successful. Otherwise, an error tree with an error message and its trace.
- */
-export function applySubstitutionToScheme(subs: Substitutions, e: EffectScheme): Either<ErrorTree, EffectScheme> {
-  const filteredSubs = subs.filter(s => !e.variables.has(s.name) && !e.effectVariables.has(s.name))
-
-  return applySubstitution(filteredSubs, e.effect)
-    .map(effect => ({ ...e, effect }))
 }
 
 function emptyVariables(variables: Variables): boolean {


### PR DESCRIPTION
Hello :octocat: 

Closes #662. In operator application, instead of applying new substitutions to all previously inferred effects, apply them only to effects from the application itself (parameters and result). In order for this to work, we need to compose these new substitutions with the previously known substitutions in a way where the "older" variables are binded to the new ones, as the new ones wouldn't occur elsewhere.

This reduces typechecking of `ics23` to 7 seconds (from over 70s in `main`).

I realize that accumulating all substitutions in `this.substitutions` is also reckless, but this is not considerably affecting performance at this point and it is not trivial to figure out the scope to which we should propagate those.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
