### PR TITLE
Add Apalache integration tests for set operator

### DIFF
--- a/examples/language-features/sets.qnt
+++ b/examples/language-features/sets.qnt
@@ -1,0 +1,35 @@
+module sets {
+  var n: int
+  var s: Set[int]
+
+  action Init = all {
+    n' = 0,
+    s' = Set(0)
+  }
+
+  action Next = all {
+    n' = n + 1,
+    s' = s.union(Set(n + 1)),
+    s.exists(x => x == n),
+    s.forall(x => x >= 0),
+    n.in(s),
+    s.contains(n),
+    (n + 1).notin(s),
+    (n + 1).in(union(s, Set(n + 1))),
+    Set(n) == s.intersect(Set(n)),
+    n.notin(s.exclude(Set(n))),
+    Set(n).subseteq(s),
+    Set() == s.filter(x => x > n),
+    s == s.map(x => x),
+    n <= s.fold(0, (x, y) => x + y),
+    s.in(powerset(s)),
+    s == flatten(Set(s)),
+    // TODO: Enable after support for lists is added
+    // Set(List(1)) == Set(1).allLists(),
+    chooseSome(s).in(s),
+    s.isFinite(),
+    n + 1 == size(s),
+    Set(0, 1, 2, 3) == 0.to(3),
+  }
+
+}

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -33,3 +33,16 @@ apalache-mc check _build/integers.qnt.json | grep -o "EXITCODE: OK"
 ```
 EXITCODE: OK
 ```
+
+## Can check `../examples/language-features/sets.qnt`
+
+<!-- !test in can check sets.qnt -->
+```
+quint typecheck --out _build/sets.qnt.json ../examples/language-features/sets.qnt
+apalache-mc check _build/sets.qnt.json | grep -o "EXITCODE: OK"
+```
+
+<!-- !test out can check sets.qnt -->
+```
+EXITCODE: OK
+```


### PR DESCRIPTION
Closes #680

One operator is commented out, because it relies on `Lists`. This will
be enabled in a followup.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `npm run format` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [x] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality