### PR TITLE
Unpacking tuples in the simulator

### DIFF
--- a/examples/cosmos/tendermint/TendermintAcc005.qnt
+++ b/examples/cosmos/tendermint/TendermintAcc005.qnt
@@ -165,8 +165,8 @@ module TendermintAcc {
   //********************* PROTOCOL INITIALIZATION ******************************
   def FaultyProposals(r) =
       tuples(Faulty, Values, RoundsOrNil)
-        .map(p =>
-          { src: p._1, round: r, proposal: p._2, validRound: p._3 })
+        .map((p, v, vr) =>
+          { src: p, round: r, proposal: v, validRound: vr })
 
   val AllFaultyProposals =
       Rounds.map(r => FaultyProposals(r))
@@ -174,7 +174,7 @@ module TendermintAcc {
 
   def FaultyPrevotes(r) =
       tuples(Faulty, Values)
-        .map(p => { src: p._1, round: r, id: p._2 })
+        .map((p, v) => { src: p, round: r, id: v })
 
   val AllFaultyPrevotes =
       Rounds.map(r => FaultyPrevotes(r))
@@ -182,7 +182,7 @@ module TendermintAcc {
 
   def FaultyPrecommits(r) =
       tuples(Faulty, Values)
-        .map(p => { src: p._1, round: r, id: p._2 })
+        .map((p, v) => { src: p, round: r, id: v })
 
   val AllFaultyPrecommits =
       Rounds.map(r => FaultyPrecommits(r))
@@ -543,9 +543,7 @@ module TendermintAcc {
   // equivocation by a process p
   def EquivocationBy(p) =
     def EquivocationIn(S) =
-      tuples(S, S).exists(msgs =>
-        val m1 = msgs._1
-        val m2 = msgs._2
+      tuples(S, S).exists((m1, m2) =>
         and {
           m1 != m2,
           m1.src == p,
@@ -562,9 +560,7 @@ module TendermintAcc {
 
   // amnesic behavior by a process p
   def AmnesiaBy(p) =
-      tuples(Rounds, Rounds).exists(rs =>
-          val r1 = rs._1
-          val r2 = rs._2
+      tuples(Rounds, Rounds).exists((r1, r2) =>
           and {
             r1 < r2,
             tuples(ValidValues, ValidValues).exists(vs =>
@@ -595,9 +591,7 @@ module TendermintAcc {
 
   // the safety property -- agreement
   val Agreement =
-    tuples(Corr, Corr).forall(ps =>
-      val p = ps._1
-      val q = ps._2
+    tuples(Corr, Corr).forall((p, q) =>
       or {
         decision.get(p) == NilValue,
         decision.get(q) == NilValue,
@@ -638,9 +632,7 @@ module TendermintAcc {
   // It is not exactly ~Agreement, as we do not want to see the states where
   // decision.get(p) = NilValue
   val NoAgreement =
-    tuples(Corr, Corr).forall(ps =>
-      val p = ps._1
-      val q = ps._2
+    tuples(Corr, Corr).forall((p, q) =>
       and {
         p != q,
         decision.get(p) != NilValue,

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -873,18 +873,27 @@ export class CompilerVisitor implements IRVisitor {
       this.addCompileError(app.id, `Called unknown operator ${app.opcode}`)
       this.compStack.push(fail)
     } else {
+      const nparams = callable.registers.length
+      // nparams === nargs, unless a tuple is passed to an n-ary operator.
+      // The type checker should have checked the types before.
+      const nargs = (app.args.length === 1 && nparams > 1) ? 1 : nparams
+
       const nactual = this.compStack.length
-      const nexpected = callable.registers.length
-      if (nactual < nexpected) {
+      if (nactual < nargs) {
         this.addCompileError(app.id,
-          `Expected ${nexpected} arguments for ${app.opcode}, found: ${nactual}`)
+          `Expected ${nargs} arguments for ${app.opcode}, found: ${nactual}`)
         this.compStack.push(fail)
       } else {
         this.applyFun(app.id,
-          callable.registers.length,
+          nargs,
           (...args: RuntimeValue[]) => {
-            for (let i = 0; i < args.length; i++) {
-              callable.registers[i].registerValue = just(args[i])
+            let actualArgs = args
+            if (nparams > nargs && args.length === 1) {
+              // unpack the tuple
+              actualArgs = [...args[0]]
+            }
+            for (let i = 0; i < actualArgs.length; i++) {
+              callable.registers[i].registerValue = just(actualArgs[i])
             }
             return callable.eval() as Maybe<RuntimeValue>
           }

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -479,6 +479,12 @@ describe('compiling specs to runtime values', () => {
       assertResultAsString('Set(1, 2, 3).exists(x => x >= 5)', 'false')
     })
 
+    it('unpacks tuples in exists', () => {
+      assertResultAsString(
+        'tuples(1.to(3), 4.to(6)).exists((x, y) => x + y == 7)', 'true'
+      )
+    })
+
     it('computes exists over intervals', () => {
       assertResultAsString('1.to(3).exists(x => true)', 'true')
       assertResultAsString('1.to(3).exists(x => false)', 'false')
@@ -491,6 +497,12 @@ describe('compiling specs to runtime values', () => {
       assertResultAsString('Set(1, 2, 3).forall(x => false)', 'false')
       assertResultAsString('Set(1, 2, 3).forall(x => x >= 2)', 'false')
       assertResultAsString('Set(1, 2, 3).forall(x => x >= 0)', 'true')
+    })
+
+    it('unpacks tuples in forall', () => {
+      assertResultAsString(
+        'tuples(1.to(3), 4.to(6)).forall((x, y) => x + y <= 9)', 'true'
+      )
     })
 
     it('computes forall over nested sets', () => {
@@ -513,6 +525,13 @@ describe('compiling specs to runtime values', () => {
       assertResultAsString('Set(1, 2, 3).map(x => x / 2)', 'Set(0, 1)')
     })
 
+    it('unpacks tuples in map', () => {
+      assertResultAsString(
+        'tuples(1.to(3), 4.to(6)).map((x, y) => x + y)',
+        'Set(5, 6, 7, 8, 9)'
+      )
+    })
+
     it('computes map over intervals', () => {
       // a bijection
       assertResultAsString('1.to(3).map(x => 2 * x)', 'Set(2, 4, 6)')
@@ -524,6 +543,13 @@ describe('compiling specs to runtime values', () => {
       assertResultAsString('Set(1, 2, 3, 4).filter(x => false)', 'Set()')
       assertResultAsString('Set(1, 2, 3, 4).filter(x => true)', 'Set(1, 2, 3, 4)')
       assertResultAsString('Set(1, 2, 3, 4).filter(x => x % 2 == 0)', 'Set(2, 4)')
+    })
+
+    it('unpacks tuples in filter', () => {
+      assertResultAsString(
+        'tuples(1.to(5), 2.to(3)).filter((x, y) => x < y)',
+        'Set(Tup(1, 2), Tup(1, 3), Tup(2, 3))'
+      )
     })
 
     it('computes filter over intervals', () => {

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -290,6 +290,14 @@ describe('compiling specs to runtime values', () => {
       assertResultAsString(input, '24')
     })
 
+    it('unpacks tuples', () => {
+      const input =
+        `def mult(x, y) = (x * y)
+         val t = (3, 4)
+         mult(t)`
+      assertResultAsString(input, '12')
+    })
+
     it('uses named def instead of lambda', () => {
       const input =
         `def positive(x) = x > 0


### PR DESCRIPTION
Closes #365. This PR implements tuple unpacking in the simulator. Although I thought this would require types, unpacking can be easily done without types. This issue could be closed much earlier.

- [x] Tests added for any new code
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
