### PR TITLE
Update built-in docs for `put`

### DIFF
--- a/doc/builtin.md
+++ b/doc/builtin.md
@@ -371,7 +371,7 @@ assert(s == Set(
 
 ## `pure def set: ((a -> b), a, b) => (a -> b)`
 
-`m.set(k, v)` is the map `m` but with the key `k` mapped `v` if `k.in(keys(m))`
+`m.set(k, v)` is the map `m` but with the key `k` mapped to `v` if `k.in(keys(m))`
 
 If `k` is not a key in `m`, this operator has undefined behavior.
 
@@ -401,17 +401,17 @@ assert(m2 == Map(1 -> true, 2 -> true))
 
 ## `pure def put: ((a -> b), a, b) => (a -> b)`
 
-`m.put(k, v)` map `m` extended with the key `k` set to `v`.
-
-If `k` is present in `m`, this operator has undefined behavior.
+`m.put(k, v)` is the map `m` but with the key `k` mapped to `v`.
 
 ### Examples
 
 ```
 pure val m = Map(1 -> true, 2 -> false)
-pure val m2 = m.put(3, true)
+pure val m2 = m.put(2, true)
+pure val m3 = m.put(3, true)
 assert(m == Map(1 -> true, 2 -> false))
-assert(m2 == Map(1 -> true, 2 -> false, 3 -> true))
+assert(m2 == Map(1 -> true, 2 -> true))
+assert(m3 == Map(1 -> true, 2 -> false, 3 -> true))
 ```
 
 ## `pure def append: (List[a], a) => List[a]`

--- a/quint/src/builtin.qnt
+++ b/quint/src/builtin.qnt
@@ -336,7 +336,7 @@ module builtin {
   /// ```
   pure def setOfMaps(s1, s2): (Set[a], Set[b]) => Set[a -> b]
 
-  /// `m.set(k, v)` is the map `m` but with the key `k` mapped `v` if `k.in(keys(m))`
+  /// `m.set(k, v)` is the map `m` but with the key `k` mapped to `v` if `k.in(keys(m))`
   ///
   /// If `k` is not a key in `m`, this operator has undefined behavior.
   ///
@@ -364,17 +364,17 @@ module builtin {
   /// ```
   pure def setBy(m, k, v): (a -> b, a, (b) => b) => a -> b
 
-  /// `m.put(k, v)` map `m` extended with the key `k` set to `v`.
-  ///
-  /// If `k` is present in `m`, this operator has undefined behavior.
+  /// `m.put(k, v)` is the map `m` but with the key `k` mapped to `v`.
   ///
   /// ### Examples
   ///
   /// ```
   /// pure val m = Map(1 -> true, 2 -> false)
-  /// pure val m2 = m.put(3, true)
+  /// pure val m2 = m.put(2, true)
+  /// pure val m3 = m.put(3, true)
   /// assert(m == Map(1 -> true, 2 -> false))
-  /// assert(m2 == Map(1 -> true, 2 -> false, 3 -> true))
+  /// assert(m2 == Map(1 -> true, 2 -> true))
+  /// assert(m3 == Map(1 -> true, 2 -> false, 3 -> true))
   /// ```
   pure def put(m, k, v): (a -> b, a, b) => a -> b
 


### PR DESCRIPTION
The API docs for `put(m, k, v)` currently state

```
If `k` is present in `m`, this operator has undefined behavior.
```

whereas the language doc claims

https://github.com/informalsystems/quint/blob/d8c1150c9c8721565b3fb006d255918906e9a574/doc/lang.md?plain=1#L1238-L1240

(which would both extend or replace the `k -> v` binding).

@konnov confirmed that the latter is the intended semantics.

- [ ] ~Tests added for any new code~
- [x] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entries added to the respective `CHANGELOG.md` for any new functionality~
- [ ] ~Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality~
