### PR TITLE
Add node dependency

### DIFF
--- a/quint/README.md
+++ b/quint/README.md
@@ -3,6 +3,10 @@
 This directory contains the `quint` CLI providing powerful tools for working
 with [the Quint specification language](https://github.com/informalsystems/quint).
 
+## Dependencies
+
+- Node.js >= 14
+
 ## Installation
 
 Install the [latest published version from npm](https://www.npmjs.com/package/@informalsystems/quint):


### PR DESCRIPTION
Hello :octocat: 

We can't run quint with versions of node prior to 14 due to [this](https://stackoverflow.com/questions/74590641/unexpected-token-when-trying-to-run-npm-run-dev). I have tested version 14 and it works. I have not tested previous versions because they are not easily available for my OS, but we got a report that it in fact breaks on node 12.