### PR TITLE
Report error when lambda returns an operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Proper errors are now reported when a lambda returns an operator (#811)
+
 ### Security
 
 ## v0.9.1 -- 2023-04-04

--- a/quint/src/effects/modeChecker.ts
+++ b/quint/src/effects/modeChecker.ts
@@ -155,7 +155,7 @@ function modeForEffect(scheme: EffectScheme): [OpQualifier, string] {
     case 'arrow': {
       const r = effect.result
       if (r.kind === 'arrow') {
-        throw new Error(`Unexpected arrow found in operator result: ${effectToString(r)}`)
+        throw new Error(`Unexpected arrow found in operator result: ${effectToString(effect)}`)
       }
 
       if (r.kind === 'variable') {

--- a/quint/test/effects/inferrer.test.ts
+++ b/quint/test/effects/inferrer.test.ts
@@ -228,4 +228,19 @@ describe('inferEffects', () => {
       location: 'Trying to infer effect for operator application in map(S, (p => assign(x, p)))',
     }))
   })
+
+  it('returns error when lambda returns an operator', () => {
+    const defs = ([
+      'pure def f(x) = x',
+      'pure def myOp = (_) => f',
+    ])
+
+    const [errors] = inferEffectsForDefs(defs)
+
+    errors.forEach(v => assert.deepEqual(v, {
+      children: [],
+      location: 'Inferring effect for f',
+      message: 'Result cannot be an opperator',
+    }))
+  })
 })


### PR DESCRIPTION
Hello :octocat: 

This is a quick fix to #810. We were not properly checking for lambdas returning operator, which is not allowed. The mode checker would throw:

```
Error: Unexpected arrow found in operator result: (e0) => (e1) => e1
    at modeForEffect (/home/gabriela/projects/quint/quint/dist/src/effects/modeChecker.js:142:23)
    at ModeChecker.exitOpDef (/home/gabriela/projects/quint/quint/dist/src/effects/modeChecker.js:51:37)
```

Now we report it properly, so the error looks like this:
```
/home/gabriela/projects/quint/examples/test.qnt:3:26 - error: [QNT000] Result cannot be an opperator
Inferring effect for f

3:   pure def myOp = (_) => f
                            ^

error: typechecking failed
```

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
