### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.9.0 -- 2023-04-03
+
+### Added
 
 - detailed run output on `run --verbosity=3` (#748)
 - detailed run output on `test --verbosity=3` (#755)

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@sweet-monads/either": "^3.0.1",

--- a/quint/package.json
+++ b/quint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Core tool for the Quint specification language",
   "keywords": [
     "temporal",


### PR DESCRIPTION
## v0.9.0 -- 2023-04-03

### Added

- detailed run output on `run --verbosity=3` (#748)
- detailed run output on `test --verbosity=3` (#755)
- detailed run output in REPL on `.verbosity=3` (#764)

### Changed
### Deprecated
### Removed

- remove `foldr` (#760)

### Fixed

- Effects no longer break when applying constant operators (#759)
- Number highlighting in vim (#765)

### Security

