### PR TITLE
cache pure val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `quint repl` is printing the same version number as returned by `quint --version` (#804)
 - add the command `.seed` in REPL (#812)
 - fix `quint run` to output compile errors again (#812)
+- cache top-level `pure val` (#837)
 
 ### Changed
 

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -167,6 +167,20 @@ export class CompilerVisitor implements IRVisitor {
       }
     }
 
+    if (opdef.qualifier === 'pureval') {
+      // a pure value may be cached, once evaluated
+      const originalEval = boundValue.eval
+      let cache: Maybe<EvalResult> | undefined = undefined
+      boundValue.eval = (): Maybe<EvalResult> => {
+        if (cache !== undefined) {
+          return cache
+        } else {
+          cache = originalEval()
+          return cache
+        }
+      }
+    }
+
     const kname = kindName('callable', opdef.id)
     // bind the callable from the stack
     this.context.set(kname, boundValue)


### PR DESCRIPTION
Closes #807. This PR adds caching of top-level `pure val`, similar to caching of nested `pure val`. There is not much we can test here.

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
