### PR TITLE
Extend flattening to support `export`

### DIFF
--- a/examples/language-features/instances.qnt
+++ b/examples/language-features/instances.qnt
@@ -23,4 +23,7 @@ module Instances {
 
   // the above is equivalent to TLA+'s instance:
   // A2 == INSTANCE A WITH x <- 15, y <- MyY
+
+  export A1
+  export A2
 }

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -645,13 +645,14 @@ true
 
 <!-- !test in compile instances -->
 ```
-echo "A2::g(false)" | quint -r ../examples/language-features/instances.qnt::Instances 2>&1 | tail -n +3
+echo -e "A1::f(1)\nA2::f(1)" | quint -r ../examples/language-features/instances.qnt::Instances 2>&1 | tail -n +3
 ```
 
 <!-- !test out compile instances -->
 ```
 true
 
->>> true
+>>> 34
+>>> 16
 >>> 
 ```

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -625,3 +625,33 @@ exit $exit_code
 ```
 error: --seed must be a big integer, found: NotANumber
 ```
+
+### OK on compile imports
+
+<!-- !test in compile imports -->
+```
+echo "init" | quint -r ../examples/language-features/imports.qnt::G 2>&1 | tail -n +3
+```
+
+<!-- !test out compile imports -->
+```
+true
+
+>>> true
+>>> 
+```
+
+### OK on compile instances
+
+<!-- !test in compile instances -->
+```
+echo "A2::g(false)" | quint -r ../examples/language-features/instances.qnt::Instances 2>&1 | tail -n +3
+```
+
+<!-- !test out compile instances -->
+```
+true
+
+>>> true
+>>> 
+```

--- a/quint/test/flatenning.test.ts
+++ b/quint/test/flatenning.test.ts
@@ -190,4 +190,29 @@ describe('flatten', () => {
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
   })
+
+  describe('export instance with qualifier', () => {
+    const baseDefs = [
+      'const N: int',
+      'val x = N + 1',
+    ]
+
+    const defs = [
+      'val myN = 1',
+      'import A(N = myN) as A1',
+      'export A1 as B',
+    ]
+
+    const expectedDefs = [
+      'val myN = 1',
+      // Namespaced defs, from the instance statement
+      'pure val A1::N: int = myN',
+      'val A1::x = iadd(A1::N, 1)',
+      // Exported defs, with namespace B
+      'pure val B::N: int = myN',
+      'val B::x = iadd(B::N, 1)',
+    ]
+
+    assertFlatennedDefs(baseDefs, defs, expectedDefs)
+  })
 })

--- a/quint/test/flatenning.test.ts
+++ b/quint/test/flatenning.test.ts
@@ -134,4 +134,60 @@ describe('flatten', () => {
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
   })
+
+  describe('export with previous import', () => {
+    const baseDefs = [
+      'val f(x) = x + 1',
+    ]
+
+    const defs = [
+      'import A.*',
+      'export A.*',
+    ]
+
+    const expectedDefs = [
+      'val f = (x => iadd(x, 1))',
+    ]
+
+    assertFlatennedDefs(baseDefs, defs, expectedDefs)
+  })
+
+  describe('export without previous import', () => {
+    const baseDefs = [
+      'val f(x) = x + 1',
+    ]
+
+    const defs = [
+      'export A.*',
+    ]
+
+    const expectedDefs = [
+      'val f = (x => iadd(x, 1))',
+    ]
+
+    assertFlatennedDefs(baseDefs, defs, expectedDefs)
+  })
+
+  describe('export instance', () => {
+    const baseDefs = [
+      'const N: int',
+      'val x = N + 1',
+    ]
+
+    const defs = [
+      'import A(N = 1) as A1',
+      'export A1.*',
+    ]
+
+    const expectedDefs = [
+      // Namespaced defs, from the instance statement
+      'pure val A1::N: int = 1',
+      'val A1::x = iadd(A1::N, 1)',
+      // Exported defs, without namespace
+      'pure val N: int = 1',
+      'val x = iadd(N, 1)',
+    ]
+
+    assertFlatennedDefs(baseDefs, defs, expectedDefs)
+  })
 })

--- a/quint/test/flatenning.test.ts
+++ b/quint/test/flatenning.test.ts
@@ -109,11 +109,11 @@ describe('flatten', () => {
     const expectedDefs = [
       'pure val A1::N: int = 1',
       'var A1::x: int',
-      'pure def A1::f = (a => iadd(a, 1))',
+      'pure def A1::f = (A1::a => iadd(A1::a, 1))',
       `action A1::V = assign(A1::x, A1::f(A1::x))`,
       'assume A1::T = igt(A1::N, 0)',
-      'def A1::lam = val A1::b = 1 { (a => iadd(A1::b, a)) }',
-      'def A1::lam2 = val A1::b = 1 { (a => iadd(A1::b, a)) }',
+      'def A1::lam = val A1::b = 1 { (A1::a => iadd(A1::b, A1::a)) }',
+      'def A1::lam2 = val A1::b = 1 { (A1::a => iadd(A1::b, A1::a)) }',
     ]
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)


### PR DESCRIPTION
Hello :octocat: 

We all noticed some weird things breaking on the compiler last week, and that's because there were many scenarios (mostly involving `export`) where the flattening procedure was not doing the right thing. This fixes a bunch of those and introduces more tests, including integration tests for the `language-feature` examples for imports and instances (which were only being parsed and typechecked until now). 

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
- [X] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
