### PR TITLE
Add global flag to README command

### DIFF
--- a/quint/README.md
+++ b/quint/README.md
@@ -8,7 +8,7 @@ with [the Quint specification language](https://github.com/informalsystems/quint
 Install the [latest published version from npm](https://www.npmjs.com/package/@informalsystems/quint):
 
 ``` sh
-npm i @informalsystems/quint
+npm i @informalsystems/quint -g
 ```
 
 ## How to run


### PR DESCRIPTION
Hello :octocat:

Our normal use case requires the global flag for npm, see https://nodejs.org/en/blog/npm/npm-1-0-global-vs-local-installation#which-to-choose