### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+### Security
+
+## v0.9.1 -- 2023-04-04
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
 
 - `test` command now exits with non-zero code on test failures (#772)
 

--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache 2.0",
       "dependencies": {
         "@sweet-monads/either": "^3.0.1",

--- a/quint/package.json
+++ b/quint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@informalsystems/quint",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Core tool for the Quint specification language",
   "keywords": [
     "temporal",


### PR DESCRIPTION
## v0.9.1 -- 2023-04-04

### Added
### Changed
### Deprecated
### Removed
### Fixed

- `test` command now exits with non-zero code on test failures (#772)

### Security

