### PR TITLE
run fails on invariant violation, add prisoners

### DIFF
--- a/examples/puzzles/prisoners/prisoners.qnt
+++ b/examples/puzzles/prisoners/prisoners.qnt
@@ -131,7 +131,7 @@ module prisoners {
 
 // An instance of prisoners for the set of size 3
 module prisoners3 {
-    module P = prisoners(allPrisoners = Set("A", "B", "C"), counter = "A")
+    import prisoners(allPrisoners = Set("A", "B", "C"), counter = "A") as P
     
-    import P.*
+    export P.*
 }

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -247,6 +247,12 @@ Temporarily disabled.
 
 <!-- !test check ics20 bank - Syntax/Types & Effects/Unit tests -->
     quint test ../examples/cosmos/ics20/bank.qnt
+    
+### OK on run prisoners
+
+<!-- !test check prisoners - Syntax/Types & Effects/Invariants -->
+    quint run --main=prisoners3 --invariant='countInv and safetyInv' \
+    ../examples/puzzles/prisoners/prisoners.qnt
 
 ### OK on typecheck SuperSpec.qnt
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -467,16 +467,34 @@ export function runSimulator(prev: TypecheckedStage):
         }
       }
 
-      if (result.errors.length != 0) {
-        // in case of 'failure', there may still be errors
-        return cliErr('run failed', { ...simulator, errors: result.errors })
-      } else {
-        return right({
+      // If nothing found, return a success. Otherwise, return an error.
+      let msg
+      switch (result.status) {
+        case 'ok':
+          return right({
+              ...simulator,
+              status: result.status,
+              trace: result.states,
+          })
+
+        case 'violation':
+          msg = 'Invariant violated'
+          break
+
+        case 'failure':
+          msg = 'Runtime error'
+          break
+
+        default:
+          msg = 'Unknown error'
+      }
+
+      return cliErr(msg, {
             ...simulator,
             status: result.status,
             trace: result.states,
-        })
-      }
+            errors: [],
+          })
     }
 }
 


### PR DESCRIPTION
This is a small PR adding two featuers:

- [x] `quint run` now returns a non-zero exit code on anything different from `ok`
- [x] `prisoners.qnt` are no using the new import/export syntax
- [x] `prisoners.qnt` have a first invariant-checking test in `cli-tests.md` 🎉 

- [x] Tests added for any new code
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
