### PR TITLE
Update  changelog for pending VSCode release

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+ - Updated compatible quint version, which includes breaking changes (#698).
+ 
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
This is just to explain what occasions the release, so we don't have an
empty changelog.