### PR TITLE
fix too much non-determinism in nondet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Heisenbugs in `nondet x = oneOf(S)` should not happen (#712)
+
 ### Security
 
 ## v0.7.0 -- 2023-03-09

--- a/examples/language-features/nondet.qnt
+++ b/examples/language-features/nondet.qnt
@@ -1,0 +1,47 @@
+// demonstrating non-trivial behavior of nondet and oneOf
+module nondetEx {
+  var x: int
+  var y: int
+  var delta: int
+  var oldDelta: int
+
+  action init = {
+    nondet v = Set(1, 2, 3).oneOf()
+    all {
+      x' = v,
+      y' = -v,
+      delta' = v,
+      oldDelta' = v,
+    }
+  }
+
+  action step =
+    nondet v = Set(1, 2, 3).oneOf()
+    all {
+      x' = x + v,
+      y' = y - v,
+      delta' = v,
+      oldDelta' = delta,
+    }
+
+  // this must be an invariant
+  val mirrorInv = all {
+    y == -x
+  }
+
+  // this invariant must be false, unless the value of v is frozen
+  val falseInv = all {
+    oldDelta == delta
+  }
+
+  run mirrorTest =
+    init.then(step)
+        .then(step)
+        .then(all {
+          assert(mirrorInv),
+          x' = x,
+          y' = y,
+          delta' = delta,
+          oldDelta' = oldDelta,
+        })
+}

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -207,6 +207,11 @@ Temporarily disabled.
 <!-- !test check SimpleAuctionNonComposable - Syntax/Types & Effects/Unit tests -->
     quint test --main=SimpleAuction ../examples/solidity/SimpleAuction/SimpleAuctionNonComposable.qnt
 
+### OK on test nondet.qnt
+
+<!-- !test check nondet - Syntax/Types & Effects/Unit tests -->
+    quint test --main=nondetEx ../examples/language-features/nondet.qnt
+
 ### OK on typecheck SuperSpec.qnt
 
 <!-- !test check SuperSpec - Types & Effects-->

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -393,18 +393,18 @@ quint run --max-steps=5 --seed=123 --invariant=totalSupplyDoesNotOverflowInv \
 [violation] (duration). See the example:
 ---------------------------------------------
 action step0 = all {
-  coin::minter' = "null",
+  coin::minter' = "charlie",
   coin::balances' = Map("alice" -> 0, "bob" -> 0, "charlie" -> 0, "eve" -> 0, "null" -> 0),
 }
 
 action step1 = all {
-  coin::minter' = "null",
-  coin::balances' = Map("alice" -> 0, "bob" -> 0, "charlie" -> 0, "eve" -> 0, "null" -> 112481458056655605601695545099703330518348568252135132870328821439856853909504),
+  coin::minter' = "charlie",
+  coin::balances' = Map("alice" -> 0, "bob" -> 103284694429057902812136720936033946290905036909354547835442699046088697970688, "charlie" -> 0, "eve" -> 0, "null" -> 0),
 }
 
 action step2 = all {
-  coin::minter' = "null",
-  coin::balances' = Map("alice" -> 0, "bob" -> 0, "charlie" -> 31453788334862831322142706925277348799769195365499601992860029384416292765696, "eve" -> 0, "null" -> 112481458056655605601695545099703330518348568252135132870328821439856853909504),
+  coin::minter' = "charlie",
+  coin::balances' = Map("alice" -> 0, "bob" -> 103284694429057902812136720936033946290905036909354547835442699046088697970688, "charlie" -> 46797254901076543191142647617814825964332772279616938906031909187844048945152, "eve" -> 0, "null" -> 0),
 }
 
 run test = {

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -144,14 +144,55 @@ export class CompilerVisitor implements IRVisitor {
   exitOpDef(opdef: ir.QuintOpDef) {
     // Either a runtime value, or a def, action, etc.
     // All of them are compiled to callables, which may have zero parameters.
-    const value = this.compStack.pop()
-    if (value === undefined) {
+    const boundValue = this.compStack.pop()
+    if (boundValue === undefined) {
       this.addCompileError(opdef.id,
         `No expression for ${opdef.name} on compStack`)
-    } else {
-      const kname = kindName('callable', opdef.id)
-      // bind the callable from the stack
-      this.context.set(kname, value)
+      return
+    }
+
+    const kname = kindName('callable', opdef.id)
+    // bind the callable from the stack
+    this.context.set(kname, boundValue)
+  }
+
+  exitLet(letDef: ir.QuintLet) {
+    // When dealing with a `val` or `nondet`, freeze the callable under
+    // the let definition. Otherwise, forms like 'nondet x = oneOf(S); A'
+    // may produce multiple values for the same name 'x'
+    // inside a single evaluation of A.
+    // In case of `val`, this is simply an optimization.
+    const qualifier = letDef.opdef.qualifier
+    if (qualifier !== 'val' && qualifier !== 'nondet') {
+      // a non-constant value, ignore
+      return
+    }
+
+    // get the expression that is evaluated in the context of let.
+    const exprUnderLet = this.compStack.slice(-1).pop()
+    if (exprUnderLet === undefined) {
+      this.addCompileError(letDef.opdef.id,
+        `No expression for ${letDef.opdef.name} on compStack`)
+      return
+    }
+
+    const kname = kindName('callable', letDef.opdef.id)
+    const boundValue = this.context.get(kname) ?? fail
+    // Override the behavior of the expression under let:
+    // It precomputes the bound value and uses it in the evaluation.
+    // Once the evaluation is done, the value is reset, so that
+    // a new random value may be produced later.
+    const undecoratedEval = exprUnderLet.eval
+    exprUnderLet.eval = function(): Maybe<EvalResult> {
+      const savedEval = boundValue.eval
+      const cachedValue = savedEval()
+      boundValue.eval = function() {
+        return cachedValue
+      }
+      // compute the result and immediately reset the cache
+      const result = undecoratedEval()
+      boundValue.eval = savedEval
+      return result
     }
   }
 
@@ -931,7 +972,11 @@ export class CompilerVisitor implements IRVisitor {
     // lambda translated to Callable
     const callable = this.compStack.pop() as Callable
     // this method supports only 1-argument callables
-    assert(callable.registers.length === 1)
+    if (callable.registers.length !== 1) {
+      const nargs = callable.registers.length
+      this.addCompileError(sourceId, `Expected 1 argument, found ${nargs}`)
+      return
+    }
     // apply the lambda to a single element of the set
     const evaluateElem = function(elem: RuntimeValue):
         Maybe<[RuntimeValue, RuntimeValue]> {

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -183,15 +183,15 @@ export class CompilerVisitor implements IRVisitor {
     // Once the evaluation is done, the value is reset, so that
     // a new random value may be produced later.
     const undecoratedEval = exprUnderLet.eval
+    const boundValueEval = boundValue.eval
     exprUnderLet.eval = function(): Maybe<EvalResult> {
-      const savedEval = boundValue.eval
-      const cachedValue = savedEval()
+      const cachedValue = boundValueEval()
       boundValue.eval = function() {
         return cachedValue
       }
       // compute the result and immediately reset the cache
       const result = undecoratedEval()
-      boundValue.eval = savedEval
+      boundValue.eval = boundValueEval
       return result
     }
   }


### PR DESCRIPTION
Closes #710. Closes #545. Finally, I have understood the cause of the heisenbugs in the simulator. `nondet x = oneOf(S); A` behaved too random, as it could produce different values for `x` in a single evaluation of `A`. Fixed it by caching the non-deterministic value in a single evaluation of `A`.

It's actually a critical bugfix. We should cut a new release once it is merged.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
