### PR TITLE
Add verbose execution output to `test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- detailed run output on `--verbosity=3` (#748)
+- detailed run output on `run --verbosity=3` (#748)
+- detailed run output on `test --verbosity=3` (#755)
 
 ### Changed
 ### Deprecated

--- a/doc/quint.md
+++ b/doc/quint.md
@@ -212,13 +212,14 @@ quint test <input>
 Run tests against a Quint specification
 
 Options:
-  --help     Show help                                                 [boolean]
-  --version  Show version number                                       [boolean]
-  --main     name of the main module (by default, computed from filename)
+  --help       Show help                                               [boolean]
+  --version    Show version number                                     [boolean]
+  --main       name of the main module (by default, computed from filename)
                                                                         [string]
-  --out      output file (suppresses all console output)                [string]
-  --seed     random seed to use for non-deterministic choice            [string]
-  --match    a string or regex that selects names to use as tests       [string]
+  --out        output file (suppresses all console output)              [string]
+  --seed       random seed to use for non-deterministic choice          [string]
+  --verbosity  control how much output is produced (0 to 5)[number] [default: 2]
+  --match      a string or regex that selects names to use as tests     [string]
 ```
 
  - If there are no critical errors (e.g., in parsing, typechecking, etc.), the

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -260,6 +260,7 @@ quint test --main counters --seed 1 \
 
   1) failingTest:
       HOME/counters.qnt:84:9 - error: Assertion failed
+      84:         assert(n == 0),
 
 
   Use --verbosity=3 to show executions.
@@ -414,7 +415,7 @@ quint run --max-steps=5 --seed=12 --invariant=totalSupplyDoesNotOverflowInv \
   --verbosity=3 \
   ../examples/solidity/Coin/coin.qnt 2>&1 | \
   sed 's/([0-9]*ms)/(duration)/g' | \
-  sed 's#^.*counters.qnt#      HOME/coin.qnt#g'
+  sed 's#^.*coin.qnt#      HOME/coin.qnt#g'
 ```
 
 <!-- !test out run shows calls -->
@@ -492,3 +493,51 @@ quint -q -r \
   ../tutorials/repl/kettle.qnt::kettle <../tutorials/repl/replTestIn.txt \
     | diff - ../tutorials/repl/replTestOut.txt
 ```
+
+### test --verbosity=3 outputs a trace
+
+<!-- !test in verbose test -->
+```
+quint test --seed=3 --verbosity=3 ../examples/solidity/Coin/coin.qnt | \
+  sed 's/([0-9]*ms)/(duration)/g' | \
+  sed 's#^.*coin.qnt#      HOME/coin.qnt#g'
+```
+
+<!-- !test out verbose test -->
+```
+
+  coin
+    ok sendWithoutMintTest
+    ok mintSendTest
+    1) mintTwiceThenSendTest
+
+  2 passing (duration)
+  1 failed
+
+  1) mintTwiceThenSendTest:
+      HOME/coin.qnt:176:5 - error: mintTwiceThenSendTest returns false
+      176:     run mintTwiceThenSendTest = {
+
+    [Frame 0]
+    mint("bob", "eve", 56121584374285688102497324576666468201644004471271061085874530776005052727296) => true
+    ├─ require(true) => true
+    └─ require(true) => true
+       └─ isUInt(56121584374285688102497324576666468201644004471271061085874530776005052727296) => true
+
+    [Frame 1]
+    mint("bob", "bob", 91422284371118026738799750509327856254566108764693012790426204149329833230336) => true
+    ├─ require(true) => true
+    └─ require(true) => true
+       └─ isUInt(91422284371118026738799750509327856254566108764693012790426204149329833230336) => true
+
+    [Frame 2]
+    send("eve", "bob", 33099102730177003576396430532542752743476829614253756677426469153216965640192) => false
+    ├─ require(true) => true
+    ├─ require(true) => true
+    │  └─ isUInt(23022481644108684526100894044123715458167174857017304408448061622788087087104) => true
+    └─ require(false) => false
+       └─ isUInt(124521387101295030315196181041870608998042938378946769467852673302546798870528) => false
+
+
+```
+

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -266,6 +266,38 @@ quint test --main counters --seed 1 \
   Use --verbosity=3 to show executions.
 ```
 
+### test counters produces no execution
+
+`test` should handle the special case of when an execution has not been
+recorded yet.
+
+<!-- !test in test empty trace -->
+```
+quint test --seed 1 --verbosity=3 \
+  ../examples/language-features/counters.qnt 2>&1 | \
+  sed 's/([0-9]*ms)/(duration)/g' | \
+  sed 's#^.*counters.qnt#      HOME/counters.qnt#g'
+```
+
+<!-- !test out test empty trace -->
+```
+
+  counters
+    ok passingTest
+    1) failingTest
+
+  1 passing (duration)
+  1 failed
+  1 ignored
+
+  1) failingTest:
+      HOME/counters.qnt:84:9 - error: Assertion failed
+      84:         assert(n == 0),
+
+    [No execution]
+
+```
+
 ### Run finds an invariant violation
 
 The command `run` finds an invariant violation.

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -260,10 +260,9 @@ quint test --main counters --seed 1 \
 
   1) failingTest:
       HOME/counters.qnt:84:9 - error: Assertion failed
-      84:         assert(n == 0),
-                  ^^^^^^^^^^^^^^
-      
 
+
+  Use --verbosity=3 to show executions.
 ```
 
 ### Run finds an invariant violation

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -92,7 +92,7 @@ const testCmd = {
         desc: 'control how much output is produced (0 to 5)',
         type: 'number',
       })
-      .default('verbosity', 2),
+      .default('verbosity', 2)
 // Timeouts are postponed for:
 // https://github.com/informalsystems/quint/issues/633
 //

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -88,6 +88,11 @@ const testCmd = {
         desc: 'random seed to use for non-deterministic choice',
         type: 'string',
       })
+      .option('verbosity', {
+        desc: 'control how much output is produced (0 to 5)',
+        type: 'number',
+      })
+      .default('verbosity', 2),
 // Timeouts are postponed for:
 // https://github.com/informalsystems/quint/issues/633
 //

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -354,6 +354,10 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
               printExecutionFrameRec(l => out('    ' + l), f, [])
               out('')
             })
+
+            if (testResult.frames.length == 0) {
+              out('    [No execution]')
+            }
           }
         })
         out('')

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -342,10 +342,10 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
           // output the header
           out(`  ${index + 1}) ${name}:`)
           const lines = details.split('\n')
-          // output the first line in red
-          if (lines.length > 0) {
-            out(chalk.red('      ' + lines[0]))
-          }
+          // output the first two lines in red
+          lines.slice(0, 2).forEach(l =>
+            out(chalk.red('      ' + l))
+          )
 
           if (verbosity.hasActionTracking(verbosityLevel)) {
             out('')

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -260,7 +260,6 @@ export function runRepl(_argv: any) {
  * @param typedStage the procedure stage produced by `typecheck`
  */
 export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
-  // output to the console, unless the json output is enabled
   const verbosityLevel = !prev.args.out ? prev.args.verbosity : 0
   const out = console.log
 

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -18,7 +18,16 @@ import { CompilationContext, compile } from './compile'
 import { newIdGenerator } from './../idGenerator'
 import { LookupTable } from '../lookupTable'
 import { Computable, kindName } from './runtime'
-import { noExecutionListener } from './trace'
+import { ExecutionFrame, newTraceRecorder } from './trace'
+
+/**
+ * Various settings to be passed to the testing framework.
+ */
+export interface TestOptions {
+  testMatch: (n: string) => boolean,
+  rand: () => number,
+  verbosity: number,
+}
 
 /**
  * Evaluation result.
@@ -37,61 +46,75 @@ export interface TestResult {
    * When status === 'failed', errors contain the explanatory error messages.
    */
   errors: ErrorMessage[]
+  /**
+   * If the trace was recorded, frames contains the history.
+   */
+  frames: ExecutionFrame[],
 }
 
 /**
  * Run a test suite of a single module.
  *
  * @param modules Quint modules in the intermediate representation
- * @param mainName the module that should be used as a state machine
+ * @param main the module that should be used as a state machine
  * @param sourceMap source map as produced by the parser
  * @param lookupTable lookup table as produced by the parser
  * @param types type table as produced by the type checker
- * @param testMatch test name matcher
- * @param rand a random number generator
+ * @param options misc test options
  * @returns the results of running the tests
  */
-export function
-  compileAndTest(modules: QuintModule[],
+export function compileAndTest(
+    modules: QuintModule[],
     main: QuintModule,
     sourceMap: Map<bigint, Loc>,
     lookupTable: LookupTable,
     types: Map<bigint, TypeScheme>,
-    testMatch: (n: string) => boolean,
-    rand: () => number): Either<string, TestResult[]> {
+    options: TestOptions): Either<string, TestResult[]> {
+  const recorder = newTraceRecorder(options.verbosity)
   const ctx =
     compile(modules, sourceMap, lookupTable,
-            types, main.name, noExecutionListener, rand)
+            types, main.name, recorder, options.rand)
 
   if(!ctx.main) {
     return left('Cannot find main module')
   }
 
   const testDefs =
-    ctx.main.defs.filter(d => d.kind === 'def' && testMatch(d.name)) as QuintOpDef[]
+    ctx.main.defs.filter(d =>
+      d.kind === 'def' && options.testMatch(d.name)) as QuintOpDef[]
 
   return merge(testDefs.map(def => {
     return getComputableForDef(ctx, def)
       .map(comp => {
+        recorder.onRunCall()
         const name = def.name
         const result = comp.eval()
+        recorder.onRunReturn(result, [] /* <= ignore the states */)
         if (result.isNone()) {
-          return { name, status: 'failed', errors: ctx.getRuntimeErrors() }
+          return {
+            name, status: 'failed', errors: ctx.getRuntimeErrors(),
+            frames: recorder.getBestTrace().subframes,
+          }
         }
 
         const ex = result.value.toQuintEx(newIdGenerator())
         if (ex.kind !== 'bool') {
-          return { name, status: 'ignored', errors: [] }
+          return { name, status: 'ignored', errors: [], frames: [] }
         }
         if (ex.value) {
-          return { name, status: 'passed', errors: [] }
+          return { name, status: 'passed', errors: [], frames: [] }
         }
 
         const e = fromIrErrorMessage(sourceMap)({
           explanation: `${name} returns false`,
           refs: [def.id],
         })
-        return { name, status: 'failed', errors: [e] }
+        return {
+          name,
+          status: 'failed',
+          errors: [e],
+          frames: recorder.getBestTrace().subframes,
+        }
       })
   }))
 }

--- a/quint/src/verbosity.ts
+++ b/quint/src/verbosity.ts
@@ -24,6 +24,13 @@ export const verbosity = {
   },
 
   /**
+   * Shall the tool output details about failing tests.
+   */
+  hasTestDetails: (level: number): boolean => {
+    return level >= 2
+  },
+
+  /**
    * Shall the tool write hints, e.g., how to change settings.
    */
   hasHints: (level: number): boolean => {


### PR DESCRIPTION
Contributes to #754. This PR implements `--verbosity=3` for `test`, similar to how it was done for `run`.

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
