### PR TITLE
Fix test command error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- `test` command now exits with non-zero code on test failures (#772)
+
 ### Security
 
 ## v0.9.0 -- 2023-04-03

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -219,8 +219,9 @@ Temporarily disabled.
 
 ### OK on test lottery.qnt
 
-<!-- !test check lottery - Syntax/Types & Effects/Unit tests -->
-    quint test --main=lotteryTests ../examples/solidity/icse23-fig7/lottery.qnt
+<!-- TODO: Spec test is erroneous https://github.com/informalsystems/quint/issues/775 -->
+<!-- <\!-- !test check lottery - Syntax/Types & Effects/Unit tests -\-> -->
+<!--     quint test --main=lotteryTests ../examples/solidity/icse23-fig7/lottery.qnt -->
 
 ### OK on test erc20.qnt
 

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -220,7 +220,7 @@ Temporarily disabled.
 ### OK on test lottery.qnt
 
 <!-- TODO: Spec test is erroneous https://github.com/informalsystems/quint/issues/775 -->
-<!-- <\!-- !test check lottery - Syntax/Types & Effects/Unit tests -\-> -->
+<!-- check lottery - Syntax/Types & Effects/Unit tests -->
 <!--     quint test --main=lotteryTests ../examples/solidity/icse23-fig7/lottery.qnt -->
 
 ### OK on test erc20.qnt

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -243,10 +243,10 @@ The command `test` finds failing tests and prints error messages.
 <!-- !test exit 1 -->
 <!-- !test in test runs -->
 ```
-quint test --main counters --seed 1 \
-  ../examples/language-features/counters.qnt 2>&1 | \
-  sed 's/([0-9]*ms)/(duration)/g' | \
-  sed 's#^.*counters.qnt#      HOME/counters.qnt#g'
+output=$(quint test --main counters --seed 1 ../examples/language-features/counters.qnt)
+exit_code=$?
+echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*counters.qnt#      HOME/counters.qnt#g'
+exit $exit_code
 ```
 
 <!-- !test out test runs -->
@@ -276,10 +276,10 @@ recorded yet.
 <!-- !test exit 1 -->
 <!-- !test in test empty trace -->
 ```
-quint test --seed 1 --verbosity=3 \
-  ../examples/language-features/counters.qnt 2>&1 | \
-  sed 's/([0-9]*ms)/(duration)/g' | \
-  sed 's#^.*counters.qnt#      HOME/counters.qnt#g'
+output=$(quint test --seed 1 --verbosity=3 ../examples/language-features/counters.qnt)
+exit_code=$?
+echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*counters.qnt#      HOME/counters.qnt#g'
+exit $exit_code
 ```
 
 <!-- !test out test empty trace -->
@@ -299,8 +299,6 @@ quint test --seed 1 --verbosity=3 \
 
     [Frame 0]
     Init() => true
-
-
 ```
 
 ### Run finds an invariant violation
@@ -539,9 +537,10 @@ quint -q -r \
 <!-- !test exit 1 -->
 <!-- !test in verbose test -->
 ```
-quint test --seed=3 --verbosity=3 ../examples/solidity/Coin/coin.qnt | \
-  sed 's/([0-9]*ms)/(duration)/g' | \
-  sed 's#^.*coin.qnt#      HOME/coin.qnt#g'
+output=$(quint test --seed=3 --verbosity=3 ../examples/solidity/Coin/coin.qnt)
+exit_code=$?
+echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
+exit $exit_code
 ```
 
 <!-- !test out verbose test -->
@@ -581,6 +580,4 @@ quint test --seed=3 --verbosity=3 ../examples/solidity/Coin/coin.qnt | \
     │  └─ isUInt(23022481644108684526100894044123715458167174857017304408448061622788087087104) => true
     └─ require(false) => false
        └─ isUInt(124521387101295030315196181041870608998042938378946769467852673302546798870528) => false
-
-
 ```

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -240,6 +240,7 @@ true
 
 The command `test` finds failing tests and prints error messages.
 
+<!-- !test exit 1 -->
 <!-- !test in test runs -->
 ```
 quint test --main counters --seed 1 \
@@ -272,6 +273,7 @@ quint test --main counters --seed 1 \
 `test` should handle the special case of when an execution has not been
 recorded yet.
 
+<!-- !test exit 1 -->
 <!-- !test in test empty trace -->
 ```
 quint test --seed 1 --verbosity=3 \
@@ -534,6 +536,7 @@ quint -q -r \
 
 ### test --verbosity=3 outputs a trace
 
+<!-- !test exit 1 -->
 <!-- !test in verbose test -->
 ```
 quint test --seed=3 --verbosity=3 ../examples/solidity/Coin/coin.qnt | \

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -283,9 +283,6 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
       out(`\n  ${mainName}`)
     }
 
-    const _matchFun =
-      (n: string): boolean => isMatchingTest(prev.args.match, n)
-
     const options: TestOptions = {
       testMatch: (n: string) => { return isMatchingTest(prev.args.match, n) },
       rand: mkRng(prev.args.seed),
@@ -369,11 +366,11 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
     } // else: we have handled the case of module not found already
 
     const errors = namedErrors.map(([_, e]) => e)
-    const result = { ...testing, passed, failed, ignored, errors }
+    const stage = { ...testing, passed, failed, ignored, errors }
     if (errors.length == 0 && failed.length == 0) {
-      return right(result)
+      return right(stage)
     } else {
-      return left({msg: "Tests failed", stage: { ...result, errors }})
+      return left({msg: "Tests failed", stage})
     }
   }
 }

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -283,6 +283,9 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
       out(`\n  ${mainName}`)
     }
 
+    const _matchFun =
+      (n: string): boolean => isMatchingTest(prev.args.match, n)
+
     const options: TestOptions = {
       testMatch: (n: string) => { return isMatchingTest(prev.args.match, n) },
       rand: mkRng(prev.args.seed),
@@ -366,7 +369,12 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
     } // else: we have handled the case of module not found already
 
     const errors = namedErrors.map(([_, e]) => e)
-    return right({ ...testing, passed, failed, ignored, errors })
+    const result = { ...testing, passed, failed, ignored, errors }
+    if (errors.length == 0 && failed.length == 0) {
+      return right(result)
+    } else {
+      return left({msg: "Tests failed", stage: { ...result, errors }})
+    }
   }
 }
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -283,9 +283,6 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
       out(`\n  ${mainName}`)
     }
 
-    const matchFun =
-      (n: string): boolean => isMatchingTest(prev.args.match, n)
-
     const options: TestOptions = {
       testMatch: (n: string) => { return isMatchingTest(prev.args.match, n) },
       rand: mkRng(prev.args.seed),


### PR DESCRIPTION
Closes #772

We have a uniform mechanism for reporting errors (along with exit codes) for
failed executions, but the `test` subcommand wasn't using it, so it was exiting
with a `0` and without reporting on stderr. 

This change makes it so that `test` produces a non-zero exit code on failures.

Note that this has also uncovered a failing test.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Ran `npm run format` (or had formatting run automatically on all files edited)
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [x] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality