### PR TITLE
set the seed in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `quint run` returns a non-zero exit code on invariant violation and errors (#793)
 - suppress comments in REPL (#806)
 - `quint repl` is printing the same version number as returned by `quint --version` (#804)
+- add the command `.seed` in REPL (#812)
 
 ### Changed
 

--- a/quint/src/rng.ts
+++ b/quint/src/rng.ts
@@ -75,7 +75,7 @@ export const newRng = (initialState?: bigint): Rng => {
     },
 
     setState: (s: bigint): void => {
-      state = BigInt(s) % U64
+      state = BigInt(s >= 0 ? s : -s) % U64
     },
 
     next: (bound: bigint): bigint => {

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -252,6 +252,25 @@ describe('repl ok', () => {
     await assertRepl(input, output)
   })
 
+  it('set and get the seed', async() => {
+    const input = dedent(
+      `.seed=4
+      |.seed
+      |.seed=0x1abc
+      |`
+    )
+    const output = dedent(
+      `>>> .seed=4
+      |.seed=4
+      |>>> .seed
+      |.seed=4
+      |>>> .seed=0x1abc
+      |.seed=6844
+      |>>> `
+    )
+    await assertRepl(input, output)
+  })
+
   it('handle exceptions', async() => {
     const input = dedent(
       `Set(Int)


### PR DESCRIPTION
This PR implements the command `.seed` that sets the random seed right in REPL.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

Here is an example:

![Screenshot 2023-04-14 at 15 30 19](https://user-images.githubusercontent.com/436810/232059450-d51a66bc-bcc2-49f0-a35f-9e4efdf33781.png)

