### PR TITLE
Renaming across effect system

### DIFF
--- a/quint/src/effects/EffectVisitor.ts
+++ b/quint/src/effects/EffectVisitor.ts
@@ -13,7 +13,7 @@
  * @module
  */
 
-import { ArrowEffect, ConcreteEffect, Effect, QuantifiedEffect } from './base'
+import { ArrowEffect, ConcreteEffect, Effect, EffectVariable } from './base'
 
 /**
  * Interface to be implemented by visitor classes.
@@ -25,8 +25,8 @@ export interface EffectVisitor {
   exitConcrete?: (_effect: ConcreteEffect) => void
   enterArrow?: (_effect: ArrowEffect) => void
   exitArrow?: (_effect: ArrowEffect) => void
-  enterQuantified?: (_effect: QuantifiedEffect) => void
-  exitQuantified?: (_effect: QuantifiedEffect) => void
+  enterVariable?: (_effect: EffectVariable) => void
+  exitVariable?: (_effect: EffectVariable) => void
 }
 
 /**
@@ -49,12 +49,12 @@ export function walkEffect(visitor: EffectVisitor, effect: Effect): void {
       }
       break
     }
-    case 'quantified': {
-      if (visitor.enterQuantified) {
-        visitor.enterQuantified(effect)
+    case 'variable': {
+      if (visitor.enterVariable) {
+        visitor.enterVariable(effect)
       }
-      if (visitor.exitQuantified) {
-        visitor.exitQuantified(effect)
+      if (visitor.exitVariable) {
+        visitor.exitVariable(effect)
       }
       break
     }

--- a/quint/src/effects/MultipleUpdatesChecker.ts
+++ b/quint/src/effects/MultipleUpdatesChecker.ts
@@ -5,7 +5,7 @@
  * --------------------------------------------------------------------------------- */
 
 /**
- * Checks effects for multiple updates of the same variable.
+ * A checker for multiple updates in inferred effects.
  *
  * @author Gabriela Moreira
  *
@@ -14,18 +14,18 @@
 
 
 import { QuintError } from "../quintError";
-import { ConcreteEffect, EffectScheme, Variables, stateVariables } from "./base";
+import { ConcreteEffect, EffectScheme, Entity, stateVariables } from "./base";
 import { EffectVisitor, walkEffect } from "./EffectVisitor";
 import { groupBy, pickBy, values } from "lodash";
 
 /**
- * Checks effects for multiple updates of the same variable.
+ * Checks effects for multiple updates of the same state variable.
  */
 export class MultipleUpdatesChecker implements EffectVisitor {
   errors: Map<bigint, QuintError> = new Map()
 
   /**
-   * Checks effects for multiple updates of the same variable.
+   * Checks effects for multiple updates of the same state variable.
    *
    * @param effects the effects to look for multiple updates on
    *
@@ -37,14 +37,14 @@ export class MultipleUpdatesChecker implements EffectVisitor {
   }
 
   exitConcrete(e: ConcreteEffect) {
-    const updateVariables = e.components.reduce((updates: Variables[], c) => {
+    const updateEntities = e.components.reduce((updates: Entity[], c) => {
       if (c.kind === "update") {
-        updates.push(c.variables);
+        updates.push(c.entity);
       }
       return updates;
     }, [])
 
-    const vars = stateVariables({ kind: 'union', variables: updateVariables })
+    const vars = stateVariables({ kind: 'union', entities: updateEntities })
 
     const repeated = values(pickBy(groupBy(vars, v => v.name), x => x.length > 1)).flat()
 

--- a/quint/src/effects/base.ts
+++ b/quint/src/effects/base.ts
@@ -57,8 +57,8 @@ export type EffectScheme = {
   entityVariables: Set<string>,
 }
 
-/* A state entity */
-export interface StateVariables {
+/* A state variable */
+export interface StateVariable {
   /* The variable name */
   name: string,
   /* The id of the expression on which the state variable ocurred */
@@ -71,7 +71,7 @@ export interface StateVariables {
  */
 export type Entity =
   /* A list of state variables */
-  | { kind: 'concrete', stateVariables: StateVariables[] }
+  | { kind: 'concrete', stateVariables: StateVariable[] }
   /* A variable representing some entity */
   | { kind: 'variable', name: string, reference?: bigint }
   /* A combination of entities */
@@ -194,7 +194,7 @@ export function entityNames(entity: Entity): string[] {
  *
  * @returns a list of state entities
  */
-export function stateVariables(entity: Entity): StateVariables[] {
+export function stateVariables(entity: Entity): StateVariable[] {
   switch (entity.kind) {
     case 'variable':
       return []

--- a/quint/src/effects/base.ts
+++ b/quint/src/effects/base.ts
@@ -12,9 +12,9 @@
  * @module
  */
 
-import { effectComponentToString, effectToString, variablesToString } from './printing'
+import { effectComponentToString, effectToString, entityToString } from './printing'
 import { Either, left, mergeInMany, right } from '@sweet-monads/either'
-import { Substitutions, applySubstitution, applySubstitutionToVariables, compose } from './substitutions'
+import { Substitutions, applySubstitution, applySubstitutionToEntity, compose } from './substitutions'
 import { Error, ErrorTree, buildErrorLeaf, buildErrorTree } from '../errorTree'
 import { flattenUnions, simplify } from './simplification'
 import isEqual from 'lodash.isequal'
@@ -22,70 +22,68 @@ import isEqual from 'lodash.isequal'
 /* Kinds for concrete effect components */
 export type ComponentKind = 'read' | 'update' | 'temporal'
 
-/* A concrete effect component, specifying a kind and the variables it acts upon */
-export interface EffectComponent { kind: ComponentKind, variables: Variables }
+/* A concrete effect component, specifying a kind and the entity it acts upon */
+export interface EffectComponent { kind: ComponentKind, entity: Entity }
 
-/* Concrete atomic effects specifying which kinds of effects act upon which variables */
+/* Concrete atomic effects specifying which kinds of effects act upon which entities */
 export interface ConcreteEffect { kind: 'concrete', components: EffectComponent[] }
 
 /* Arrow effects for expressions with effects depending on parameters */
 export interface ArrowEffect { kind: 'arrow', params: Effect[], result: Effect }
 
-/* A quantification variable, referring to an effect */
-export interface QuantifiedEffect { kind: 'quantified', name: string }
+/* A variable representing some effect */
+export interface EffectVariable { kind: 'variable', name: string }
 
 /*
- * The effect of a Quint expression, regarding which state variables are read
+ * The effect of a Quint expression, regarding which state entities are read
  * and/or updated
  */
 export type Effect =
   | ConcreteEffect
   | ArrowEffect
-  | QuantifiedEffect
+  | EffectVariable
 
 /*
- * An effect scheme, listing universally quantified variables (for names
- * refering to Variables) and effect variables (for names refering to Effects)
+ * An effect scheme, listing which effect variables (names referring to effects)
+ * and entity variables (names refering to entities) are universally quantified
+ * in the effect
  */
 export type EffectScheme = {
   /* The effect */
   effect: Effect,
   /* Universally quantified names refering to Effects */
   effectVariables: Set<string>,
-  /* Universally quantified names refering to Variables */
-  variables: Set<string>,
+  /* Universally quantified names refering to Entities */
+  entityVariables: Set<string>,
 }
 
-/* A state variable */
-export interface StateVariable {
+/* A state entity */
+export interface StateVariables {
   /* The variable name */
   name: string,
-  /* The variable id */
+  /* The id of the expression on which the state variable ocurred */
   reference: bigint
 }
 
 /*
- * The variables an effect acts upon. Either a list of state variables, a
- * quantification over them or a combination of other variables.
- * Uses the plural form since all forms represent a plurality of variables.
+ * The Entity an effect acts upon. Either a list of state variables, a
+ * variable or a combination of other entities.
  */
-export type Variables =
+export type Entity =
   /* A list of state variables */
-  | { kind: 'concrete', vars: StateVariable[] }
-  /* A quantification variable, referring to an array of state variables, to be substituted */
-  | { kind: 'quantified', name: string, reference?: bigint }
-  /* A combination of variables to be computed as a union when concrete */
-  | { kind: 'union', variables: Variables[] }
+  | { kind: 'concrete', stateVariables: StateVariables[] }
+  /* A variable representing some entity */
+  | { kind: 'variable', name: string, reference?: bigint }
+  /* A combination of entities */
+  | { kind: 'union', entities: Entity[] }
 
 /*
  * An effect signature, which can vary according to the number of arguments.
- * Signatures assume an additional level of quantification over all names and
- * should be instantiated before being used
  */
 export type Signature = (_arity: number) => EffectScheme
 
 /**
- * Unifies two effects by matching effect types and unifying their variables.
+ * Unifies two effects by matching effect types and unifying their entities.
  *
  * @param ea an effect to be unified
  * @param eb the effect to be unified with
@@ -103,10 +101,10 @@ export function unify(ea: Effect, eb: Effect): Either<ErrorTree, Substitutions> 
     return unifyArrows(location, e1, e2)
   } else if (e1.kind === 'concrete' && e2.kind === 'concrete') {
     return unifyConcrete(location, e1, e2).mapLeft(err => buildErrorTree(location, err))
-  } else if (e1.kind === 'quantified') {
+  } else if (e1.kind === 'variable') {
     return bindEffect(e1.name, e2)
       .mapLeft(msg => buildErrorLeaf(location, msg))
-  } else if (e2.kind === 'quantified') {
+  } else if (e2.kind === 'variable') {
     return bindEffect(e2.name, e1)
       .mapLeft(msg => buildErrorLeaf(location, msg))
   } else {
@@ -123,23 +121,23 @@ export function unify(ea: Effect, eb: Effect): Either<ErrorTree, Substitutions> 
  *
  * @param effect the Effect to have its names found
  *
- * @returns the set of variables and the set of effect variables
+ * @returns the set of effect variables and the set of entity variables
  */
-export function effectNames(effect: Effect): { effectVariables: Set<string>, variables: Set<string> } {
+export function effectNames(effect: Effect): { effectVariables: Set<string>, entityVariables: Set<string> } {
   switch (effect.kind) {
     case 'concrete':
       return {
         effectVariables: new Set(),
-        variables: new Set(effect.components.flatMap(c => variablesNames(c.variables))),
+        entityVariables: new Set(effect.components.flatMap(c => entityNames(c.entity))),
       }
     case 'arrow': {
       const nested = effect.params.concat(effect.result).flatMap(effectNames)
-      return nested.reduce((acc, { effectVariables, variables }) => ({
+      return nested.reduce((acc, { effectVariables: effectVariables, entityVariables: entityVariables }) => ({
         effectVariables: new Set([...acc.effectVariables, ...effectVariables]),
-        variables: new Set([...acc.variables, ...variables]),
-      }), { effectVariables: new Set(), variables: new Set() })
+        entityVariables: new Set([...acc.entityVariables, ...entityVariables]),
+      }), { effectVariables: new Set(), entityVariables: new Set() })
     }
-    case 'quantified': return { effectVariables: new Set([effect.name]), variables: new Set() }
+    case 'variable': return { effectVariables: new Set([effect.name]), entityVariables: new Set() }
   }
 }
 
@@ -154,7 +152,7 @@ export function toScheme(effect: Effect): EffectScheme {
   return {
     effect: effect,
     effectVariables: new Set(),
-    variables: new Set(),
+    entityVariables: new Set(),
   }
 }
 
@@ -166,44 +164,44 @@ function bindEffect(name: string, effect: Effect): Either<string, Substitutions>
   }
 }
 
-function bindVariables(name: string, variables: Variables): Either<string, Substitutions> {
-  if (variablesNames(variables).includes(name)) {
-    return left(`Can't bind ${name} to ${variablesToString(variables)}: cyclical binding`)
+function bindEntity(name: string, entity: Entity): Either<string, Substitutions> {
+  if (entityNames(entity).includes(name)) {
+    return left(`Can't bind ${name} to ${entityToString(entity)}: cyclical binding`)
   } else {
-    return right([{ kind: 'variable', name, value: variables }])
+    return right([{ kind: 'entity', name, value: entity }])
   }
 }
 
 /**
- * Finds all variable names refered to by some variables
+ * Finds all entity names refered to by an entity
  *
- * @param variables the variables to be searched
+ * @param entity the entity to be searched
  *
  * @returns a list of names
  */
-export function variablesNames(variables: Variables): string[] {
-  switch (variables.kind) {
+export function entityNames(entity: Entity): string[] {
+  switch (entity.kind) {
     case 'concrete': return []
-    case 'quantified': return [variables.name]
-    case 'union': return variables.variables.flatMap(variablesNames)
+    case 'variable': return [entity.name]
+    case 'union': return entity.entities.flatMap(entityNames)
   }
 }
 
 /**
- * Finds all state variables refered to by some variables
+ * Finds all state variables refered to by an entity
  *
- * @param variables the variables to be searched
+ * @param entity the entity to be searched
  *
- * @returns a list of state variables
+ * @returns a list of state entities
  */
-export function stateVariables(variables: Variables): StateVariable[] {
-  switch (variables.kind) {
-    case 'quantified':
+export function stateVariables(entity: Entity): StateVariables[] {
+  switch (entity.kind) {
+    case 'variable':
       return []
     case 'concrete':
-      return variables.vars
+      return entity.stateVariables
     case 'union':
-      return variables.variables.flatMap(stateVariables)
+      return entity.entities.flatMap(stateVariables)
   }
 }
 
@@ -247,19 +245,19 @@ function unifyConcrete(location: string, e1: ConcreteEffect, e2: ConcreteEffect)
   const generalResult = e1.components.reduce((result: Either<Error, Substitutions>, ca) => {
     return e2.components.reduce((innerResult: Either<Error, Substitutions>, cb) => {
       return innerResult.chain(subs => {
-        const c1: EffectComponent = { ...ca, variables: applySubstitutionToVariables(subs, ca.variables) }
-        const c2: EffectComponent = { ...cb, variables: applySubstitutionToVariables(subs, cb.variables) }
+        const c1: EffectComponent = { ...ca, entity: applySubstitutionToEntity(subs, ca.entity) }
+        const c2: EffectComponent = { ...cb, entity: applySubstitutionToEntity(subs, cb.entity) }
 
         if (c1.kind === c2.kind) {
-          return unifyVariables(c1.variables, c2.variables)
+          return unifyEntities(c1.entity, c2.entity)
         } else if (canCoexist(c1, c2)) {
           return right([] as Substitutions)
         } else if (isDominant(c1, c2)) {
           // The dominated component has to be nullified
-          return unifyVariables({ kind: 'concrete', vars: [] }, c2.variables)
+          return unifyEntities({ kind: 'concrete', stateVariables: [] }, c2.entity)
         } else if (isDominant(c2, c1)) {
           // The dominated component has to be nullified
-          return unifyVariables(c1.variables, { kind: 'concrete', vars: [] })
+          return unifyEntities(c1.entity, { kind: 'concrete', stateVariables: [] })
         } else {
           // We should never reach this. Instead, one of the kinds should
           // dominate the other, and then we nullify the dominated component
@@ -278,29 +276,28 @@ function unifyConcrete(location: string, e1: ConcreteEffect, e2: ConcreteEffect)
     .chain(s1 => generalResult.chain(s2 => compose(s1, s2)))
 }
 
-export function unifyVariables(va: Variables, vb: Variables): Either<ErrorTree, Substitutions> {
+export function unifyEntities(va: Entity, vb: Entity): Either<ErrorTree, Substitutions> {
   const v1 = flattenUnions(va)
   const v2 = flattenUnions(vb)
-  const location = `Trying to unify variables [${variablesToString(v1)}] and [${variablesToString(v2)}]`
+  const location = `Trying to unify entities [${entityToString(v1)}] and [${entityToString(v2)}]`
 
   if (v1.kind === 'concrete' && v2.kind === 'concrete') {
-    // Both state
-    if (isEqual(new Set(v1.vars.map(v => v.name)), new Set(v2.vars.map(v => v.name)))) {
+    if (isEqual(new Set(v1.stateVariables.map(v => v.name)), new Set(v2.stateVariables.map(v => v.name)))) {
       return right([])
     } else {
       return left({
         location,
-        message: `Expected variables [${v1.vars.map(v => v.name)}] and [${v2.vars.map(v => v.name)}] to be the same`,
+        message: `Expected [${v1.stateVariables.map(v => v.name)}] and [${v2.stateVariables.map(v => v.name)}] to be the same`,
         children: [],
       })
     }
-  } else if (v1.kind === 'quantified' && v2.kind === 'quantified' && v1.name === v2.name) {
+  } else if (v1.kind === 'variable' && v2.kind === 'variable' && v1.name === v2.name) {
     return right([])
-  } else if (v1.kind === 'quantified') {
-    return bindVariables(v1.name, v2)
+  } else if (v1.kind === 'variable') {
+    return bindEntity(v1.name, v2)
       .mapLeft(msg => buildErrorLeaf(location, msg))
-  } else if (v2.kind === 'quantified') {
-    return bindVariables(v2.name, v1)
+  } else if (v2.kind === 'variable') {
+    return bindEntity(v2.name, v1)
       .mapLeft(msg => buildErrorLeaf(location, msg))
   } else {
     if (isEqual(v1, v2)) {
@@ -308,21 +305,21 @@ export function unifyVariables(va: Variables, vb: Variables): Either<ErrorTree, 
     }
 
     if (v1.kind === 'union' && v2.kind === 'concrete') {
-      return mergeInMany(v1.variables.map(v => unifyVariables(v, v2)))
+      return mergeInMany(v1.entities.map(v => unifyEntities(v, v2)))
         .map(subs => subs.flat())
         .mapLeft(err => buildErrorTree(location, err))
     }
 
     if (v1.kind === 'concrete' && v2.kind === 'union') {
-      return unifyVariables(v2, v1)
+      return unifyEntities(v2, v1)
     }
 
-    // At least one of the variables is a union
+    // At least one of the entities is a union
     // Unifying sets is complicated and we should never have to do this in Quint's
     // use case for this effect system
     return left({
       location,
-      message: 'Unification for unions of variables is not implemented',
+      message: 'Unification for unions of entities is not implemented',
       children: [],
     })
   }
@@ -337,7 +334,7 @@ function nullifyUnmatchedComponents(
   return components1.reduce((result: Either<Error, Substitutions>, c2) => {
     return result.chain(subs => {
       if (!components2.some(c1 => c1.kind === c2.kind)) {
-        const newSubs = unifyVariables(c2.variables, { kind: 'concrete', vars: [] })
+        const newSubs = unifyEntities(c2.entity, { kind: 'concrete', stateVariables: [] })
         return newSubs.chain(s => compose(subs, s))
       }
 
@@ -368,27 +365,27 @@ function tryToUnpack(
     return left(buildErrorLeaf(location, `Expected ${effects2.length} arguments, got ${effects1.length}`))
   }
 
-  const variablesByComponentKind: Map<ComponentKind, Variables[]> = new Map()
+  const entitiesByComponentKind: Map<ComponentKind, Entity[]> = new Map()
 
   // Combine the other effects into a single effect, to be unified with the unpacked effect
 
   // If all the effects are concrete, we combine them into a single concrete
-  // effect by combining the variables of each component of the same kind
+  // effect by combining the entities of each component of the same kind
   if (effects2.every(e => e.kind === 'concrete')) {
     effects2.forEach(e => {
       if (e.kind === 'concrete') {
         e.components.forEach(c => {
-          const variables = variablesByComponentKind.get(c.kind) ?? []
-          variables.push(c.variables)
-          variablesByComponentKind.set(c.kind, variables)
+          const entities = entitiesByComponentKind.get(c.kind) ?? []
+          entities.push(c.entity)
+          entitiesByComponentKind.set(c.kind, entities)
         })
       }
     })
 
     const unpacked: ConcreteEffect = {
       kind: 'concrete',
-      components: [...variablesByComponentKind.entries()].map(([kind, variables]) => {
-        return { kind, variables: { kind: 'union', variables } }
+      components: [...entitiesByComponentKind.entries()].map(([kind, entities]) => {
+        return { kind, entity: { kind: 'union', entities: entities } }
       }),
     }
 
@@ -396,14 +393,14 @@ function tryToUnpack(
     return right([effects1, [result], []])
   }
 
-  // If all the effects are quantified like e0, ..., en, we combine them into a
-  // single quantified effect called e0#...#en. See simplifyArrowEffect for a
+  // If all the effects are variable like e0, ..., en, we combine them into a
+  // single variable effect called e0#...#en. See simplifyArrowEffect for a
   // similar process description
-  if (effects2.every(e => e.kind === 'quantified')) {
-    const names = effects2.map(e => e.kind === 'quantified' ? e.name : '')
+  if (effects2.every(e => e.kind === 'variable')) {
+    const names = effects2.map(e => e.kind === 'variable' ? e.name : '')
 
     const unpacked: Effect = {
-      kind: 'quantified',
+      kind: 'variable',
       name: names.join('#'),
     }
 
@@ -419,33 +416,33 @@ function tryToUnpack(
 
   return left(buildErrorLeaf(
     `Trying to unpack effects: ${effects1.map(effectToString)} and ${effects2.map(effectToString)}`,
-    'Can only unpack effects if they are all concrete or all quantified'
+    'Can only unpack effects if they are all concrete or all variable'
   ))
 }
 
 /**
  * Simplifies effects of the form (Read[v0, ..., vn]) => Read[v0, ..., vn] into
- * (Read[v0#...#vn]) => Read[v0#...#vn] so the variables can be unified with other
- * sets of variables. All of the variables v0, ..., vn are bound to the single variable
- * named v0#...#vn. E.g., for variables v0, v1, v2, we will produce the new unique variable
+ * (Read[v0#...#vn]) => Read[v0#...#vn] so the entities can be unified with other
+ * sets of entities. All of the entities v0, ..., vn are bound to the single entity
+ * named v0#...#vn. E.g., for entities v0, v1, v2, we will produce the new unique entity
  * v0#v1#v2 and the bindings v1 |-> v0#v1#v2, v1 |-> v0#v1#v2, v2 |-> v0#v1#v2.
- * This new name could be a fresh variable, but we use an unique name since there is no
- * fresh variable generation in this pure unification environment.
+ * This new name could be a fresh name, but we use an unique name since there is no
+ * fresh name generation in this pure unification environment.
  *
  * @param params the arrow effect parameters
  * @param result the arrow effect result
- * @returns an arrow effect with the new format and the substitutions with binded variables
+ * @returns an arrow effect with the new format and the substitutions with binded entities
  */
 function simplifyArrowEffect(params: Effect[], result: Effect): [ArrowEffect, Substitutions] {
   if (params.length === 1 && effectToString(params[0]) === effectToString(result) && params[0].kind === 'concrete') {
     const effect = params[0]
 
-    const hashedComponents = effect.components.map(c => ({ kind: c.kind, variables: hashVariables(c.variables) }))
+    const hashedComponents = effect.components.map(c => ({ kind: c.kind, entity: hashEntity(c.entity) }))
 
     const arrow: ArrowEffect = { kind: 'arrow', params: [{ kind: 'concrete', components: hashedComponents }], result }
     const subs: Substitutions = effect.components.flatMap(c => {
-      return variablesNames(c.variables).map(n => {
-        return { kind: 'variable', name: n, value: hashVariables(c.variables) }
+      return entityNames(c.entity).map(n => {
+        return { kind: 'entity', name: n, value: hashEntity(c.entity) }
       })
     })
 
@@ -455,37 +452,35 @@ function simplifyArrowEffect(params: Effect[], result: Effect): [ArrowEffect, Su
   return [{ kind: 'arrow', params, result }, []]
 }
 
-function hashVariables(va: Variables): Variables {
+function hashEntity(va: Entity): Entity {
   switch (va.kind) {
-    case 'concrete': {
-      return va
-    }
-    case 'quantified': return va
+    case 'concrete': return va
+    case 'variable': return va
     case 'union': {
-      const nested = va.variables.map(hashVariables)
+      const nested = va.entities.map(hashEntity)
 
-      // Separate quantified variables from the rest
-      const [name, variables] = nested.reduce(([name, variables]: [string[], Variables[]], v) => {
-        if (v.kind === 'quantified') {
+      // Separate variables from the rest
+      const [name, entities] = nested.reduce(([name, entities]: [string[], Entity[]], v) => {
+        if (v.kind === 'variable') {
           name.push(v.name)
         } else {
-          variables.push(v)
+          entities.push(v)
         }
-        return [name, variables]
+        return [name, entities]
       }, [[], []])
 
-      // Consider all cases of name and variables being empty or not
+      // Consider all cases of name and entities being empty or not
       if (name.length === 0) {
-        if (variables.length === 0) {
-          return { kind: 'concrete', vars: [] }
+        if (entities.length === 0) {
+          return { kind: 'concrete', stateVariables: [] }
         } else {
-          return { kind: 'union', variables }
+          return { kind: 'union', entities: entities }
         }
       } else {
-        if (variables.length === 0) {
-          return { kind: 'quantified', name: name.join('#') }
+        if (entities.length === 0) {
+          return { kind: 'variable', name: name.join('#') }
         } else {
-          return { kind: 'union', variables: [{ kind: 'quantified', name: name.join('#') }, ...variables] }
+          return { kind: 'union', entities: [{ kind: 'variable', name: name.join('#') }, ...entities] }
         }
       }
     }

--- a/quint/src/effects/builtinSignatures.ts
+++ b/quint/src/effects/builtinSignatures.ts
@@ -12,7 +12,7 @@
  * @module
  */
 
-import { ComponentKind, Effect, EffectComponent, EffectScheme, Signature, Variables, effectNames, toScheme } from './base'
+import { ComponentKind, Effect, EffectComponent, EffectScheme, Entity, Signature, effectNames, toScheme } from './base'
 import { parseEffectOrThrow } from './parser'
 import { range, times } from 'lodash'
 
@@ -25,7 +25,7 @@ function parseAndQuantify(effectString: string): EffectScheme {
   return { effect: e, ...effectNames(e) }
 }
 
-/** Generate a name for a variable of certain component kind:
+/** Generate a name for an entity variable of certain component kind:
  * r0, r1, r2, ... for read components
  * t0, t1, t2, ... for temporal components
  * u0, u1, u2, ... for update components
@@ -53,7 +53,7 @@ function propagateComponents(kinds: ComponentKind[]): ((arity: number) => Effect
   return (arity: number) => {
     const params: Effect[] = times(arity, i => {
       const components: EffectComponent[] = kinds.map(kind => {
-        return { kind: kind, variables: { kind: 'quantified', name: nameForVariable(kind, i + 1) } }
+        return { kind: kind, entity: { kind: 'variable', name: nameForVariable(kind, i + 1) } }
       })
 
       return { kind: 'concrete', components: components }
@@ -61,8 +61,8 @@ function propagateComponents(kinds: ComponentKind[]): ((arity: number) => Effect
 
     const resultComponents: EffectComponent[] = kinds.map(kind => {
       const names = times(arity, i => nameForVariable(kind, i + 1))
-      const variables: Variables[] = names.map(name => ({ kind: 'quantified', name }))
-      return { kind: kind, variables: { kind: 'union', variables } }
+      const entities: Entity[] = names.map(name => ({ kind: 'variable', name }))
+      return { kind: kind, entity: { kind: 'union', entities } }
     })
 
     const result: Effect = { kind: 'concrete', components: resultComponents }
@@ -88,7 +88,7 @@ function propagationWithLambda(kinds: ComponentKind[]): ((arity: number) => Effe
   return (arity: number) => {
     const params: Effect[] = times(arity - 1, i => {
       const components: EffectComponent[] = kinds.map(kind => {
-        return { kind: kind, variables: { kind: 'quantified', name: nameForVariable(kind, i + 1) } }
+        return { kind: kind, entity: { kind: 'variable', name: nameForVariable(kind, i + 1) } }
       })
 
       return { kind: 'concrete', components: components }
@@ -96,7 +96,7 @@ function propagationWithLambda(kinds: ComponentKind[]): ((arity: number) => Effe
 
     const lambdaResult: Effect = {
       kind: 'concrete', components: kinds.map(kind => {
-        return { kind: kind, variables: { kind: 'quantified', name: nameForVariable(kind, arity) } }
+        return { kind: kind, entity: { kind: 'variable', name: nameForVariable(kind, arity) } }
       }),
     }
 
@@ -104,8 +104,8 @@ function propagationWithLambda(kinds: ComponentKind[]): ((arity: number) => Effe
 
     const resultComponents: EffectComponent[] = kinds.map(kind => {
       const names = times(arity, i => nameForVariable(kind, i + 1))
-      const variables: Variables[] = names.map(name => ({ kind: 'quantified', name }))
-      return { kind: kind, variables: { kind: 'union', variables } }
+      const entities: Entity[] = names.map(name => ({ kind: 'variable', name }))
+      return { kind: kind, entity: { kind: 'union', entities } }
     })
 
     const result: Effect = { kind: 'concrete', components: resultComponents }

--- a/quint/src/effects/modeChecker.ts
+++ b/quint/src/effects/modeChecker.ts
@@ -162,7 +162,7 @@ function modeForEffect(scheme: EffectScheme): [OpQualifier, string] {
         return ['puredef', "doesn't read or update any state variable"]
       }
 
-      const entitiesByComponentKind = paramentitiesByEffect(effect)
+      const entitiesByComponentKind = paramEntitiesByEffect(effect)
       const addedEntitiesByComponentKind = new Map<ComponentKind, Entity[]>()
 
       r.components.forEach(c => {
@@ -217,7 +217,7 @@ function addedEntities(paramEntities: Entity[], resultEntity: Entity): Entity[] 
   }
 }
 
-function paramentitiesByEffect(effect: ArrowEffect): Map<ComponentKind, Entity[]> {
+function paramEntitiesByEffect(effect: ArrowEffect): Map<ComponentKind, Entity[]> {
   const entitiesByComponentKind: Map<ComponentKind, Entity[]> = new Map()
 
   effect.params.forEach(p => {
@@ -230,7 +230,7 @@ function paramentitiesByEffect(effect: ArrowEffect): Map<ComponentKind, Entity[]
         break
       }
       case 'arrow': {
-        const nested = paramentitiesByEffect(p)
+        const nested = paramEntitiesByEffect(p)
         nested.forEach((entities, kind) => {
           const existing = entitiesByComponentKind.get(kind) || []
           entitiesByComponentKind.set(kind, existing.concat(entities))

--- a/quint/src/effects/simplification.ts
+++ b/quint/src/effects/simplification.ts
@@ -13,7 +13,7 @@
  */
 
 import isEqual from 'lodash.isequal'
-import { ConcreteEffect, Effect, Entity, StateVariables } from './base'
+import { ConcreteEffect, Effect, Entity, StateVariable } from './base'
 
 /**
  * Simplifies a concrete effect by:
@@ -58,7 +58,7 @@ export function flattenUnions(entity: Entity): Entity {
   switch (entity.kind) {
     case 'union': {
       const unionEntities: Entity[] = []
-      const vars: StateVariables[] = []
+      const vars: StateVariable[] = []
       const flattenEntities = entity.entities.map(v => flattenUnions(v))
       flattenEntities.forEach(v => {
         switch (v.kind) {
@@ -91,7 +91,7 @@ function deduplicateEntity(entity: Entity): Entity {
     case 'variable':
       return entity
     case 'concrete':
-      return { kind: 'concrete', stateVariables: Array.from(new Set<StateVariables>(entity.stateVariables)) }
+      return { kind: 'concrete', stateVariables: Array.from(new Set<StateVariable>(entity.stateVariables)) }
     case 'union': {
       const nestedEntities = entity.entities.map(v => deduplicateEntity(v))
       const unique: Entity[] = []

--- a/quint/src/effects/simplification.ts
+++ b/quint/src/effects/simplification.ts
@@ -5,7 +5,7 @@
  * --------------------------------------------------------------------------------- */
 
 /**
- * Simplification for effects, including a check on multiple updates of the same variable
+ * Simplification for effects, including a check on multiple updates of the same entity
  *
  * @author Gabriela Moreira
  *
@@ -13,23 +13,22 @@
  */
 
 import isEqual from 'lodash.isequal'
-import { ConcreteEffect, Effect, StateVariable, Variables } from './base'
+import { ConcreteEffect, Effect, Entity, StateVariables } from './base'
 
-/*
- * Simplifies a concrete effect Read[r] & Update[u] by:
- *   1. Removing repeated variables in r
- *   2. Flattening nested unions under r and u
- *   3. Checking for any repeated state variables in u and reporting if found
+/**
+ * Simplifies a concrete effect by:
+ *   1. Removing repeated entities (except for updates)
+ *   2. Flattening nested unions
  *
  * @param e the concrete effect to be simplified
  *
- * @returns the simplified effect if no multiple updates are found. Otherwise, the error.
+ * @returns the simplified effect
  */
 function simplifyConcreteEffect(e: ConcreteEffect): Effect {
   const components = e.components.map(c => {
-    const flatVariables = flattenUnions(c.variables)
-    const variables = c.kind === 'update' ? flatVariables : uniqueVariables(flatVariables)
-    return { ...c, variables }
+    const flatEntity = flattenUnions(c.entity)
+    const entity = c.kind === 'update' ? flatEntity : deduplicateEntity(flatEntity)
+    return { kind: c.kind, entity }
   })
 
   return { kind: 'concrete', components }
@@ -38,7 +37,7 @@ function simplifyConcreteEffect(e: ConcreteEffect): Effect {
 export function simplify(e: Effect): Effect {
   switch (e.kind) {
     case 'concrete': return simplifyConcreteEffect(e)
-    case 'quantified': return e
+    case 'variable': return e
     case 'arrow': {
       const params = e.params.map(simplify)
       const result = simplify(e.result)
@@ -47,61 +46,61 @@ export function simplify(e: Effect): Effect {
   }
 }
 
-/*
- * Transforms variables of form [x, [y, z]] into [x, y, z]
+/**
+ * Transforms entities of form [x, [y, z]] into [x, y, z]
  *
- * @param variables the variables to be transformed
+ * @param entity the entity to be transformed
  *
  * @returns the flattened form of union if a union.
- *          Otherwise, the variables without change.
+ *          Otherwise, the entity without change.
  */
-export function flattenUnions(variables: Variables): Variables {
-  switch (variables.kind) {
+export function flattenUnions(entity: Entity): Entity {
+  switch (entity.kind) {
     case 'union': {
-      const unionVariables: Variables[] = []
-      const vars: StateVariable[] = []
-      const flattenVariables = variables.variables.map(v => flattenUnions(v))
-      flattenVariables.forEach(v => {
+      const unionEntities: Entity[] = []
+      const vars: StateVariables[] = []
+      const flattenEntities = entity.entities.map(v => flattenUnions(v))
+      flattenEntities.forEach(v => {
         switch (v.kind) {
-          case 'quantified':
-            unionVariables.push(v)
+          case 'variable':
+            unionEntities.push(v)
             break
           case 'concrete':
-            vars.push(...v.vars)
+            vars.push(...v.stateVariables)
             break
           case 'union':
-            unionVariables.push(...v.variables)
+            unionEntities.push(...v.entities)
             break
         }
       })
 
-      if (unionVariables.length > 0) {
-        const variables = vars.length > 0 ? unionVariables.concat({ kind: 'concrete', vars }) : unionVariables
-        return variables.length > 1 ? { kind: 'union', variables } : variables[0]
+      if (unionEntities.length > 0) {
+        const entities = vars.length > 0 ? unionEntities.concat({ kind: 'concrete', stateVariables: vars }) : unionEntities
+        return entities.length > 1 ? { kind: 'union', entities: entities } : entities[0]
       } else {
-        return { kind: 'concrete', vars }
+        return { kind: 'concrete', stateVariables: vars }
       }
     }
     default:
-      return variables
+      return entity
   }
 }
 
-function uniqueVariables(variables: Variables): Variables {
-  switch (variables.kind) {
-    case 'quantified':
-      return variables
+function deduplicateEntity(entity: Entity): Entity {
+  switch (entity.kind) {
+    case 'variable':
+      return entity
     case 'concrete':
-      return { kind: 'concrete', vars: Array.from(new Set<StateVariable>(variables.vars)) }
+      return { kind: 'concrete', stateVariables: Array.from(new Set<StateVariables>(entity.stateVariables)) }
     case 'union': {
-      const nestedVariables = variables.variables.map(v => uniqueVariables(v))
-      const unique: Variables[] = []
-      nestedVariables.forEach(variable => {
-        if (!unique.some(v => isEqual(v, variable))) {
-          unique.push(variable)
+      const nestedEntities = entity.entities.map(v => deduplicateEntity(v))
+      const unique: Entity[] = []
+      nestedEntities.forEach(entity => {
+        if (!unique.some(v => isEqual(v, entity))) {
+          unique.push(entity)
         }
       })
-      return { kind: 'union', variables: unique }
+      return { kind: 'union', entities: unique }
     }
   }
 }

--- a/quint/src/generated/Effect.g4
+++ b/quint/src/generated/Effect.g4
@@ -7,12 +7,12 @@ grammar Effect;
 
 effect:   concrete                                           # concreteEffect
         | '(' (effect (', ' effect)*)? ')' '=>' effect       # arrowEffect
-        | IDENTIFIER                                         # quantifiedEffect
+        | IDENTIFIER                                         # variableEffect
         ;
 
-read: 'Read' '[' vars ']' ;
-update: 'Update' '[' vars ']' ;
-temporal: 'Temporal' '[' vars ']' ;
+read: 'Read' '[' entity ']' ;
+update: 'Update' '[' entity ']' ;
+temporal: 'Temporal' '[' entity ']' ;
 
 concrete:   read                                        # readOnly
           | update                                      # updateOnly
@@ -22,7 +22,7 @@ concrete:   read                                        # readOnly
           | 'Pure'                                      # pure
           ;
 
-vars : ((stateVarRef | IDENTIFIER) (', ' (stateVarRef | IDENTIFIER))*)? ;
+entity : ((stateVarRef | IDENTIFIER) (', ' (stateVarRef | IDENTIFIER))*)? ;
 
 stateVarRef : '\'' IDENTIFIER '\'' ;
 

--- a/quint/src/generated/Effect.interp
+++ b/quint/src/generated/Effect.interp
@@ -38,7 +38,7 @@ read
 update
 temporal
 concrete
-vars
+entity
 stateVarRef
 
 

--- a/quint/src/generated/EffectListener.ts
+++ b/quint/src/generated/EffectListener.ts
@@ -11,13 +11,13 @@ import { ReadAndTemporalContext } from "./EffectParser";
 import { PureContext } from "./EffectParser";
 import { ConcreteEffectContext } from "./EffectParser";
 import { ArrowEffectContext } from "./EffectParser";
-import { QuantifiedEffectContext } from "./EffectParser";
+import { VariableEffectContext } from "./EffectParser";
 import { EffectContext } from "./EffectParser";
 import { ReadContext } from "./EffectParser";
 import { UpdateContext } from "./EffectParser";
 import { TemporalContext } from "./EffectParser";
 import { ConcreteContext } from "./EffectParser";
-import { VarsContext } from "./EffectParser";
+import { EntityContext } from "./EffectParser";
 import { StateVarRefContext } from "./EffectParser";
 
 
@@ -131,17 +131,17 @@ export interface EffectListener extends ParseTreeListener {
 	exitArrowEffect?: (ctx: ArrowEffectContext) => void;
 
 	/**
-	 * Enter a parse tree produced by the `quantifiedEffect`
+	 * Enter a parse tree produced by the `variableEffect`
 	 * labeled alternative in `EffectParser.effect`.
 	 * @param ctx the parse tree
 	 */
-	enterQuantifiedEffect?: (ctx: QuantifiedEffectContext) => void;
+	enterVariableEffect?: (ctx: VariableEffectContext) => void;
 	/**
-	 * Exit a parse tree produced by the `quantifiedEffect`
+	 * Exit a parse tree produced by the `variableEffect`
 	 * labeled alternative in `EffectParser.effect`.
 	 * @param ctx the parse tree
 	 */
-	exitQuantifiedEffect?: (ctx: QuantifiedEffectContext) => void;
+	exitVariableEffect?: (ctx: VariableEffectContext) => void;
 
 	/**
 	 * Enter a parse tree produced by `EffectParser.effect`.
@@ -199,15 +199,15 @@ export interface EffectListener extends ParseTreeListener {
 	exitConcrete?: (ctx: ConcreteContext) => void;
 
 	/**
-	 * Enter a parse tree produced by `EffectParser.vars`.
+	 * Enter a parse tree produced by `EffectParser.entity`.
 	 * @param ctx the parse tree
 	 */
-	enterVars?: (ctx: VarsContext) => void;
+	enterEntity?: (ctx: EntityContext) => void;
 	/**
-	 * Exit a parse tree produced by `EffectParser.vars`.
+	 * Exit a parse tree produced by `EffectParser.entity`.
 	 * @param ctx the parse tree
 	 */
-	exitVars?: (ctx: VarsContext) => void;
+	exitEntity?: (ctx: EntityContext) => void;
 
 	/**
 	 * Enter a parse tree produced by `EffectParser.stateVarRef`.

--- a/quint/src/generated/EffectParser.ts
+++ b/quint/src/generated/EffectParser.ts
@@ -47,11 +47,11 @@ export class EffectParser extends Parser {
 	public static readonly RULE_update = 2;
 	public static readonly RULE_temporal = 3;
 	public static readonly RULE_concrete = 4;
-	public static readonly RULE_vars = 5;
+	public static readonly RULE_entity = 5;
 	public static readonly RULE_stateVarRef = 6;
 	// tslint:disable:no-trailing-whitespace
 	public static readonly ruleNames: string[] = [
-		"effect", "read", "update", "temporal", "concrete", "vars", "stateVarRef",
+		"effect", "read", "update", "temporal", "concrete", "entity", "stateVarRef",
 	];
 
 	private static readonly _LITERAL_NAMES: Array<string | undefined> = [
@@ -150,7 +150,7 @@ export class EffectParser extends Parser {
 				}
 				break;
 			case EffectParser.IDENTIFIER:
-				_localctx = new QuantifiedEffectContext(_localctx);
+				_localctx = new VariableEffectContext(_localctx);
 				this.enterOuterAlt(_localctx, 3);
 				{
 				this.state = 29;
@@ -187,7 +187,7 @@ export class EffectParser extends Parser {
 			this.state = 33;
 			this.match(EffectParser.T__5);
 			this.state = 34;
-			this.vars();
+			this.entity();
 			this.state = 35;
 			this.match(EffectParser.T__6);
 			}
@@ -218,7 +218,7 @@ export class EffectParser extends Parser {
 			this.state = 38;
 			this.match(EffectParser.T__5);
 			this.state = 39;
-			this.vars();
+			this.entity();
 			this.state = 40;
 			this.match(EffectParser.T__6);
 			}
@@ -249,7 +249,7 @@ export class EffectParser extends Parser {
 			this.state = 43;
 			this.match(EffectParser.T__5);
 			this.state = 44;
-			this.vars();
+			this.entity();
 			this.state = 45;
 			this.match(EffectParser.T__6);
 			}
@@ -394,9 +394,9 @@ export class EffectParser extends Parser {
 		return _localctx;
 	}
 	// @RuleVersion(0)
-	public vars(): VarsContext {
-		let _localctx: VarsContext = new VarsContext(this._ctx, this.state);
-		this.enterRule(_localctx, 10, EffectParser.RULE_vars);
+	public entity(): EntityContext {
+		let _localctx: EntityContext = new EntityContext(this._ctx, this.state);
+		this.enterRule(_localctx, 10, EffectParser.RULE_entity);
 		let _la: number;
 		try {
 			this.enterOuterAlt(_localctx, 1);
@@ -631,7 +631,7 @@ export class ArrowEffectContext extends EffectContext {
 		}
 	}
 }
-export class QuantifiedEffectContext extends EffectContext {
+export class VariableEffectContext extends EffectContext {
 	public IDENTIFIER(): TerminalNode { return this.getToken(EffectParser.IDENTIFIER, 0); }
 	constructor(ctx: EffectContext) {
 		super(ctx.parent, ctx.invokingState);
@@ -639,20 +639,20 @@ export class QuantifiedEffectContext extends EffectContext {
 	}
 	// @Override
 	public enterRule(listener: EffectListener): void {
-		if (listener.enterQuantifiedEffect) {
-			listener.enterQuantifiedEffect(this);
+		if (listener.enterVariableEffect) {
+			listener.enterVariableEffect(this);
 		}
 	}
 	// @Override
 	public exitRule(listener: EffectListener): void {
-		if (listener.exitQuantifiedEffect) {
-			listener.exitQuantifiedEffect(this);
+		if (listener.exitVariableEffect) {
+			listener.exitVariableEffect(this);
 		}
 	}
 	// @Override
 	public accept<Result>(visitor: EffectVisitor<Result>): Result {
-		if (visitor.visitQuantifiedEffect) {
-			return visitor.visitQuantifiedEffect(this);
+		if (visitor.visitVariableEffect) {
+			return visitor.visitVariableEffect(this);
 		} else {
 			return visitor.visitChildren(this);
 		}
@@ -661,8 +661,8 @@ export class QuantifiedEffectContext extends EffectContext {
 
 
 export class ReadContext extends ParserRuleContext {
-	public vars(): VarsContext {
-		return this.getRuleContext(0, VarsContext);
+	public entity(): EntityContext {
+		return this.getRuleContext(0, EntityContext);
 	}
 	constructor(parent: ParserRuleContext | undefined, invokingState: number) {
 		super(parent, invokingState);
@@ -693,8 +693,8 @@ export class ReadContext extends ParserRuleContext {
 
 
 export class UpdateContext extends ParserRuleContext {
-	public vars(): VarsContext {
-		return this.getRuleContext(0, VarsContext);
+	public entity(): EntityContext {
+		return this.getRuleContext(0, EntityContext);
 	}
 	constructor(parent: ParserRuleContext | undefined, invokingState: number) {
 		super(parent, invokingState);
@@ -725,8 +725,8 @@ export class UpdateContext extends ParserRuleContext {
 
 
 export class TemporalContext extends ParserRuleContext {
-	public vars(): VarsContext {
-		return this.getRuleContext(0, VarsContext);
+	public entity(): EntityContext {
+		return this.getRuleContext(0, EntityContext);
 	}
 	constructor(parent: ParserRuleContext | undefined, invokingState: number) {
 		super(parent, invokingState);
@@ -948,7 +948,7 @@ export class PureContext extends ConcreteContext {
 }
 
 
-export class VarsContext extends ParserRuleContext {
+export class EntityContext extends ParserRuleContext {
 	public stateVarRef(): StateVarRefContext[];
 	public stateVarRef(i: number): StateVarRefContext;
 	public stateVarRef(i?: number): StateVarRefContext | StateVarRefContext[] {
@@ -971,23 +971,23 @@ export class VarsContext extends ParserRuleContext {
 		super(parent, invokingState);
 	}
 	// @Override
-	public get ruleIndex(): number { return EffectParser.RULE_vars; }
+	public get ruleIndex(): number { return EffectParser.RULE_entity; }
 	// @Override
 	public enterRule(listener: EffectListener): void {
-		if (listener.enterVars) {
-			listener.enterVars(this);
+		if (listener.enterEntity) {
+			listener.enterEntity(this);
 		}
 	}
 	// @Override
 	public exitRule(listener: EffectListener): void {
-		if (listener.exitVars) {
-			listener.exitVars(this);
+		if (listener.exitEntity) {
+			listener.exitEntity(this);
 		}
 	}
 	// @Override
 	public accept<Result>(visitor: EffectVisitor<Result>): Result {
-		if (visitor.visitVars) {
-			return visitor.visitVars(this);
+		if (visitor.visitEntity) {
+			return visitor.visitEntity(this);
 		} else {
 			return visitor.visitChildren(this);
 		}

--- a/quint/src/generated/EffectVisitor.ts
+++ b/quint/src/generated/EffectVisitor.ts
@@ -11,13 +11,13 @@ import { ReadAndTemporalContext } from "./EffectParser";
 import { PureContext } from "./EffectParser";
 import { ConcreteEffectContext } from "./EffectParser";
 import { ArrowEffectContext } from "./EffectParser";
-import { QuantifiedEffectContext } from "./EffectParser";
+import { VariableEffectContext } from "./EffectParser";
 import { EffectContext } from "./EffectParser";
 import { ReadContext } from "./EffectParser";
 import { UpdateContext } from "./EffectParser";
 import { TemporalContext } from "./EffectParser";
 import { ConcreteContext } from "./EffectParser";
-import { VarsContext } from "./EffectParser";
+import { EntityContext } from "./EffectParser";
 import { StateVarRefContext } from "./EffectParser";
 
 
@@ -94,12 +94,12 @@ export interface EffectVisitor<Result> extends ParseTreeVisitor<Result> {
 	visitArrowEffect?: (ctx: ArrowEffectContext) => Result;
 
 	/**
-	 * Visit a parse tree produced by the `quantifiedEffect`
+	 * Visit a parse tree produced by the `variableEffect`
 	 * labeled alternative in `EffectParser.effect`.
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
-	visitQuantifiedEffect?: (ctx: QuantifiedEffectContext) => Result;
+	visitVariableEffect?: (ctx: VariableEffectContext) => Result;
 
 	/**
 	 * Visit a parse tree produced by `EffectParser.effect`.
@@ -137,11 +137,11 @@ export interface EffectVisitor<Result> extends ParseTreeVisitor<Result> {
 	visitConcrete?: (ctx: ConcreteContext) => Result;
 
 	/**
-	 * Visit a parse tree produced by `EffectParser.vars`.
+	 * Visit a parse tree produced by `EffectParser.entity`.
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
-	visitVars?: (ctx: VarsContext) => Result;
+	visitEntity?: (ctx: EntityContext) => Result;
 
 	/**
 	 * Visit a parse tree produced by `EffectParser.stateVarRef`.

--- a/quint/test/effects/EffectVisitor.test.ts
+++ b/quint/test/effects/EffectVisitor.test.ts
@@ -69,16 +69,16 @@ describe('walkEffect', () => {
     assert.deepEqual(visitor.exited.map(effectToString), exitedEffects)
   })
 
-  it('finds quantified effects', () => {
+  it('finds variable effects', () => {
     class TestVisitor implements EffectVisitor {
       entered: Effect[] = []
       exited: Effect[] = []
 
-      enterQuantified(e: Effect): void {
+      enterVariable(e: Effect): void {
         this.entered.push(e)
       }
 
-      exitQuantified(e: Effect): void {
+      exitVariable(e: Effect): void {
         this.exited.push(e)
       }
     }

--- a/quint/test/effects/base.test.ts
+++ b/quint/test/effects/base.test.ts
@@ -15,7 +15,7 @@ describe('unify', () => {
 
       assert.isTrue(result.isRight())
       result.map(r => assert.sameDeepMembers(r, [
-        { kind: 'variable', name: 't1', value: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
+        { kind: 'entity', name: 't1', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
       ]))
     })
 
@@ -29,8 +29,8 @@ describe('unify', () => {
       result.mapLeft(r => assert.deepEqual(r, {
         location: "Trying to unify Update['x'] and Temporal['y']",
         children: [{
-          location: "Trying to unify variables ['x'] and []",
-          message: 'Expected variables [x] and [] to be the same',
+          location: "Trying to unify entities ['x'] and []",
+          message: 'Expected [x] and [] to be the same',
           children: [],
         }],
       }))
@@ -46,14 +46,14 @@ describe('unify', () => {
       result.mapLeft(r => assert.deepEqual(r, {
         location: "Trying to unify Pure and Temporal['y']",
         children: [{
-          location: "Trying to unify variables ['y'] and []",
-          message: 'Expected variables [y] and [] to be the same',
+          location: "Trying to unify entities ['y'] and []",
+          message: 'Expected [y] and [] to be the same',
           children: [],
         }],
       }))
     })
 
-    it('unifies variables with different orders', () => {
+    it('unifies entities with different orders', () => {
       const e1 = parseEffectOrThrow("Read['x', 'y']")
       const e2 = parseEffectOrThrow("Read['y', 'x']")
 
@@ -71,11 +71,11 @@ describe('unify', () => {
         components: [
           {
             kind: 'read',
-            variables: {
+            entity: {
               kind: 'union',
-              variables: [
-                { kind: 'union', variables: [{ kind: 'quantified', name: 'r1' }, { kind: 'quantified', name: 'r2' }] },
-                { kind: 'concrete', vars: [{ name: 'x', reference: 1n }, { name: 'y', reference: 2n }] },
+              entities: [
+                { kind: 'union', entities: [{ kind: 'variable', name: 'r1' }, { kind: 'variable', name: 'r2' }] },
+                { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }, { name: 'y', reference: 2n }] },
               ],
             },
           },
@@ -122,7 +122,7 @@ describe('unify', () => {
 
       assert.isTrue(result.isRight())
       result.map(r => assert.sameDeepMembers(r, [
-        { kind: 'variable', name: 'v', value: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
+        { kind: 'entity', name: 'v', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
         { kind: 'effect', name: 'E', value: parseEffectOrThrow("Update['x']") },
       ]))
     })
@@ -134,8 +134,8 @@ describe('unify', () => {
       const result = unify(e1, e2)
 
       result.map(r => assert.sameDeepMembers(r, [
-        { kind: 'variable', name: 'r1', value: { kind: 'concrete', vars: [] } },
-        { kind: 'variable', name: 'r2', value: { kind: 'concrete', vars: [] } },
+        { kind: 'entity', name: 'r1', value: { kind: 'concrete', stateVariables: [] } },
+        { kind: 'entity', name: 'r2', value: { kind: 'concrete', stateVariables: [] } },
         { kind: 'effect', name: 'E', value: parseEffectOrThrow('Pure') },
       ])).mapLeft(err => assert.fail(`Should find no errros, found ${errorTreeToString(err)}`))
     })
@@ -147,22 +147,22 @@ describe('unify', () => {
       const result = unify(e1, e2)
 
       result.map(r => assert.sameDeepMembers(r, [
-        { kind: 'variable', name: 'r1', value: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
-        { kind: 'variable', name: 'r2', value: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
-        { kind: 'variable', name: 't1', value: { kind: 'concrete', vars: [{ name: 't', reference: 2n }] } },
-        { kind: 'variable', name: 't2', value: { kind: 'concrete', vars: [{ name: 't', reference: 2n }] } },
+        { kind: 'entity', name: 'r1', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
+        { kind: 'entity', name: 'r2', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
+        { kind: 'entity', name: 't1', value: { kind: 'concrete', stateVariables: [{ name: 't', reference: 2n }] } },
+        { kind: 'entity', name: 't2', value: { kind: 'concrete', stateVariables: [{ name: 't', reference: 2n }] } },
         {
           kind: 'effect', name: 'E', value: {
             kind: 'concrete', components: [
-              { kind: 'read', variables: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
-              { kind: 'temporal', variables: { kind: 'concrete', vars: [{ name: 't', reference: 2n }] } },
+              { kind: 'read', entity: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
+              { kind: 'temporal', entity: { kind: 'concrete', stateVariables: [{ name: 't', reference: 2n }] } },
             ],
           },
         },
       ])).mapLeft(err => assert.fail(`Should find no errros, found ${errorTreeToString(err)}`))
     })
 
-    it('unpacks arguments as tuples with quantified effects', () => {
+    it('unpacks arguments as tuples with variable effects', () => {
       const e1 = parseEffectOrThrow('(e0, e1) => e1')
       const e2 = parseEffectOrThrow("(Pure) => E")
 
@@ -202,8 +202,8 @@ describe('unify', () => {
           {
             location: "Trying to unify Temporal['x'] and Read[r1, r2]",
             children: [{
-              location: "Trying to unify variables ['x'] and []",
-              message: 'Expected variables [x] and [] to be the same',
+              location: "Trying to unify entities ['x'] and []",
+              message: 'Expected [x] and [] to be the same',
               children: [],
             }],
           },
@@ -211,7 +211,7 @@ describe('unify', () => {
       }))
     })
 
-    it('returns error when cannot unify variables', () => {
+    it('returns error when cannot unify entities', () => {
       const e1 = parseEffectOrThrow('(Read[v]) => Update[v]')
       const e2 = parseEffectOrThrow("(Read['x']) => Update['y']")
 
@@ -223,8 +223,8 @@ describe('unify', () => {
         children: [{
           location: "Trying to unify Update['x'] and Update['y']",
           children: [{
-            location: "Trying to unify variables ['x'] and ['y']",
-            message: 'Expected variables [x] and [y] to be the same',
+            location: "Trying to unify entities ['x'] and ['y']",
+            message: 'Expected [x] and [y] to be the same',
             children: [],
           }],
         }],
@@ -274,7 +274,7 @@ describe('unify', () => {
     })
   })
 
-  describe('effects with multiple quantified variables', () => {
+  describe('effects with multiple variable entities', () => {
     it('unfies with concrete and unifiable effect', () => {
       const e1 = parseEffectOrThrow('(Read[r1] & Update[u], Read[r2] & Update[u]) => Read[r1, r2] & Update[u]')
       const e2 = parseEffectOrThrow("(Read['x'] & Update['x'], Read['y', 'z'] & Update['x']) => Read['x', 'y', 'z'] & Update['x']")
@@ -284,9 +284,9 @@ describe('unify', () => {
 
       assert.isTrue(result.isRight())
       result.map(r => assert.sameDeepMembers(r, [
-        { kind: 'variable', name: 'r1', value: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
-        { kind: 'variable', name: 'r2', value: { kind: 'concrete', vars: [{ name: 'y', reference: 3n }, { name: 'z', reference: 4n }] } },
-        { kind: 'variable', name: 'u', value: { kind: 'concrete', vars: [{ name: 'x', reference: 2n }] } },
+        { kind: 'entity', name: 'r1', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
+        { kind: 'entity', name: 'r2', value: { kind: 'concrete', stateVariables: [{ name: 'y', reference: 3n }, { name: 'z', reference: 4n }] } },
+        { kind: 'entity', name: 'u', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 2n }] } },
       ]))
       assert.deepEqual(result, reversedResult, 'Result should be the same regardless of the effect order in parameters')
     })
@@ -302,28 +302,28 @@ describe('unify', () => {
         children: [{
           location: "Trying to unify Read[r2] & Update['x'] and Read['y'] & Update['y']",
           children: [{
-            location: "Trying to unify variables ['x'] and ['y']",
-            message: 'Expected variables [x] and [y] to be the same',
+            location: "Trying to unify entities ['x'] and ['y']",
+            message: 'Expected [x] and [y] to be the same',
             children: [],
           }],
         }],
       }))
     })
 
-    it('returns partial quantified when unifying with another quantified effect', () => {
+    it('returns partial bindings when unifying with another variable effect', () => {
       const e1 = parseEffectOrThrow('(Read[r1] & Update[u], Read[r2] & Update[u]) => Read[r1, r2] & Update[u]')
       const e2 = parseEffectOrThrow("(Read['x'] & Update[v], Read['y'] & Update[v]) => Read['x', 'y'] & Update[v]")
 
       const result = unify(e1, e2)
       assert.isTrue(result.isRight())
       result.map(r => assert.sameDeepMembers(r, [
-        { kind: 'variable', name: 'r1', value: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] } },
-        { kind: 'variable', name: 'r2', value: { kind: 'concrete', vars: [{ name: 'y', reference: 2n }] } },
-        { kind: 'variable', name: 'u', value: { kind: 'quantified', name: 'v' } },
+        { kind: 'entity', name: 'r1', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] } },
+        { kind: 'entity', name: 'r2', value: { kind: 'concrete', stateVariables: [{ name: 'y', reference: 2n }] } },
+        { kind: 'entity', name: 'u', value: { kind: 'variable', name: 'v' } },
       ]))
     })
 
-    it('returns error with incompatible quantified effect', () => {
+    it('returns error with effect with incompatible entity variables', () => {
       const e1 = parseEffectOrThrow('(Read[r1] & Update[u], Read[r2] & Update[u]) => Read[r1, r2] & Update[u]')
       const e2 = parseEffectOrThrow("(Read['y'] & Update['x'], Read['z'] & Update['x']) => Read['y'] & Update[u]")
 
@@ -334,8 +334,8 @@ describe('unify', () => {
         children: [{
           location: "Trying to unify Read['y', 'z'] & Update['x'] and Read['y'] & Update['x']",
           children: [{
-            location: "Trying to unify variables ['y', 'z'] and ['y']",
-            message: 'Expected variables [y,z] and [y] to be the same',
+            location: "Trying to unify entities ['y', 'z'] and ['y']",
+            message: 'Expected [y,z] and [y] to be the same',
             children: [],
           }],
         }],
@@ -351,8 +351,8 @@ describe('unify', () => {
       result.mapLeft(r => assert.deepEqual(r, {
         location: "Trying to unify Read[r1, r2] and Read[r, 'x', 'y']",
         children: [{
-          location: "Trying to unify variables [r1, r2] and [r, 'x', 'y']",
-          message: 'Unification for unions of variables is not implemented',
+          location: "Trying to unify entities [r1, r2] and [r, 'x', 'y']",
+          message: 'Unification for unions of entities is not implemented',
           children: [],
         }],
       }))
@@ -390,7 +390,7 @@ describe('unify', () => {
       assert.isTrue(result.isLeft())
     })
 
-    it('returs error when variable names are cyclical', () => {
+    it('returs error when entity names are cyclical', () => {
       const e1 = parseEffectOrThrow('Read[v1]')
       const e2 = parseEffectOrThrow('Read[v1, v2]')
 
@@ -401,7 +401,7 @@ describe('unify', () => {
           location: 'Trying to unify Read[v1] and Read[v1, v2]',
           children: [
             {
-              location: 'Trying to unify variables [v1] and [v1, v2]',
+              location: 'Trying to unify entities [v1] and [v1, v2]',
               message: "Can't bind v1 to v1, v2: cyclical binding",
               children: [],
             },
@@ -411,7 +411,7 @@ describe('unify', () => {
       assert.isTrue(result.isLeft())
     })
 
-    it('returs error when variable names are cyclical in other way', () => {
+    it('returs error when entity names are cyclical in other way', () => {
       const e1 = parseEffectOrThrow('Temporal[v1, v2]')
       const e2 = parseEffectOrThrow('Temporal[v1]')
 
@@ -422,7 +422,7 @@ describe('unify', () => {
           location: 'Trying to unify Temporal[v1, v2] and Temporal[v1]',
           children: [
             {
-              location: 'Trying to unify variables [v1, v2] and [v1]',
+              location: 'Trying to unify entities [v1, v2] and [v1]',
               message: "Can't bind v1 to v1, v2: cyclical binding",
               children: [],
             },

--- a/quint/test/effects/inferrer.test.ts
+++ b/quint/test/effects/inferrer.test.ts
@@ -216,8 +216,8 @@ describe('inferEffects', () => {
           children: [{
             children: [{
               children: [],
-              location: "Trying to unify variables ['x'] and []",
-              message: 'Expected variables [x] and [] to be the same',
+              location: "Trying to unify entities ['x'] and []",
+              message: 'Expected [x] and [] to be the same',
             }],
             location: "Trying to unify Read[v5] & Temporal[v6] and Update['x']",
           }],

--- a/quint/test/effects/parser.test.ts
+++ b/quint/test/effects/parser.test.ts
@@ -12,8 +12,8 @@ describe('parseEffect', () => {
       assert.deepEqual(value, {
         kind: 'concrete',
         components: [
-          { kind: 'read', variables: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }, { name: 'y', reference: 2n }] } },
-          { kind: 'update', variables: { kind: 'quantified', name: 'v' } },
+          { kind: 'read', entity: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }, { name: 'y', reference: 2n }] } },
+          { kind: 'update', entity: { kind: 'variable', name: 'v' } },
         ],
       })
     }
@@ -28,8 +28,8 @@ describe('parseEffect', () => {
       assert.deepEqual(value, {
         kind: 'concrete',
         components: [
-          { kind: 'read', variables: { kind: 'concrete', vars: [{ name: 'x', reference: 1n }, { name: 'y', reference: 2n }] } },
-          { kind: 'temporal', variables: { kind: 'quantified', name: 'v' } },
+          { kind: 'read', entity: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }, { name: 'y', reference: 2n }] } },
+          { kind: 'temporal', entity: { kind: 'variable', name: 'v' } },
         ],
       })
     }
@@ -44,7 +44,7 @@ describe('parseEffect', () => {
       assert.deepEqual(value, {
         kind: 'concrete',
         components: [{
-          kind: 'temporal', variables: { kind: 'quantified', name: 'v' },
+          kind: 'temporal', entity: { kind: 'variable', name: 'v' },
         }],
       })
     }
@@ -62,14 +62,14 @@ describe('parseEffect', () => {
           {
             kind: 'concrete',
             components: [{
-              kind: 'read', variables: { kind: 'quantified', name: 'v' },
+              kind: 'read', entity: { kind: 'variable', name: 'v' },
             }],
           },
         ],
         result: {
           kind: 'concrete',
           components: [{
-            kind: 'update', variables: { kind: 'quantified', name: 'v' },
+            kind: 'update', entity: { kind: 'variable', name: 'v' },
           }],
         },
       })
@@ -90,20 +90,20 @@ describe('parseEffect', () => {
             params: [{ kind: 'concrete', components: [] }],
             result: {
               kind: 'concrete', components: [{
-                kind: 'read', variables: { kind: 'quantified', name: 'v' },
+                kind: 'read', entity: { kind: 'variable', name: 'v' },
               }],
             },
           },
           {
             kind: 'arrow',
             params: [{ kind: 'concrete', components: [] }],
-            result: { kind: 'quantified', name: 'E' },
+            result: { kind: 'variable', name: 'E' },
           },
         ],
         result: {
           kind: 'concrete',
           components: [{
-            kind: 'update', variables: { kind: 'quantified', name: 'v' },
+            kind: 'update', entity: { kind: 'variable', name: 'v' },
           }],
         },
       })
@@ -122,10 +122,10 @@ describe('parseEffect', () => {
           {
             kind: 'concrete',
             components: [{
-              kind: 'read', variables: {
-                kind: 'union', variables: [
-                  { kind: 'quantified', name: 'v' },
-                  { kind: 'quantified', name: 'w' },
+              kind: 'read', entity: {
+                kind: 'union', entities: [
+                  { kind: 'variable', name: 'v' },
+                  { kind: 'variable', name: 'w' },
                 ],
               },
             }],
@@ -134,7 +134,7 @@ describe('parseEffect', () => {
         result: {
           kind: 'concrete',
           components: [{
-            kind: 'update', variables: { kind: 'quantified', name: 'v' },
+            kind: 'update', entity: { kind: 'variable', name: 'v' },
           }],
         },
       })
@@ -153,9 +153,9 @@ describe('parseEffect', () => {
           {
             kind: 'concrete',
             components: [{
-              kind: 'read', variables: {
-                kind: 'union', variables: [
-                  { kind: 'quantified', name: 'v' }, { kind: 'concrete', vars: [{ name: 'x', reference: 1n }] },
+              kind: 'read', entity: {
+                kind: 'union', entities: [
+                  { kind: 'variable', name: 'v' }, { kind: 'concrete', stateVariables: [{ name: 'x', reference: 1n }] },
                 ],
               },
             }],
@@ -164,9 +164,9 @@ describe('parseEffect', () => {
         result: {
           kind: 'concrete',
           components: [{
-            kind: 'update', variables: {
-              kind: 'union', variables: [
-                { kind: 'quantified', name: 'v' }, { kind: 'concrete', vars: [{ name: 'y', reference: 2n }] },
+            kind: 'update', entity: {
+              kind: 'union', entities: [
+                { kind: 'variable', name: 'v' }, { kind: 'concrete', stateVariables: [{ name: 'y', reference: 2n }] },
               ],
             },
           }],
@@ -187,7 +187,7 @@ describe('parseEffect', () => {
         result: {
           kind: 'concrete',
           components: [{
-            kind: 'update', variables: { kind: 'quantified', name: 'v' },
+            kind: 'update', entity: { kind: 'variable', name: 'v' },
           }],
         },
       })
@@ -206,14 +206,14 @@ describe('parseEffect', () => {
           {
             kind: 'concrete',
             components: [{
-              kind: 'read', variables: { kind: 'concrete', vars: [] },
+              kind: 'read', entity: { kind: 'concrete', stateVariables: [] },
             }],
           },
         ],
         result: {
           kind: 'concrete',
           components: [{
-            kind: 'update', variables: { kind: 'concrete', vars: [] },
+            kind: 'update', entity: { kind: 'concrete', stateVariables: [] },
           }],
         },
       })

--- a/quint/test/effects/substitutions.test.ts
+++ b/quint/test/effects/substitutions.test.ts
@@ -5,7 +5,7 @@ import { parseEffectOrThrow } from '../../src/effects/parser'
 
 describe('compose', () => {
   it('applies the first substitutions to all values', () => {
-    const s1: Substitutions = [{ kind: 'variable', name: 'v1', value: { kind: 'concrete', vars: [{ name: 'x', reference: 0n }] } }]
+    const s1: Substitutions = [{ kind: 'entity', name: 'v1', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 0n }] } }]
     const s2: Substitutions = [{ kind: 'effect', name: 'e1', value: parseEffectOrThrow('Read[v1] & Update[v1]') }]
 
     const result = compose(s1, s2)
@@ -14,8 +14,8 @@ describe('compose', () => {
       {
         kind: 'effect', name: 'e1', value: {
           kind: 'concrete', components: [
-            { kind: 'read', variables: { kind: 'concrete', vars: [{ name: 'x', reference: 0n }] } },
-            { kind: 'update', variables: { kind: 'concrete', vars: [{ name: 'x', reference: 0n }] } },
+            { kind: 'read', entity: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 0n }] } },
+            { kind: 'update', entity: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 0n }] } },
           ],
         },
       },
@@ -25,13 +25,13 @@ describe('compose', () => {
   })
 
   it('unifies values of substitutions with same name', () => {
-    const s1: Substitutions = [{ kind: 'variable', name: 'v1', value: { kind: 'concrete', vars: [{ name: 'x', reference: 2n }] } }]
-    const s2: Substitutions = [{ kind: 'variable', name: 'v1', value: { kind: 'quantified', name: 'q' } }]
+    const s1: Substitutions = [{ kind: 'entity', name: 'v1', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 2n }] } }]
+    const s2: Substitutions = [{ kind: 'entity', name: 'v1', value: { kind: 'variable', name: 'q' } }]
 
     const result = compose(s1, s2)
 
     result.map(r => assert.sameDeepMembers(r, s1.concat([
-      { kind: 'variable', name: 'q', value: { kind: 'concrete', vars: [{ name: 'x', reference: 2n }] } },
+      { kind: 'entity', name: 'q', value: { kind: 'concrete', stateVariables: [{ name: 'x', reference: 2n }] } },
     ])))
 
     assert.isTrue(result.isRight())


### PR DESCRIPTION
Hello :octocat: 

This fixes #668 by renaming `Variables` to `Entity`, and the kind `'quantified'` to `'variable'` (plus some consequential renaming from that).

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
