### PR TITLE
fix error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - suppress comments in REPL (#806)
 - `quint repl` is printing the same version number as returned by `quint --version` (#804)
 - add the command `.seed` in REPL (#812)
+- fix `quint run` to output compile errors again (#812)
 
 ### Changed
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -493,7 +493,7 @@ export function runSimulator(prev: TypecheckedStage):
             ...simulator,
             status: result.status,
             trace: result.states,
-            errors: [],
+            errors: result.errors,
           })
     }
 }


### PR DESCRIPTION
A one-line fix for the issue that I somehow introduced in `run`: It stopped showing compile errors. 

I wanted to add a test for it, but then realized that it was hitting a rare case when the spec was parsed, type checked, resolved, but then the compile phase in the simulator failed. We should add some tests for this behavior in the future.

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
