### PR TITLE
VSCode Release v0.2.1

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.2.1 -- 2023-03-24
+
+### Added
 
 - Go to definition now works for parameters (#711)
 - Go to definition now works for type aliases (#726)

--- a/vscode/quint-vscode/package-lock.json
+++ b/vscode/quint-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quint-vscode",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-vscode",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "quint-vscode",
 	"displayName": "Quint",
 	"description": "Language support for Quint specifications",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "informal",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vscode/quint-vscode/server/package-lock.json
+++ b/vscode/quint-vscode/server/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "quint-lsp-server",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-lsp-server",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "Apache 2.0",
 			"dependencies": {
-				"@informalsystems/quint": "^0.7.0",
+				"@informalsystems/quint": "^0.8.0",
 				"vscode-languageserver": "^7.0.0",
 				"vscode-languageserver-textdocument": "^1.0.1"
 			},
@@ -387,9 +387,9 @@
 			"dev": true
 		},
 		"node_modules/@informalsystems/quint": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.7.0.tgz",
-			"integrity": "sha512-WSaPQZvrnvHiys2qrdTsuxaPaae4wyf9fTC2UEgTXvjmArc7v8HxFoZZodGZDozSdD7uyFXT1LOOeTLwr/AHNA==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.8.0.tgz",
+			"integrity": "sha512-fIZzo9ozEOUCUg6ZbRteEWvdOVZfmmvXGkMIub98NSiWS5Y70d+CZvh4y+CcJXF6gMLbd60sDz04A+TReoH7wA==",
 			"dependencies": {
 				"@sweet-monads/either": "^3.0.1",
 				"@sweet-monads/maybe": "^3.1.0",
@@ -448,9 +448,9 @@
 			}
 		},
 		"node_modules/@informalsystems/quint/node_modules/yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -642,9 +642,9 @@
 			"dev": true
 		},
 		"node_modules/@types/seedrandom": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.4.tgz",
-			"integrity": "sha512-/rWdxeiuZenlawrHU+XV6ZHMTKOqrC2hMfeDfLTIWJhDZP5aVqXRysduYHBbhD7CeJO6FJr/D2uBVXB7GT6v7w=="
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.5.tgz",
+			"integrity": "sha512-kopEpYpFQvQdYsZkZVwht/0THHmTFFYXDaqV/lM45eweJ8kcGVDgZHs0RVTolSq55UPZNmjhKc9r7UvLu/mQQg=="
 		},
 		"node_modules/@types/semver": {
 			"version": "7.3.13",
@@ -4386,9 +4386,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-			"integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+			"integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -6762,9 +6762,9 @@
 			"dev": true
 		},
 		"@informalsystems/quint": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.7.0.tgz",
-			"integrity": "sha512-WSaPQZvrnvHiys2qrdTsuxaPaae4wyf9fTC2UEgTXvjmArc7v8HxFoZZodGZDozSdD7uyFXT1LOOeTLwr/AHNA==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.8.0.tgz",
+			"integrity": "sha512-fIZzo9ozEOUCUg6ZbRteEWvdOVZfmmvXGkMIub98NSiWS5Y70d+CZvh4y+CcJXF6gMLbd60sDz04A+TReoH7wA==",
 			"requires": {
 				"@sweet-monads/either": "^3.0.1",
 				"@sweet-monads/maybe": "^3.1.0",
@@ -6808,9 +6808,9 @@
 					}
 				},
 				"yargs": {
-					"version": "17.6.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-					"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+					"version": "17.7.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+					"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
 					"requires": {
 						"cliui": "^8.0.1",
 						"escalade": "^3.1.1",
@@ -6980,9 +6980,9 @@
 			"dev": true
 		},
 		"@types/seedrandom": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.4.tgz",
-			"integrity": "sha512-/rWdxeiuZenlawrHU+XV6ZHMTKOqrC2hMfeDfLTIWJhDZP5aVqXRysduYHBbhD7CeJO6FJr/D2uBVXB7GT6v7w=="
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.5.tgz",
+			"integrity": "sha512-kopEpYpFQvQdYsZkZVwht/0THHmTFFYXDaqV/lM45eweJ8kcGVDgZHs0RVTolSq55UPZNmjhKc9r7UvLu/mQQg=="
 		},
 		"@types/semver": {
 			"version": "7.3.13",
@@ -9758,9 +9758,9 @@
 			"dev": true
 		},
 		"immutable": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-			"integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+			"integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "quint-lsp-server",
 	"description": "LSP server for Quint in node.",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"author": "Informal Systems",
 	"license": "Apache 2.0",
 	"engines": {
@@ -12,7 +12,7 @@
 		"url": "https://github.com/informalsystems/quint"
 	},
 	"dependencies": {
-		"@informalsystems/quint": "^0.7.0",
+		"@informalsystems/quint": "^0.8.0",
 		"vscode-languageserver": "^7.0.0",
 		"vscode-languageserver-textdocument": "^1.0.1"
 	},


### PR DESCRIPTION
## v0.2.1 -- 2023-03-24

### Added

- Go to definition now works for parameters (#711)
- Go to definition now works for type aliases (#726)

### Changed
### Deprecated
### Removed
### Fixed
### Security

