### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.8.0 -- 2023-03-24
+
+### Added
 
 - short-circuiting for `implies` (#717)
 - improve the summary output of `run` (#719)

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@sweet-monads/either": "^3.0.1",

--- a/quint/package.json
+++ b/quint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Core tool for the Quint specification language",
   "keywords": [
     "temporal",


### PR DESCRIPTION
## v0.8.0 -- 2023-03-24

### Added

- short-circuiting for `implies` (#717)
- improve the summary output of `run` (#719)
- support for tuple unpacking in the simulator (#720)
- instances are now fully supported (#725)
- save the run results to ITF (#727)
- imports can now be qualified (#742)

### Changed

- The syntax for instances is now similar to imports (#739)

### Deprecated
### Removed
### Fixed

- Heisenbugs in `nondet x = oneOf(S)` should not happen (#712)
- REPL doesn't show unecessary namespaces for variable names anymore (#739)

### Security

