### PR TITLE
Update the Quint manual and the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ editor (currently, VSCode, Emacs and Vim are supported).
    components](./doc/adr003-visiting-ir-components.md)
  - [ADR004: An Effect System for Quint](./doc/adr004-effect-system.md)
  - [ADR005: A Type System for Quint](./doc/adr005-type-system.md)
+ - [ADR006: Design of modules and lookup tables](./doc/adr006-modules.lit.md)
 
 ### Source code :hash:
 

--- a/doc/quint.md
+++ b/doc/quint.md
@@ -183,10 +183,14 @@ Options:
 ```
 
  - If there are no critical errors (e.g., in parsing, typechecking, etc.),
-   the trace is currently written as a serialized Quint expression.
-   In the future, the trace will be written in the [Informal Trace Format][].
-   See the [issue #277](https://github.com/informalsystems/quint/issues/277).
-
+   the simulator tries to find the shortest trace that violates the invariant.
+   If it finds one, it prints the trace on the standard output.
+   If it does not find a violating trace, it prints the longest sample trace
+   that the simulator has found during the execution. When the parameter
+   `--out` is supplied, the trace is written as a JSON representation of
+   Quint IR in the output file. When the parameter `--out-itf` is supplied,
+   the trace is written in the [Informal Trace Format][].
+   
  - If the specification cannot be run (e.g., due to a parsing error), the file
    contains an error message in JSON:
 


### PR DESCRIPTION
This PR fixes the text that is a bit outdated.
