### PR TITLE
fix highlighting for numbers in vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Effects no longer break when applying constant operators (#759)
+- Number highlighting in vim (#765)
 
 ### Security
 

--- a/editor-plugins/vim/quint.vim
+++ b/editor-plugins/vim/quint.vim
@@ -29,7 +29,7 @@ syn region quintComment start="/\*" end="\*/" fold
 syn match quintIdent "[a-zA-Z_][a-zA-Z0-9_]*"
 
 " numbers and strings
-syn match quintNumber '-\?\(0x[0-9a-fA-F]\([0-9a-fA-F]\|_[0-9a-fA-F]\)*\|0\|[1-9]([0-9]\|_[0-9])*\)'
+syn match quintNumber '-\?\(0x[0-9a-fA-F]\([0-9a-fA-F]\|_[0-9a-fA-F]\)*\|0\|[1-9]\([0-9]\|_[0-9]\)*\)'
 syn region quintString start='"' end='"'
 
 " types


### PR DESCRIPTION
This one-liner fixes vim highlighting
