### PR TITLE
Showing execution details in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - detailed run output on `run --verbosity=3` (#748)
 - detailed run output on `test --verbosity=3` (#755)
+- detailed run output in REPL on `.verbosity=3` (#764)
 
 ### Changed
 ### Deprecated

--- a/doc/quint.md
+++ b/doc/quint.md
@@ -51,6 +51,8 @@ Options:
       --version  Show version number                                   [boolean]
   -r, --require  filename[::module]. Preload the file and, optionally, import
                  the module                                             [string]
+      --verbosity  control how much output is produced (0 to 5)
+                                                           [number] [default: 2]
 ```
 
 ```sh
@@ -59,6 +61,9 @@ quint repl
 
 The REPL is especially useful for learning the language. See the
 [repl](./repl.md) documentation for more details.
+
+The verbosity levels 3 and 4 are used to show execution details. They are
+especially useful for debugging complex specifications.
 
 ## Command `parse`
 

--- a/examples/cosmos/ics23/ics23.qnt
+++ b/examples/cosmos/ics23/ics23.qnt
@@ -28,7 +28,7 @@
 // >>> _test(1000, 10, "Init", "Next", "TestNonMem")
 //
 // If REPL displays 'false', it has found an example,
-// which can be inspected with _lastTrace.
+// which can be inspected with q::lastTrace.
 //
 // 3. To execute advanced PBT-like tests for 1000 runs in REPL,
 // type the following:
@@ -39,7 +39,7 @@
 // >>> _test(1000, 1, "Init", "Next", "MemInv")
 //
 // If REPL displays 'false', it has found an example,
-// which can be inspected with _lastTrace. We expect these tests to
+// which can be inspected with q::lastTrace. We expect these tests to
 // always return 'true'. Otherwise, this indicates an invariant violation.
 //
 // Igor Konnov, Informal Systems, 2022

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -294,7 +294,9 @@ quint test --seed 1 --verbosity=3 \
       HOME/counters.qnt:84:9 - error: Assertion failed
       84:         assert(n == 0),
 
-    [No execution]
+    [Frame 0]
+    Init() => true
+
 
 ```
 
@@ -455,9 +457,10 @@ quint run --max-steps=5 --seed=12 --invariant=totalSupplyDoesNotOverflowInv \
 An example execution:
 
 [Frame 0]
- q::init() => true
- └─ q::inv() => true
-    └─ isUInt(0) => true
+ q::initAndInvariant() => true
+ ├─ q::init() => true
+ │  └─ init() => true
+ └─ isUInt(0) => true
 
 [State 0]
  minter: "null"
@@ -465,13 +468,14 @@ An example execution:
 ────────────────────────────────────────────────────────────────────────────────
 
 [Frame 1]
- q::step() => true
- ├─ mint("null", "null", 79724149679233970751606042021871459804676944172294020221997378231441129734144) => true
- │  ├─ require(true) => true
- │  └─ require(true) => true
- │     └─ isUInt(79724149679233970751606042021871459804676944172294020221997378231441129734144) => true
- └─ q::inv() => true
-    └─ isUInt(79724149679233970751606042021871459804676944172294020221997378231441129734144) => true
+ q::stepAndInvariant() => true
+ ├─ q::step() => true
+ │  └─ step() => true
+ │     └─ mint("null", "null", 79724149679233970751606042021871459804676944172294020221997378231441129734144) => true
+ │        ├─ require(true) => true
+ │        └─ require(true) => true
+ │           └─ isUInt(79724149679233970751606042021871459804676944172294020221997378231441129734144) => true
+ └─ isUInt(79724149679233970751606042021871459804676944172294020221997378231441129734144) => true
 
 [State 1]
  minter: "null"
@@ -479,13 +483,14 @@ An example execution:
 ────────────────────────────────────────────────────────────────────────────────
 
 [Frame 2]
- q::step() => true
- ├─ mint("null", "charlie", 112817691068065462651698786821247929788486899638158978042098855089169166761984) => true
- │  ├─ require(true) => true
- │  └─ require(true) => true
- │     └─ isUInt(112817691068065462651698786821247929788486899638158978042098855089169166761984) => true
- └─ q::inv() => true
-    └─ isUInt(192541840747299433403304828843119389593163843810452998264096233320610296496128) => false
+ q::stepAndInvariant() => true
+ ├─ q::step() => true
+ │  └─ step() => true
+ │     └─ mint("null", "charlie", 112817691068065462651698786821247929788486899638158978042098855089169166761984) => true
+ │        ├─ require(true) => true
+ │        └─ require(true) => true
+ │           └─ isUInt(112817691068065462651698786821247929788486899638158978042098855089169166761984) => true
+ └─ isUInt(192541840747299433403304828843119389593163843810452998264096233320610296496128) => false
 
 [State 2]
  minter: "null"
@@ -551,18 +556,21 @@ quint test --seed=3 --verbosity=3 ../examples/solidity/Coin/coin.qnt | \
       176:     run mintTwiceThenSendTest = {
 
     [Frame 0]
+    init() => true
+
+    [Frame 1]
     mint("bob", "eve", 56121584374285688102497324576666468201644004471271061085874530776005052727296) => true
     ├─ require(true) => true
     └─ require(true) => true
        └─ isUInt(56121584374285688102497324576666468201644004471271061085874530776005052727296) => true
 
-    [Frame 1]
+    [Frame 2]
     mint("bob", "bob", 91422284371118026738799750509327856254566108764693012790426204149329833230336) => true
     ├─ require(true) => true
     └─ require(true) => true
        └─ isUInt(91422284371118026738799750509327856254566108764693012790426204149329833230336) => true
 
-    [Frame 2]
+    [Frame 3]
     send("eve", "bob", 33099102730177003576396430532542752743476829614253756677426469153216965640192) => false
     ├─ require(true) => true
     ├─ require(true) => true

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -42,7 +42,7 @@ const parseCmd = {
 // construct typecheck commands with yargs
 const typecheckCmd = {
   command: 'typecheck <input>',
-  desc: 'check types (TBD) and effects of a Quint specification',
+  desc: 'check types and effects of a Quint specification',
   builder: (yargs: any) =>
     yargs
       .option('out', {

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -16,6 +16,8 @@ import {
   docs, load, outputResult, parse, runRepl, runSimulator, runTests, typecheck
 } from './cliCommands'
 
+import { verbosity } from './verbosity'
+
 // construct parsing commands with yargs
 const parseCmd = {
   command: 'parse <input>',
@@ -62,11 +64,16 @@ const replCmd = {
         type: 'string',
       })
       .option('quiet', {
-        desc: 'Disable banners and prompts, to simplify scripting',
+        desc: 'Disable banners and prompts, to simplify scripting (alias for --verbosity=0)',
         alias: 'q',
         type: 'boolean',
       })
-      .default('quiet', false),
+      .default('quiet', false)
+      .option('verbosity', {
+        desc: 'control how much output is produced (0 to 5)',
+        type: 'number',
+      })
+      .default('verbosity', verbosity.defaultLevel),
   handler: runRepl,
 }
 
@@ -92,7 +99,7 @@ const testCmd = {
         desc: 'control how much output is produced (0 to 5)',
         type: 'number',
       })
-      .default('verbosity', 2)
+      .default('verbosity', verbosity.defaultLevel)
 // Timeouts are postponed for:
 // https://github.com/informalsystems/quint/issues/633
 //
@@ -159,7 +166,7 @@ const runCmd = {
         desc: 'control how much output is produced (0 to 5)',
         type: 'number',
       })
-      .default('verbosity', 2),
+      .default('verbosity', verbosity.defaultLevel),
 // Timeouts are postponed for:
 // https://github.com/informalsystems/quint/issues/633
 //

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -249,7 +249,7 @@ export function runRepl(_argv: any) {
   const options: ReplOptions = {
     preloadFilename: filename,
     importModule: moduleName,
-    quiet: _argv.quiet === true,
+    verbosity: _argv.quiet ? 0 : _argv.verbosity,
   }
   quintRepl(process.stdin, process.stdout, options)
 }

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -28,6 +28,7 @@ import { noExecutionListener } from './runtime/trace'
 import { ErrorMessage, probeParse } from './quintParserFrontend'
 import { IdGenerator, newIdGenerator } from './idGenerator'
 import { chalkQuintEx } from './graphics'
+import { verbosity } from './verbosity'
 
 // tunable settings
 export const settings = {
@@ -65,21 +66,23 @@ function defaultExit() {
 export interface ReplOptions {
   preloadFilename?: string,
   importModule?: string,
-  quiet?: boolean,
+  verbosity: number,
 }
 
 // the entry point to the REPL
 export function quintRepl(input: Readable,
                           output: Writable,
-                          options: ReplOptions = {},
+                          options: ReplOptions = {
+                            verbosity: verbosity.defaultLevel
+                          },
                           exit: () => void = defaultExit) {
   function out(text: string) {
     output.write(text + '\n')
   }
   function prompt(text: string) {
-    return options.quiet ? "" : text
+    return verbosity.hasReplPrompt(options.verbosity) ? text : ""
   }
-  if (!options.quiet) {
+  if (verbosity.hasReplBanners(options.verbosity)) {
     out(chalk.gray('Quint REPL v0.0.3'))
     out(chalk.gray('Type ".exit" to exit, or ".help" for more information'))
   }

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -223,7 +223,7 @@ export function quintRepl(input: Readable,
       case '.load': {
         const [filename, moduleName] = [args[1], args[2]]
         if (!filename) {
-          out(chalk.red('.load requires a filename'))
+          out(r('.load requires a filename'))
         } else {
           load(filename, moduleName)
         }
@@ -235,17 +235,29 @@ export function quintRepl(input: Readable,
         if (state.lastLoadedFileAndModule[0] !== undefined) {
           load(state.lastLoadedFileAndModule[0], state.lastLoadedFileAndModule[1])
         } else {
-          out(chalk.red('Nothing to reload. Use: .load filename [moduleName].'))
+          out(r('Nothing to reload. Use: .load filename [moduleName].'))
         }
         break
 
       case '.save':
         if (!args[1]) {
-          out(chalk.red('.save requires a filename'))
+          out(r('.save requires a filename'))
         } else {
           saveToFile(out, state, args[1])
         }
         rl.prompt()
+        break
+
+      case '.verbosity':
+        if (!args[1] || args[1].match(/^[0-5]$/) === null) {
+          out(r('.verbosity requires a level from 0 to 5'))
+        } else {
+          options.verbosity = Number(args[1])
+          if (verbosity.hasReplPrompt(options.verbosity)) {
+            out(g(`.verbosity is set to ${options.verbosity}`))
+          }
+          rl.setPrompt(prompt(settings.prompt))
+        }
         break
 
       default:

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -435,8 +435,8 @@ function loadShadowVars(state: ReplState, context: CompilationContext): void {
 // In the future, we will declare them in a separate module.
 const simulatorBuiltins =
 `val ${lastTraceName} = [];
-def _test(__nruns, __nsteps, __init, __next, __inv) = false;
-def _testOnce(__nsteps, __init, __next, __inv) = false;
+def q::test(q::nruns, q::nsteps, q::init, q::next, q::inv) = false;
+def q::testOnce(q::nsteps, q::init, q::next, q::inv) = false;
 `
 
 // try to evaluate the expression in a string and print it, if successful
@@ -471,7 +471,7 @@ ${textToAdd}
   }
   if (probeResult.kind === 'expr') {
     // embed expression text into a value definition inside a module
-    const moduleText = prepareParserInput(`  action __input =\n${newInput}`)
+    const moduleText = prepareParserInput(`  action q::input =\n${newInput}`)
     // compile the expression or definition and evaluate it
     const recorder = newTraceRecorder(state.verbosityLevel)
     const context =
@@ -487,7 +487,7 @@ ${textToAdd}
 
     loadVars(state, context)
     loadShadowVars(state, context)
-    const computable = contextNameLookup(context, '__input', 'callable')
+    const computable = contextNameLookup(context, 'q::input', 'callable')
     const result =
       computable
       .mapRight(comp => {
@@ -514,7 +514,7 @@ ${textToAdd}
               // Save the state, if there were any updates to variables.
               saveVars(state, context).map(missing => {
                 if (missing.length > 0) {
-                  out(chalk.yellow('Warning: Some variables are undefined: '
+                  out(chalk.yellow('[warning] some variables are undefined: '
                                    + missing.join(', ')))
                 }
               })

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -192,17 +192,20 @@ export function quintRepl(input: Readable,
   // the read-eval-print loop
   rl.on('line', (line) => {
     const args = line.trim().split(/\s+/)
+    const r = (s: string): string => { return chalk.red(s) }
+    const g = (s: string): string => { return chalk.gray(s) }
     switch (args[0]) {
       case '.help':
-        out('.clear\tClear the history')
-        out('.exit\tExit the REPL')
-        out('.help\tPrint this help message')
-        out('.load <filename> [<module>]\tClear the history,')
+        out(`${r('.clear')}\tClear the history`)
+        out(`${r('.exit')}\tExit the REPL`)
+        out(`${r('.help')}\tPrint this help message`)
+        out(`${r('.load')} <filename> ${g('[<module>]')}\tClear the history,`)
         out('     \tload the code from a file into the REPL session')
         out('     \tand optionally import all definitions from <module>')
-        out('.reload\tClear the history, load and (optionally) import the last loaded file.')
+        out(`${r('.reload')}\tClear the history, load and (optionally) import the last loaded file.`)
         out('     \t^ a productivity hack')
-        out('.save <filename>\tSave the accumulated definitions to a file')
+        out(`${r('.save')} <filename>\tSave the accumulated definitions to a file`)
+        out(`${r('.verbosity')} [0-5]\tSet the output level (0 = quiet, 5 = very detailed).`)
         out('\nType an expression and press Enter to evaluate it.')
         out('When the REPL switches to multiline mode "...", finish it with an empty line.')
         out('\nPress Ctrl+C to abort current expression, Ctrl+D to exit the REPL')

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -27,7 +27,7 @@ import { flatten } from '../flattening'
 /**
  * The name of the shadow variable that stores the last found trace.
  */
-export const lastTraceName = '_lastTrace'
+export const lastTraceName = 'q::lastTrace'
 
 /**
  * A compilation context returned by 'compile'.

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -1432,8 +1432,9 @@ export class CompilerVisitor implements IRVisitor {
                   // the run. Hence, do not report an error here, but simply
                   // drop the run. Otherwise, we would have a lot of false
                   // positives, which look like deadlocks but they are not.
-                  break
                   this.execListener.onUserOperatorReturn(nextApp, [], nextResult)
+                  break
+
                 }
               }
             }

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -30,7 +30,10 @@ import { RuntimeValue, rv } from './runtimeValue'
 
 import { lastTraceName } from '../compile'
 
-const specialNames = ['__input', '__runResult', '__nruns', '__nsteps', '__init', '__next', '__inv']
+const specialNames = [
+  'q::input', 'q::runResult', 'q::nruns',
+  'q::nsteps', 'q::init', 'q::next', 'q::inv',
+]
 
 export function builtinContext() {
   return new Map<string, Computable>([
@@ -91,7 +94,7 @@ export class CompilerVisitor implements IRVisitor {
     this.execListener = listener
     const lastTrace =
       mkRegister('shadow', lastTraceName, none(),
-        () => this.addRuntimeError(0n, '_lastTrace is not set'))
+        () => this.addRuntimeError(0n, 'q::lastTrace is not set'))
     this.shadowVars.push(lastTrace)
     this.context.set(kindName(lastTrace.kind, lastTrace.name), lastTrace)
   }
@@ -148,6 +151,22 @@ export class CompilerVisitor implements IRVisitor {
         `No expression for ${opdef.name} on compStack`)
       return
     }
+
+    if (opdef.qualifier === 'action' && opdef.expr.kind !== 'lambda') {
+      // A nullary action like `init` or `step`.
+      // It is not handled via applyUserDefined.
+      // Wrap its evaluation with the listener calls.
+      const unwrappedEval = boundValue.eval
+      const app: ir.QuintApp =
+        { id: opdef.id, kind: 'app', opcode: opdef.name, args: [] }
+      boundValue.eval = () => {
+        this.execListener.onUserOperatorCall(app)
+        const r = unwrappedEval()
+        this.execListener.onUserOperatorReturn(app, [], r)
+        return r
+      }
+    }
+
     const kname = kindName('callable', opdef.id)
     // bind the callable from the stack
     this.context.set(kname, boundValue)
@@ -240,7 +259,7 @@ export class CompilerVisitor implements IRVisitor {
     const comp =
       this.contextGet(name.name, ['shadow'])
       ?? this.contextLookup(name.id, ['arg', 'var', 'callable'])
-      // a backup case for Nat, Int, and Bool, and special names such as __input
+      // a backup case for Nat, Int, and Bool, and special names such as q::input
       ?? this.contextGet(name.name, ['arg', 'callable'])
     if (comp) {
       // this name has an associated computable object already
@@ -822,12 +841,12 @@ export class CompilerVisitor implements IRVisitor {
         this.translateRepeated(app)
         break
 
-      case '_test':
+      case 'q::test':
         // the special operator that runs random simulation
         this.test(app.id)
         break
 
-      case '_testOnce':
+      case 'q::testOnce':
         // the special operator that runs random simulation
         this.testOnce(app.id)
         break
@@ -1311,7 +1330,7 @@ export class CompilerVisitor implements IRVisitor {
   private test(sourceId: bigint) {
     if (this.compStack.length < 5) {
       this.addCompileError(sourceId,
-        'Not enough arguments on stack for "_test"')
+        'Not enough arguments on stack for "q::test"')
       return
     }
 
@@ -1322,7 +1341,7 @@ export class CompilerVisitor implements IRVisitor {
   private testOnce(sourceId: bigint) {
     if (this.compStack.length < 4) {
       this.addCompileError(sourceId,
-        'Not enough arguments on stack for "_testOnce"')
+        'Not enough arguments on stack for "q::testOnce"')
       return
     }
 
@@ -1373,7 +1392,7 @@ export class CompilerVisitor implements IRVisitor {
           trace = []
           // check Init()
           const initApp: ir.QuintApp =
-            { id: 0n, kind: 'app', opcode: 'q::init', args: [] }
+            { id: 0n, kind: 'app', opcode: 'q::initAndInvariant', args: [] }
           this.execListener.onUserOperatorCall(initApp)
           const initResult = init.eval()
           failure = initResult.isNone() || failure
@@ -1385,11 +1404,7 @@ export class CompilerVisitor implements IRVisitor {
             this.shiftVars()
             trace.push(varsToRecord())
             // check the invariant Inv
-            const invApp: ir.QuintApp =
-              { id: 0n, kind: 'app', opcode: 'q::inv', args: [] }
-            this.execListener.onUserOperatorCall(invApp)
             const invResult = inv.eval()
-            this.execListener.onUserOperatorReturn(invApp, [], invResult)
             this.execListener.onUserOperatorReturn(initApp, [], initResult)
             failure = invResult.isNone() || failure
             if (!isTrue(invResult)) {
@@ -1398,17 +1413,16 @@ export class CompilerVisitor implements IRVisitor {
               // check all { Next(), shift(), Inv } in a loop
               const nsteps = (nstepsRes as RuntimeValue).toInt()
               for (let i = 0; !errorFound && !failure && i < nsteps; i++) {
-                const nextApp: ir.QuintApp =
-                  { id: 0n, kind: 'app', opcode: 'q::step', args: [] }
+                const nextApp: ir.QuintApp = {
+                  id: 0n, kind: 'app', opcode: 'q::stepAndInvariant', args: []
+                }
                 this.execListener.onUserOperatorCall(nextApp)
                 const nextResult = next.eval()
                 failure = nextResult.isNone() || failure
                 if (isTrue(nextResult)) {
                   this.shiftVars()
                   trace.push(varsToRecord())
-                  this.execListener.onUserOperatorCall(invApp)
                   errorFound = !isTrue(inv.eval())
-                  this.execListener.onUserOperatorReturn(invApp, [], invResult)
                   this.execListener.onUserOperatorReturn(nextApp, [], nextResult)
                 } else {
                   // Otherwise, the run cannot be extended.
@@ -1418,8 +1432,8 @@ export class CompilerVisitor implements IRVisitor {
                   // the run. Hence, do not report an error here, but simply
                   // drop the run. Otherwise, we would have a lot of false
                   // positives, which look like deadlocks but they are not.
-                  this.execListener.onUserOperatorReturn(nextApp, [], nextResult)
                   break
+                  this.execListener.onUserOperatorReturn(nextApp, [], nextResult)
                 }
               }
             }

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -91,12 +91,12 @@ module __run__ {
   import ${mainName}.*
 
   val ${lastTraceName} = [];
-  def _test(__nrunsArg, __nstepsArg, __initArg, __nextArg, __invArg) = false;
-  action __init = { ${o.init} }
-  action __step = { ${o.step} }
-  val __inv = { ${o.invariant} }
-  val __runResult =
-    _test(${o.maxSamples}, ${o.maxSteps}, __init, __step, __inv)
+  def q::test(q::nrunsArg, q::nstepsArg, q::initArg, q::nextArg, q::invArg) = false;
+  action q::init = { ${o.init} }
+  action q::step = { ${o.step} }
+  val q::inv = { ${o.invariant} }
+  val q::runResult =
+    q::test(${o.maxSamples}, ${o.maxSteps}, q::init, q::step, q::inv)
 }
 `
 
@@ -113,9 +113,9 @@ module __run__ {
         .concat(ctx.compileErrors)
     return errSimulationResult('error', errors)
   } else {
-    // evaluate __runResult, which triggers the simulator
+    // evaluate q::runResult, which triggers the simulator
     const res: Either<string, Computable> =
-      contextNameLookup(ctx, '__runResult', 'callable')
+      contextNameLookup(ctx, 'q::runResult', 'callable')
     if (res.isLeft()) {
       const errors = [{ explanation: res.value, locs: [] }] as ErrorMessage[]
       return errSimulationResult('error', errors)

--- a/quint/src/verbosity.ts
+++ b/quint/src/verbosity.ts
@@ -12,9 +12,28 @@
 
 export const verbosity = {
   /**
+   * The default verbosity level.
+   */
+  defaultLevel: 2,
+
+  /**
    * The maximal verbosity level.
    */
   maxVerbosity: 5,
+
+  /**
+   * Shall REPL show the prompts like '>>> ' and '... '?
+   */
+  hasReplPrompt: (level: number): boolean => {
+    return level > 0
+  },
+
+  /**
+   * Shall REPL show the banner?
+   */
+  hasReplBanners: (level: number): boolean => {
+    return level > 0
+  },
 
   /**
    * Shall the tool output the execution results.

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -38,7 +38,7 @@ const withIO = async(inputText: string): Promise<string> => {
   // whatever is written on the input goes to the output
   input.pipe(output)
 
-  const rl = quintRepl(input, output, {}, () => {})
+  const rl = quintRepl(input, output, { verbosity: 2 }, () => {})
 
   // Emit the input line-by-line, as nodejs is printing prompts.
   // TODO: is it a potential source of race conditions in unit tests?

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -227,6 +227,30 @@ describe('repl ok', () => {
     await assertRepl(input, output)
   })
 
+  it('change verbosity and track executions', async() => {
+    const input = dedent(
+      `pure def plus(x, y) = x + y
+      |.verbosity=4
+      |plus(2, 3)
+      |`
+    )
+    const output = dedent(
+      `>>> pure def plus(x, y) = x + y
+      |
+      |>>> .verbosity=4
+      |.verbosity=4
+      |>>> plus(2, 3)
+      |5
+      |
+      | [Frame 0]
+      | q::input() => 5
+      | └─ plus(2, 3) => 5
+      |
+      |>>> `
+    )
+    await assertRepl(input, output)
+  })
+
   it('handle exceptions', async() => {
     const input = dedent(
       `Set(Int)

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -213,11 +213,11 @@ describe('repl ok', () => {
       |>>> .clear
       |
       |>>> n * n
-      |syntax error: error: Failed to resolve name n in definition for __input, in module __repl__
+      |syntax error: error: Failed to resolve name n in definition for q::input, in module __repl__
       |n * n
       |^
       |
-      |syntax error: error: Failed to resolve name n in definition for __input, in module __repl__
+      |syntax error: error: Failed to resolve name n in definition for q::input, in module __repl__
       |n * n
       |    ^
       |
@@ -457,19 +457,19 @@ describe('repl ok', () => {
     await assertRepl(input, output)
   })
 
-  it('run _test, _testOnce, and _lastTrace', async() => {
+  it('run q::test, q::testOnce, and q::lastTrace', async() => {
     const input = dedent(
       `
       |var n: int
       |action Init = n' = 0
       |action Next = n' = n + 1
       |val Inv = n < 10
-      |_testOnce(5, Init, Next, Inv)
-      |_testOnce(10, Init, Next, Inv)
-      |_test(5, 5, Init, Next, Inv)
-      |_test(5, 10, Init, Next, Inv)
-      |_lastTrace.length()
-      |_lastTrace.nth(_lastTrace.length() - 1)
+      |q::testOnce(5, Init, Next, Inv)
+      |q::testOnce(10, Init, Next, Inv)
+      |q::test(5, 5, Init, Next, Inv)
+      |q::test(5, 10, Init, Next, Inv)
+      |q::lastTrace.length()
+      |q::lastTrace.nth(q::lastTrace.length() - 1)
       |`
     )
     const output = dedent(
@@ -482,17 +482,17 @@ describe('repl ok', () => {
       |
       |>>> val Inv = n < 10
       |
-      |>>> _testOnce(5, Init, Next, Inv)
+      |>>> q::testOnce(5, Init, Next, Inv)
       |true
-      |>>> _testOnce(10, Init, Next, Inv)
+      |>>> q::testOnce(10, Init, Next, Inv)
       |false
-      |>>> _test(5, 5, Init, Next, Inv)
+      |>>> q::test(5, 5, Init, Next, Inv)
       |true
-      |>>> _test(5, 10, Init, Next, Inv)
+      |>>> q::test(5, 10, Init, Next, Inv)
       |false
-      |>>> _lastTrace.length()
+      |>>> q::lastTrace.length()
       |11
-      |>>> _lastTrace.nth(_lastTrace.length() - 1)
+      |>>> q::lastTrace.nth(q::lastTrace.length() - 1)
       |{ n: 10 }
       |>>> `
     )

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -19,7 +19,7 @@ const idGen = newIdGenerator()
 // Compile an expression, evaluate it, convert to QuintEx, then to a string,
 // compare the result. This is the easiest path to test the results.
 function assertResultAsString(input: string, expected: string | undefined) {
-  const moduleText = `module __runtime { val __input = ${input} }`
+  const moduleText = `module __runtime { val q::input = ${input} }`
   const context =
     compileFromCode(idGen,
       moduleText, '__runtime', noExecutionListener, () => Math.random())
@@ -27,7 +27,7 @@ function assertResultAsString(input: string, expected: string | undefined) {
   assert.isEmpty(context.syntaxErrors, `Syntax errors: ${context.syntaxErrors.map(e => e.explanation).join(', ')}`)
   assert.isEmpty(context.compileErrors, `Compile errors: ${context.compileErrors.map(e => e.explanation).join(', ')}`)
 
-  contextNameLookup(context, '__input', 'callable')
+  contextNameLookup(context, 'q::input', 'callable')
     .mapLeft(msg => assert(false, `Unexpected error: ${msg}`))
     .mapRight(value => {
       const result = value.eval()


### PR DESCRIPTION
Closes #754. Closes #762. This PR finishes the work on detailed output for operator evaluation. As in case of `run` and `test`, this output is enabled with `--verbosity=3`. Additionally, one can enable it with `.verbosity=3` directly in REPL.

I've also found the case when the action call was not tracked, namely, the case of nullary actions like `init` or `step`. Fixed that. As a result, the detailed output is a bit more verbose than before.

Also, I've renamed all operators like `__test` and `_lastTrace` to `q::test` and `q::lastTrace`. Let's use the namespace `q` for the operators internal to Quint.

- [x] Tests added for any new code
- [x] Update the docs
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
