### PR TITLE
Prevent self imports and instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modes for nested definitions are now properly checked (#661)
 - All basic operators can now be used with temporal formulas (#646)
 - Effect checking performance for large specs is massively improved (#669)
+- A module can no longer import or instance itself (#676)
 
 ### Security
 

--- a/quint/src/importResolver.ts
+++ b/quint/src/importResolver.ts
@@ -79,7 +79,7 @@ class ImportResolverVisitor implements IRVisitor {
       // Importing current module
       this.errors.set(def.id, {
         code: 'QNT407',
-        message: `Cannot instance ${def.protoName} inside itself`,
+        message: `Cannot instantiate ${def.protoName} inside ${def.protoName}`,
         data: {},
       })
       return

--- a/quint/src/importResolver.ts
+++ b/quint/src/importResolver.ts
@@ -136,7 +136,7 @@ class ImportResolverVisitor implements IRVisitor {
       // Importing current module
       this.errors.set(def.id, {
         code: 'QNT407',
-        message: `Cannot import ${def.path} inside itself`,
+        message: `Cannot import ${def.path} inside ${def.path}`,
         data: {},
       })
       return

--- a/quint/src/importResolver.ts
+++ b/quint/src/importResolver.ts
@@ -63,10 +63,10 @@ class ImportResolverVisitor implements IRVisitor {
   errors: Map<bigint, QuintError> = new Map<bigint, QuintError>()
   table: LookupTable = newTable({})
 
-  private currentModuleId: bigint = 0n
+  private currentModule?: QuintModule
 
   enterModule(module: QuintModule): void {
-    this.currentModuleId = module.id
+    this.currentModule = module
     this.table = this.tables.get(module.name) ?? newTable({})
   }
 
@@ -75,6 +75,16 @@ class ImportResolverVisitor implements IRVisitor {
   }
 
   enterInstance(def: QuintInstance): void {
+    if (def.protoName === this.currentModule?.name) {
+      // Importing current module
+      this.errors.set(def.id, {
+        code: 'QNT407',
+        message: `Cannot instance ${def.protoName} inside itself`,
+        data: {},
+      })
+      return
+    }
+
     const moduleTable = this.tables.get(def.protoName)
 
     if (!moduleTable) {
@@ -117,11 +127,21 @@ class ImportResolverVisitor implements IRVisitor {
 
     // All names from the instanced module should be acessible with the instance namespace
     // So, copy them to the current module's lookup table
-    const newEntries = copyNames(instanceTable, def.name, this.currentModuleId)
+    const newEntries = copyNames(instanceTable, def.name, this.currentModule?.id)
     this.table = mergeTables(this.table, newEntries)
   }
 
   enterImport(def: QuintImport): void {
+    if(def.path === this.currentModule?.name) {
+      // Importing current module
+      this.errors.set(def.id, {
+        code: 'QNT407',
+        message: `Cannot import ${def.path} inside itself`,
+        data: {},
+      })
+      return
+    }
+
     const moduleTable = this.tables.get(def.path)
     if (!moduleTable) {
       // Importing unexisting module
@@ -133,7 +153,7 @@ class ImportResolverVisitor implements IRVisitor {
       return
     }
 
-    const importableDefinitions = copyNames(moduleTable, undefined, this.currentModuleId)
+    const importableDefinitions = copyNames(moduleTable, undefined, this.currentModule?.id)
 
     if (def.name === '*') {
       // Imports all definitions

--- a/quint/src/quintError.ts
+++ b/quint/src/quintError.ts
@@ -53,6 +53,8 @@ export type ErrorCode =
   | 'QNT405'
   /* QNT406: Instantiation error */
   | 'QNT406'
+  /* QNT407: Cannot import self */
+  | 'QNT407'
 
 /* Additional data for a Quint error */
 export interface QuintErrorData {

--- a/quint/test/importResolver.test.ts
+++ b/quint/test/importResolver.test.ts
@@ -75,6 +75,22 @@ describe('resolveImports', () => {
         })
         .mapLeft(e => assert.fail(`Expected no error, got ${e}`))
     })
+
+    it('fails importing itself', () => {
+      const quintModule = buildModuleWithDefs([
+        'import wrapper.*',
+        'module w = wrapper(c1 = 1)',
+      ])
+
+      const result = resolveImports(quintModule, tables)
+
+      result
+        .mapLeft(errors => assert.sameDeepMembers([...errors.entries()], [
+          [1n, { code: 'QNT407', message: 'Cannot import wrapper inside itself', data: {} }],
+          [3n, { code: 'QNT407', message: 'Cannot instance wrapper inside itself', data: {} }],
+        ]))
+        .map(_ => assert.fail('Expected errors'))
+    })
   })
 
   describe('unexisting modules', () => {

--- a/quint/test/importResolver.test.ts
+++ b/quint/test/importResolver.test.ts
@@ -86,8 +86,8 @@ describe('resolveImports', () => {
 
       result
         .mapLeft(errors => assert.sameDeepMembers([...errors.entries()], [
-          [1n, { code: 'QNT407', message: 'Cannot import wrapper inside itself', data: {} }],
-          [3n, { code: 'QNT407', message: 'Cannot instance wrapper inside itself', data: {} }],
+          [1n, { code: 'QNT407', message: 'Cannot import wrapper inside wrapper', data: {} }],
+          [3n, { code: 'QNT407', message: 'Cannot instantiate wrapper inside wrapper', data: {} }],
         ]))
         .map(_ => assert.fail('Expected errors'))
     })


### PR DESCRIPTION
Hello :octocat: 

Closes #523 by preventing a module to import or instance itself. I believe the remaining problems of the issue were already addressed by removing nested modules :smile: 

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
