### PR TITLE
ICS20 spec integrating `bank` and `denomTrace`

### DIFF
--- a/examples/cosmos/ics20/bank.qnt
+++ b/examples/cosmos/ics20/bank.qnt
@@ -20,7 +20,6 @@ module bank {
    * TYPES
    * **************************************************************************/
 
-  type Address = str
   type Amount = int
   type Denomination = DenomTrace
 
@@ -127,6 +126,11 @@ module bank {
       { success: false, accounts: accounts}
     }
   }
+}
+
+module bankTests {
+  import base.* from "./base"
+  import bank.*
 
   /* ***************************************************************************
    * STATE MACHINE

--- a/examples/cosmos/ics20/bank.qnt
+++ b/examples/cosmos/ics20/bank.qnt
@@ -14,14 +14,15 @@
  */
 
 module bank {
+  import base.* from "./base"
 
   /* ***************************************************************************
    * TYPES
    * **************************************************************************/
 
   type Address = str
-  type Denomination = str
   type Amount = int
+  type Denomination = DenomTrace
 
   type TokenBalances = Denomination -> Amount
   type Accounts = Address -> TokenBalances
@@ -127,6 +128,10 @@ module bank {
     }
   }
 
+  pure def toDenom(baseDenom: str): Denomination = {
+    { baseDenom: baseDenom, path: [] }
+  }
+
   /* ***************************************************************************
    * STATE MACHINE
    * **************************************************************************/
@@ -135,7 +140,7 @@ module bank {
   var error: bool  // true iff a previous bank operation has been unsuccessful
 
   pure val Addresses : Set[Address] = Set("alice", "bob", "charlie")
-  pure val Denoms : Set[Denomination] = Set("atom", "eth", "osmo")
+  pure val Denoms : Set[Denomination] = Set(toDenom("atom"), toDenom("eth"), toDenom("osmo"))
 
   // Trivial action defs for the bank module operations
   action burn(sender: Address, denom: Denomination, amount: Amount): bool =
@@ -165,7 +170,7 @@ module bank {
    * Alice, Bob and Charlie initially hold 10 ATOMs, and no other coins.
    */
   action init = all {
-    state' = Addresses.mapBy(_ => Map("atom" -> 10)),
+    state' = Addresses.mapBy(_ => Map(toDenom("atom") -> 10)),
     error' = false
   }
 
@@ -194,16 +199,16 @@ module bank {
     // last operation successful
     assert(not(error)),
     // everybody holds 10 ATOM
-    assert(state.getBalances("alice").getBalance("atom") == 10),
-    assert(state.getBalances("bob").getBalance("atom") == 10),
-    assert(state.getBalances("charlie").getBalance("atom") == 10),
+    assert(state.getBalances("alice").getBalance(toDenom("atom")) == 10),
+    assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
+    assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
     // nobody holds ETH
-    assert(state.getBalances("alice").getBalance("eth") == 0),
-    assert(state.getBalances("bob").getBalance("eth") == 0),
-    assert(state.getBalances("charlie").getBalance("eth") == 0),
+    assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
+    assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
+    assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 0),
     // "noAccount" holds nothing
-    assert(state.getBalances("noAccount").getBalance("atom") == 0),
-    assert(state.getBalances("noAccount").getBalance("eth") == 0),
+    assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
+    assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
   }
 
   // Do some mint, burn, transfer steps and check that account balances are correct.
@@ -212,76 +217,76 @@ module bank {
       .then(all {
         initialState,
         // now mint alice 15 ATOMs
-        mint("alice", "atom", 15)
+        mint("alice", toDenom("atom"), 15)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // alice received her 15 ATOM
-        assert(state.getBalances("alice").getBalance("atom") == 25),
-        assert(state.getBalances("bob").getBalance("atom") == 10),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
         // still nobody holds ETH
-        assert(state.getBalances("alice").getBalance("eth") == 0),
-        assert(state.getBalances("bob").getBalance("eth") == 0),
-        assert(state.getBalances("charlie").getBalance("eth") == 0),
+        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 0),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance("atom") == 0),
-        assert(state.getBalances("noAccount").getBalance("eth") == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
 
         // now burn bob 6 ATOMs
-        burn("bob", "atom", 6)
+        burn("bob", toDenom("atom"), 6)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // bob lost 42 ATOM
-        assert(state.getBalances("alice").getBalance("atom") == 25),
-        assert(state.getBalances("bob").getBalance("atom") == 4),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 4),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
         // still nobody holds ETH
-        assert(state.getBalances("alice").getBalance("eth") == 0),
-        assert(state.getBalances("bob").getBalance("eth") == 0),
-        assert(state.getBalances("charlie").getBalance("eth") == 0),
+        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 0),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance("atom") == 0),
-        assert(state.getBalances("noAccount").getBalance("eth") == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
 
         // now mint charlie 6 ETH
-        mint("charlie", "eth", 6)
+        mint("charlie", toDenom("eth"), 6)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // ATOM balances remain the same
-        assert(state.getBalances("alice").getBalance("atom") == 25),
-        assert(state.getBalances("bob").getBalance("atom") == 4),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 4),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
         // now charlie holds 6 ETH
-        assert(state.getBalances("alice").getBalance("eth") == 0),
-        assert(state.getBalances("bob").getBalance("eth") == 0),
-        assert(state.getBalances("charlie").getBalance("eth") == 6),
+        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 6),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance("atom") == 0),
-        assert(state.getBalances("noAccount").getBalance("eth") == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
 
         // now transfer 4 of charlie's ETH to bob
-        transfer("charlie", "bob", "eth", 4)
+        transfer("charlie", "bob", toDenom("eth"), 4)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // ATOM balances remain the same
-        assert(state.getBalances("alice").getBalance("atom") == 25),
-        assert(state.getBalances("bob").getBalance("atom") == 4),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 4),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
         // bob got 4 of charlie's ETH
-        assert(state.getBalances("alice").getBalance("eth") == 0),
-        assert(state.getBalances("bob").getBalance("eth") == 4),
-        assert(state.getBalances("charlie").getBalance("eth") == 2),
+        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 4),
+        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 2),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance("atom") == 0),
-        assert(state.getBalances("noAccount").getBalance("eth") == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
+        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
 
         // nothing changes
         state' = state,
@@ -296,18 +301,18 @@ module bank {
         initialState,
 
         // now burn alice 10 ATOMs
-        burn("alice", "atom", 10)
+        burn("alice", toDenom("atom"), 10)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // alice lost 10 ATOM
-        assert(state.getBalances("alice").getBalance("atom") == 0),
-        assert(state.getBalances("bob").getBalance("atom") == 10),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 0),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
 
         // now burn bob 11 ATOMs
-        burn("bob", "atom", 11)
+        burn("bob", toDenom("atom"), 11)
       })
       .then(all{
         // burning over balance failed
@@ -326,18 +331,18 @@ module bank {
         initialState,
 
         // now transfer 10 ATOMs from alice to bob
-        transfer("alice", "bob", "atom", 10)
+        transfer("alice", "bob", toDenom("atom"), 10)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // alice -- 10 ATOM --> bob
-        assert(state.getBalances("alice").getBalance("atom") == 0),
-        assert(state.getBalances("bob").getBalance("atom") == 20),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 0),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 20),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
 
         // now transfer 21 ATOMs from bob to charlie
-        transfer("bob", "charlie", "atom", 21)
+        transfer("bob", "charlie", toDenom("atom"), 21)
       })
       .then(all{
         // transfer over balance failed
@@ -356,18 +361,18 @@ module bank {
         initialState,
 
         // now mint alice 0 ATOMs
-        mint("alice", "atom", 0)
+        mint("alice", toDenom("atom"), 0)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // balances remain
-        assert(state.getBalances("alice").getBalance("atom") == 10),
-        assert(state.getBalances("bob").getBalance("atom") == 10),
-        assert(state.getBalances("charlie").getBalance("atom") == 10),
+        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
 
         // now mint alice -1 ATOMs
-        mint("alice", "atom", -1)
+        mint("alice", toDenom("atom"), -1)
       })
       .then(all{
         // negative minting failed

--- a/examples/cosmos/ics20/bank.qnt
+++ b/examples/cosmos/ics20/bank.qnt
@@ -67,7 +67,7 @@ module bank {
 
   /* Return `accounts`, where `address` is updated to hold
    * `currentAmount + amount` tokens of denomination `denom`.
-   * 
+   *
    * `currentAmount` refers to the number of tokens of denomination `denom` held
    * by `address` in `accounts`.
    *
@@ -126,10 +126,6 @@ module bank {
     } else {
       { success: false, accounts: accounts}
     }
-  }
-
-  pure def toDenom(baseDenom: str): Denomination = {
-    { baseDenom: baseDenom, path: [] }
   }
 
   /* ***************************************************************************

--- a/examples/cosmos/ics20/base.qnt
+++ b/examples/cosmos/ics20/base.qnt
@@ -23,6 +23,7 @@ module base {
   }
 
   type UINT256 = int
+  type Address = str
 
   pure def toDenom(baseDenom: str): DenomTrace = {
     { baseDenom: baseDenom, path: [] }

--- a/examples/cosmos/ics20/base.qnt
+++ b/examples/cosmos/ics20/base.qnt
@@ -25,6 +25,10 @@ module base {
   type UINT256 = int
   type Address = str
 
+  type Channel = str
+  /// Map from channel name in a chain to its counterparty on other chain
+  type Channels = Channel -> Channel
+
   pure def toDenom(baseDenom: str): DenomTrace = {
     { baseDenom: baseDenom, path: [] }
   }

--- a/examples/cosmos/ics20/base.qnt
+++ b/examples/cosmos/ics20/base.qnt
@@ -1,0 +1,26 @@
+module base {
+  /// A hop is a step taken by a token sent from one chain to another. In this
+  /// spec, we only care about one element of the hop (sometimes the source
+  /// chain, sometimes the destination chain). A `HopElement` is a representation
+  /// of either the source or the destination chain of a hop.
+  type HopElement = {
+    port: str,
+    channel: str,
+  }
+
+  /// A denomination trace is a representation of the original denomination
+  /// (also: base denomination) and all the hops it has done to get where it is.
+  /// For every token transfer, ICS-020 either adds or removes one hop from the
+  /// list. In the implementation, a `DenomTrace` is represented as a string of
+  /// the form
+  /// `{ics20Port_n}/{ics20Channel_n}/.../{ics20Port_1}/{ics20Channel_1}/{baseDenom}`,
+  /// where `ics20Port_i` and `ics20Channel_i` are the destination port and
+  /// channel of the i-th hop. A token transfer then means adding or dropping a
+  /// prefix.
+  type DenomTrace = {
+    path: List[HopElement],
+    baseDenom: str,
+  }
+
+  type UINT256 = int
+}

--- a/examples/cosmos/ics20/base.qnt
+++ b/examples/cosmos/ics20/base.qnt
@@ -23,4 +23,8 @@ module base {
   }
 
   type UINT256 = int
+
+  pure def toDenom(baseDenom: str): DenomTrace = {
+    { baseDenom: baseDenom, path: [] }
+  }
 }

--- a/examples/cosmos/ics20/denomTrace.qnt
+++ b/examples/cosmos/ics20/denomTrace.qnt
@@ -33,17 +33,17 @@ module denomTrace {
   /// and adds a hop if the token is moving somewhere else.
   pure def updateTrace(denomTrace: DenomTrace, sourcePort: str, sourceChannel: str, destPort: str, destChannel: str): DenomTrace = {
     val hopSource = { port: sourcePort, channel: sourceChannel }
-    val hopDestination = { port: destPort, channel: destChannel}
+    val hopDestination = { port: destPort, channel: destChannel }
     if (movingBackAlongTrace(hopSource, denomTrace)) {
       // Sender is sink (receiver is source). Token is moving back in timeline.
       // Remove prefix from trace, since we already used that information to
       // find that the token just undid a previous hop.
-      { path: denomTrace.path.tail(), baseDenom: denomTrace.baseDenom }
+      { baseDenom: denomTrace.baseDenom, path: denomTrace.path.tail() }
     } else {
       // Sender is source (receiver is sink). Token is moving forward in timeline.
       // Add prefix to trace, in order to know that if the token ever returns
       // from the destination chain, it is undoing this hop.
-      { path: [hopDestination].concat(denomTrace.path), baseDenom: denomTrace.baseDenom }
+      { baseDenom: denomTrace.baseDenom, path: [hopDestination].concat(denomTrace.path) }
     }
   }
 
@@ -66,7 +66,7 @@ module denomTrace {
 // Tests for denom trace manipulation
 module denomTraceTest {
   import base.* from "./base"
-  import denomTrace.updateTrace
+  import denomTrace.*
 
   // For testing, imagine the following channels in these chains setups
   // PS: There should be similar channels between A and C, those are ommited in the diagram for simplicity
@@ -84,8 +84,8 @@ module denomTraceTest {
   var trace: DenomTrace
 
   action init = trace' = {
-    path: [],
     baseDenom: "denom",
+    path: [],
   }
 
   /// Finds the correct channels for a transfer according to the chain setup
@@ -169,6 +169,7 @@ module denomTraceTest {
 }
 
 module denomTraceSimulation {
+  import base.* from "./base"
   import denomTrace.*
 
   pure val chains = Set("A", "B", "C")
@@ -204,8 +205,8 @@ module denomTraceSimulation {
     nondet someMap = possibleChannelSetups.oneOf()
     all {
       trace' = {
-        path: [],
         baseDenom: "denom",
+        path: [],
       },
       channelSetup' = someMap,
       counter' = 0,
@@ -247,89 +248,4 @@ module properChannelsTests {
   import denomTraceSimulation(
     channelPredicate = isProperChannelSetup
   ) as S
-}
-
-// For now, this module is just a setup to show how `denomTrace` can be used in the IBC context.
-module ics20 {
-  import denomTrace.*
-
-  type Uint = int
-
-  type FungibleTokenPacketData = {
-    ibcTrace: DenomTrace,
-    amount: Uint,
-    sender: str,
-    receiver: str,
-    memo: str,
-  }
-
-  type Packet = {
-    data: FungibleTokenPacketData,
-    sourcePort: str,
-    sourceChannel: str,
-    destPort: str,
-    destChannel: str,
-  }
-
-  type Result = { tokenOperation: str, ibcDenom: DenomTrace }
-
-  pure def onRecvPacket(packet: Packet): Result =
-    pure val tokenOperation =
-      if (movingBackAlongTrace({ port: packet.sourcePort, channel: packet.sourceChannel}, packet.data.ibcTrace))
-        // This should interact with the bank module. For now, we just return
-        // the token operation to enable visualization and testing the sequence
-        // of operations.
-        "transfer"
-      else
-        "mint"
-    pure val ibcDenom = updateTrace(packet.data.ibcTrace, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
-    { tokenOperation: tokenOperation, ibcDenom: ibcDenom }
-}
-
-// An example run with some packets transferring tokens from
-// A -> B -> C -> A -> C -> B -> A (the same example from denomTraceTest)
-module ics20Example {
-  import denomTrace.*
-  import denomTraceTest.getChannelsForTransfer
-  import ics20.*
-
-  var log: List[Result]
-  action init =
-    log' = [{ tokenOperation: "transfer", ibcDenom: { path: [], baseDenom: "denom" } }]
-
-  pure def buildPacket(ibcTrace: DenomTrace, sourceChain: str, destChain: str): Packet =
-    pure val channels = getChannelsForTransfer(sourceChain, destChain)
-    ({
-      data: {
-        ibcTrace: ibcTrace,
-        amount: 100,
-        sender: "todo",
-        receiver: "todo",
-        memo: "todo",
-      },
-      sourcePort: "transfer",
-      sourceChannel: channels.sourceChannel,
-      destPort: "transfer",
-      destChannel: channels.destChannel,
-    })
-
-  run transferOperations = init.then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "A", "B")))
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "B", "C"))),
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "C", "A"))),
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "A", "C"))),
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "C", "B")))
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "B", "A"))),
-  }))
 }

--- a/examples/cosmos/ics20/denomTrace.qnt
+++ b/examples/cosmos/ics20/denomTrace.qnt
@@ -167,3 +167,169 @@ module denomTraceTest {
     trace' = trace,
   }))
 }
+
+module denomTraceSimulation {
+  import denomTrace.*
+
+  pure val chains = Set("A", "B", "C")
+  pure val transferSequence = List(
+    ("A", "B"),
+    ("B", "C"),
+    ("C", "A"),
+    ("A", "C"),
+    ("C", "B"),
+    ("B", "A")
+  )
+
+  const channelPredicate: (str -> str -> str) => bool
+
+  pure val channelNames = Set("channel-1", "channel-2", "channel-3")
+
+  /// All possible combination of channels by chain satisfying `channelPredicate`
+  pure val possibleChannelSetups = chains.setOfMaps(chains.setOfMaps(channelNames)).filter(channelPredicate)
+
+  var trace: DenomTrace
+  var channelSetup: str -> str -> str
+  var counter: int
+
+  def getChannelsForTransfer(transfer: (str, str)): { sourceChannel: str, destChannel: str } =
+    ({
+      sourceChannel: channelSetup.get(transfer._1).get(transfer._2),
+      // The destination channel would be the source channel in the opposite
+      // direction, so we only need to reverse the order of the chains
+      destChannel: channelSetup.get(transfer._2).get(transfer._1),
+    })
+
+  action init =
+    nondet someMap = possibleChannelSetups.oneOf()
+    all {
+      trace' = {
+        path: [],
+        baseDenom: "denom",
+      },
+      channelSetup' = someMap,
+      counter' = 0,
+    }
+
+  action step =
+    val channels = getChannelsForTransfer(transferSequence[counter])
+    all {
+      trace' = updateTrace(trace, "transfer", channels.sourceChannel, "transfer", channels.destChannel),
+      counter' = counter + 1,
+      channelSetup' = channelSetup,
+    }
+
+  action unchanged = all {
+    trace' = trace,
+    counter' = counter,
+    channelSetup' = channelSetup,
+  }
+
+  run simulationTest = init.then(step.repeated(6)).then((all {
+    def show(a) = true { show(channelSetup) },
+    assert(trace.path == []),
+    unchanged,
+  }))
+}
+
+// Fails because the channel setup is not proper
+// The aim is to show that it is, in fact, necessary to enforce `isProperChannelSetup`
+module randomChannelsTests {
+  import denomTraceSimulation(
+    channelPredicate = (_) => true
+  ) as S
+}
+
+// Passes because the channel setup is proper
+module properChannelsTests {
+  import denomTrace.isProperChannelSetup
+
+  import denomTraceSimulation(
+    channelPredicate = isProperChannelSetup
+  ) as S
+}
+
+// For now, this module is just a setup to show how `denomTrace` can be used in the IBC context.
+module ics20 {
+  import denomTrace.*
+
+  type Uint = int
+
+  type FungibleTokenPacketData = {
+    ibcTrace: DenomTrace,
+    amount: Uint,
+    sender: str,
+    receiver: str,
+    memo: str,
+  }
+
+  type Packet = {
+    data: FungibleTokenPacketData,
+    sourcePort: str,
+    sourceChannel: str,
+    destPort: str,
+    destChannel: str,
+  }
+
+  type Result = { tokenOperation: str, ibcDenom: DenomTrace }
+
+  pure def onRecvPacket(packet: Packet): Result =
+    pure val tokenOperation =
+      if (movingBackAlongTrace({ port: packet.sourcePort, channel: packet.sourceChannel}, packet.data.ibcTrace))
+        // This should interact with the bank module. For now, we just return
+        // the token operation to enable visualization and testing the sequence
+        // of operations.
+        "transfer"
+      else
+        "mint"
+    pure val ibcDenom = updateTrace(packet.data.ibcTrace, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
+    { tokenOperation: tokenOperation, ibcDenom: ibcDenom }
+}
+
+// An example run with some packets transferring tokens from
+// A -> B -> C -> A -> C -> B -> A (the same example from denomTraceTest)
+module ics20Example {
+  import denomTrace.*
+  import denomTraceTest.getChannelsForTransfer
+  import ics20.*
+
+  var log: List[Result]
+  action init =
+    log' = [{ tokenOperation: "transfer", ibcDenom: { path: [], baseDenom: "denom" } }]
+
+  pure def buildPacket(ibcTrace: DenomTrace, sourceChain: str, destChain: str): Packet =
+    pure val channels = getChannelsForTransfer(sourceChain, destChain)
+    ({
+      data: {
+        ibcTrace: ibcTrace,
+        amount: 100,
+        sender: "todo",
+        receiver: "todo",
+        memo: "todo",
+      },
+      sourcePort: "transfer",
+      sourceChannel: channels.sourceChannel,
+      destPort: "transfer",
+      destChannel: channels.destChannel,
+    })
+
+  run transferOperations = init.then((all {
+    val lastTrace = log[log.length() - 1].ibcDenom
+    log' = log.append(onRecvPacket(buildPacket(lastTrace, "A", "B")))
+  })).then((all {
+    val lastTrace = log[log.length() - 1].ibcDenom
+    log' = log.append(onRecvPacket(buildPacket(lastTrace, "B", "C"))),
+  })).then((all {
+    val lastTrace = log[log.length() - 1].ibcDenom
+    log' = log.append(onRecvPacket(buildPacket(lastTrace, "C", "A"))),
+  })).then((all {
+    val lastTrace = log[log.length() - 1].ibcDenom
+    log' = log.append(onRecvPacket(buildPacket(lastTrace, "A", "C"))),
+  })).then((all {
+    val lastTrace = log[log.length() - 1].ibcDenom
+    log' = log.append(onRecvPacket(buildPacket(lastTrace, "C", "B")))
+  })).then((all {
+    val lastTrace = log[log.length() - 1].ibcDenom
+    log' = log.append(onRecvPacket(buildPacket(lastTrace, "B", "A"))),
+  }))
+}

--- a/examples/cosmos/ics20/denomTrace.qnt
+++ b/examples/cosmos/ics20/denomTrace.qnt
@@ -66,7 +66,7 @@ module denomTrace {
 // Tests for denom trace manipulation
 module denomTraceTest {
   import base.* from "./base"
-  import denomTrace.*
+  import denomTrace.updateTrace
 
   // For testing, imagine the following channels in these chains setups
   // PS: There should be similar channels between A and C, those are ommited in the diagram for simplicity

--- a/examples/cosmos/ics20/denomTrace.qnt
+++ b/examples/cosmos/ics20/denomTrace.qnt
@@ -7,28 +7,7 @@
  * Gabriela Moreira, Informal Systems, 2023
  */
 module denomTrace {
-  /// A hop is a step taken by a token sent from one chain to another. In this
-  /// spec, we only care about one element of the hop (sometimes the source
-  /// chain, sometimes the destination chain). A `HopElement` is a representation
-  /// of either the source or the destination chain of a hop.
-  type HopElement = {
-    port: str,
-    channel: str,
-  }
-
-  /// A denomination trace is a representation of the original denomination
-  /// (also: base denomination) and all the hops it has done to get where it is.
-  /// For every token transfer, ICS-020 either adds or removes one hop from the
-  /// list. In the implementation, a `DenomTrace` is represented as a string of
-  /// the form
-  /// `{ics20Port_n}/{ics20Channel_n}/.../{ics20Port_1}/{ics20Channel_1}/{baseDenom}`,
-  /// where `ics20Port_i` and `ics20Channel_i` are the destination port and
-  /// channel of the i-th hop. A token transfer then means adding or dropping a
-  /// prefix.
-  type DenomTrace = {
-    path: List[HopElement],
-    baseDenom: str,
-  }
+  import base.* from "./base"
 
   /// `movingBackAlongTrace` is true for a hop iff that hop is the reverse of the
   /// last hop done by the token. That is, if the source of this hop is equal to
@@ -86,6 +65,7 @@ module denomTrace {
 
 // Tests for denom trace manipulation
 module denomTraceTest {
+  import base.* from "./base"
   import denomTrace.*
 
   // For testing, imagine the following channels in these chains setups
@@ -185,171 +165,5 @@ module denomTraceTest {
   })).then((all {
     assert(trace.path == []),
     trace' = trace,
-  }))
-}
-
-module denomTraceSimulation {
-  import denomTrace.*
-
-  pure val chains = Set("A", "B", "C")
-  pure val transferSequence = List(
-    ("A", "B"),
-    ("B", "C"),
-    ("C", "A"),
-    ("A", "C"),
-    ("C", "B"),
-    ("B", "A")
-  )
-
-  const channelPredicate: (str -> str -> str) => bool
-
-  pure val channelNames = Set("channel-1", "channel-2", "channel-3")
-
-  /// All possible combination of channels by chain satisfying `channelPredicate`
-  pure val possibleChannelSetups = chains.setOfMaps(chains.setOfMaps(channelNames)).filter(channelPredicate)
-
-  var trace: DenomTrace
-  var channelSetup: str -> str -> str
-  var counter: int
-
-  def getChannelsForTransfer(transfer: (str, str)): { sourceChannel: str, destChannel: str } =
-    ({
-      sourceChannel: channelSetup.get(transfer._1).get(transfer._2),
-      // The destination channel would be the source channel in the opposite
-      // direction, so we only need to reverse the order of the chains
-      destChannel: channelSetup.get(transfer._2).get(transfer._1),
-    })
-
-  action init =
-    nondet someMap = possibleChannelSetups.oneOf()
-    all {
-      trace' = {
-        path: [],
-        baseDenom: "denom",
-      },
-      channelSetup' = someMap,
-      counter' = 0,
-    }
-
-  action step =
-    val channels = getChannelsForTransfer(transferSequence[counter])
-    all {
-      trace' = updateTrace(trace, "transfer", channels.sourceChannel, "transfer", channels.destChannel),
-      counter' = counter + 1,
-      channelSetup' = channelSetup,
-    }
-
-  action unchanged = all {
-    trace' = trace,
-    counter' = counter,
-    channelSetup' = channelSetup,
-  }
-
-  run simulationTest = init.then(step.repeated(6)).then((all {
-    def show(a) = true { show(channelSetup) },
-    assert(trace.path == []),
-    unchanged,
-  }))
-}
-
-// Fails because the channel setup is not proper
-// The aim is to show that it is, in fact, necessary to enforce `isProperChannelSetup`
-module randomChannelsTests {
-  import denomTraceSimulation(
-    channelPredicate = (_) => true
-  ) as S
-}
-
-// Passes because the channel setup is proper
-module properChannelsTests {
-  import denomTrace.isProperChannelSetup
-
-  import denomTraceSimulation(
-    channelPredicate = isProperChannelSetup
-  ) as S
-}
-
-// For now, this module is just a setup to show how `denomTrace` can be used in the IBC context.
-module ics20 {
-  import denomTrace.*
-
-  type Uint = int
-
-  type FungibleTokenPacketData = {
-    ibcTrace: DenomTrace,
-    amount: Uint,
-    sender: str,
-    receiver: str,
-    memo: str,
-  }
-
-  type Packet = {
-    data: FungibleTokenPacketData,
-    sourcePort: str,
-    sourceChannel: str,
-    destPort: str,
-    destChannel: str,
-  }
-
-  type Result = { tokenOperation: str, ibcDenom: DenomTrace }
-
-  pure def onRecvPacket(packet: Packet): Result =
-    pure val tokenOperation =
-      if (movingBackAlongTrace({ port: packet.sourcePort, channel: packet.sourceChannel}, packet.data.ibcTrace))
-        // This should interact with the bank module. For now, we just return
-        // the token operation to enable visualization and testing the sequence
-        // of operations.
-        "transfer"
-      else
-        "mint"
-    pure val ibcDenom = updateTrace(packet.data.ibcTrace, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
-    { tokenOperation: tokenOperation, ibcDenom: ibcDenom }
-}
-
-// An example run with some packets transferring tokens from
-// A -> B -> C -> A -> C -> B -> A (the same example from denomTraceTest)
-module ics20Example {
-  import denomTrace.*
-  import denomTraceTest.getChannelsForTransfer
-  import ics20.*
-
-  var log: List[Result]
-  action init =
-    log' = [{ tokenOperation: "transfer", ibcDenom: { path: [], baseDenom: "denom" } }]
-
-  pure def buildPacket(ibcTrace: DenomTrace, sourceChain: str, destChain: str): Packet =
-    pure val channels = getChannelsForTransfer(sourceChain, destChain)
-    ({
-      data: {
-        ibcTrace: ibcTrace,
-        amount: 100,
-        sender: "todo",
-        receiver: "todo",
-        memo: "todo",
-      },
-      sourcePort: "transfer",
-      sourceChannel: channels.sourceChannel,
-      destPort: "transfer",
-      destChannel: channels.destChannel,
-    })
-
-  run transferOperations = init.then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "A", "B")))
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "B", "C"))),
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "C", "A"))),
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "A", "C"))),
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "C", "B")))
-  })).then((all {
-    val lastTrace = log[log.length() - 1].ibcDenom
-    log' = log.append(onRecvPacket(buildPacket(lastTrace, "B", "A"))),
   }))
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -47,14 +47,6 @@ module ics20 {
     channelEscrowAddresses: Channel -> Address,
   }
 
-  /// `onRecvPacket` should return an acknowledgment, but it also has to update
-  /// the chain state, so the return type is the updated value for the chain
-  /// state and the acknowledgment
-  type ReceiveTokenPacketResult = {
-    chainState: ChainState,
-    acknowledgement: FungibleTokenPacketAcknowledgement
-  }
-
   /// The counterparty for a channel `C` in a chain is the channel identifier of
   /// the channel `C` connects to, in the other chain.
   pure def getCounterparty(chainState: ChainState, sourceChannel: Channel): Channel = {
@@ -93,38 +85,33 @@ module ics20 {
     }
   }
 
-  pure def onRecvPacket(chainState: ChainState, packet: Packet): ReceiveTokenPacketResult = {
+  /// `onRecvPacket` should return an acknowledgment, but it also has to update
+  /// the chain state, so the return type is the updated value for the chain
+  /// state and the acknowledgment
+  pure def onRecvPacket(chainState: ChainState, packet: Packet): (ChainState, FungibleTokenPacketAcknowledgement) = {
     pure val data = packet.data
-    if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
+    pure val result = if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
       // unescrow tokens to receiver
       pure val escrowAccount = chainState.channelEscrowAddresses.get(packet.destChannel)
       pure val receiverDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
-
+      
       pure val bankResult = chainState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
-
-      pure val newChainState = chainState.with("bank", bankResult.accounts)
-      pure val ack = if (bankResult.success) {
-        { success: true, errorMessage: "" }
-      } else {
-        { success: false, errorMessage: "transfer coins failed" }
-      }
-
-      { chainState: newChainState, acknowledgement: ack }
+      (bankResult, "transfer coins failed")
     } else {
       // mint vouchers to receiver
       pure val newDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
       pure val bankResult = chainState.bank.MintCoins(data.receiver, newDenom, data.amount)
-
-      pure val newChainState = chainState.with("bank", bankResult.accounts)
-      pure val ack = if (bankResult.success) {
-        { success: true, errorMessage: "" }
-      } else {
-        { success: false, errorMessage: "mint coins failed" }
-      }
-
-      { chainState: newChainState, acknowledgement: ack }
+      (bankResult, "mint coins failed")
     }
+    pure val newChainState = chainState.with("bank", result._1.accounts)
+    pure val ack = if (result._1.success) {
+      { success: true, errorMessage: "" }
+    } else {
+      { success: false, errorMessage: result._2 }
+    }
+
+    (newChainState, ack)
   }
 }
 
@@ -135,10 +122,10 @@ module ics20Test {
   /// Map from chain identifiers to their state
   var chainStates: str -> ChainState
 
-  /// Map from chain identifiers to their connections.
-  /// A connection is a map from counterparty chain identifiers to the local chain's channel identifier.
-  /// For example, chain A connects to chain B through channel "channelToB".
-  pure val connections = Map(
+  /// Map from chain identifiers to a map of the chain identifiers it can
+  /// communicate with and the channel to be used to send packets. For example,
+  /// chain A connects to chain B through channel "channelToB".
+  pure val channelTopology = Map(
     "A" -> Map(
       "B" -> "channelToB",
       "C" -> "channelToC"
@@ -154,19 +141,19 @@ module ics20Test {
   )
 
   /// For each chain, a map from channel to their channel counterparties,
-  /// derived from `connections`. For example, in chain A, channel "channelToB"
+  /// derived from `channelTopology`. For example, in chain A, channel "channelToB"
   /// has the counterparty "channelToA".
-  pure val channelCounterparties: str -> Channel -> Channel = connections.keys().mapBy(chain => {
-    pure val connectedChains = connections.get(chain).keys()
+  pure val channelCounterparties: str -> Channel -> Channel = channelTopology.keys().mapBy(chain => {
+    pure val connectedChains = channelTopology.get(chain).keys()
     connectedChains.map(counterpartyChain => {
-      pure val localChannel = connections.get(chain).get(counterpartyChain)
-      pure val counterpartyChannel = connections.get(counterpartyChain).get(chain)
+      pure val localChannel = channelTopology.get(chain).get(counterpartyChain)
+      pure val counterpartyChannel = channelTopology.get(counterpartyChain).get(chain)
       (localChannel, counterpartyChannel)
     }).setToMap()
   })
 
   action init = {
-    chainStates' = connections.keys().mapBy(chain => {
+    chainStates' = channelTopology.keys().mapBy(chain => {
       // All accounts are empty, except for Alice in chain A who has 100 atoms
       bank: if (chain == "A") Map("alice" -> Map(toDenom("atom") -> 100)) else Map(),
       channels: channelCounterparties.get(chain),
@@ -182,7 +169,7 @@ module ics20Test {
     val result = onRecvPacket(chainStates.get(destChain), packet)
     all {
       chainStates' = chainStates
-        .set(destChain, result.chainState)
+        .set(destChain, result._1)
         .set(sourceChain, sourceChainState.with("outPackets", sourceChainState.outPackets.exclude(Set(packet))))
     }
   }
@@ -192,7 +179,7 @@ module ics20Test {
   /// packet from `sourceChain` and other that receives the packet in `destChain`
   run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
     all {
-      val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", connections.get(sourceChain).get(destChain), 0, 0)
+      val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", channelTopology.get(sourceChain).get(destChain), 0, 0)
       chainStates' = chainStates.set(sourceChain, result),
     }).then(
       receivePacket(sourceChain, destChain)

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -186,7 +186,7 @@ module ics20Test {
   }
 
   val packetsToReceiveAsRecords = inFlightPackets.filter(p => p.destPort == "transfer").map(p =>
-    modules.filter(mod => p.destChannel.in(channelsForModule(mod))).map(mod =>
+    modules.filter(mod => p.sourceChannel == getCounterparty(mod, p.destChannel) and p.destChannel.in(channelsForModule(mod))).map(mod =>
       { mod: mod, packet: p }
     )
   ).flatten()
@@ -222,7 +222,6 @@ module ics20Test {
       destChannel: channels.get(sourceChain),
     })
 
-  def print(a) = true
 
   run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
     pure val channels = getChannelsForTransfer(sourceChain, destChain)
@@ -230,15 +229,9 @@ module ics20Test {
     all {
       moduleStates' = moduleStates.set(sourceChain, result.moduleState),
       inFlightPackets' = result.inFlightPackets
-    })
-    .then(all {
-      print(inFlightPackets),
+    }).then(
       receivePacket
-    }
     )
-
-  run tTest = init.then(
-    sendTransfer(toDenom("atom"), "A", "B", "alice", "bob"))
 
   run ABCACBATest = init.then(
     sendTransfer(toDenom("atom"), "A", "B", "alice", "bob")

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -135,9 +135,9 @@ module ics20Test {
   /// Map from chain identifiers to their state
   var chainStates: str -> ChainState
 
-  /// Map from chain identifiers to their connections, which are maps from
-  /// counterparty chain identifiers to channel identifiers. For example, chain
-  /// A connects to chain B through channel "channelToB".
+  /// Map from chain identifiers to their connections.
+  /// A connection is a map from counterparty chain identifiers to the local chain's channel identifier.
+  /// For example, chain A connects to chain B through channel "channelToB".
   pure val connections = Map(
     "A" -> Map(
       "B" -> "channelToB",
@@ -159,9 +159,9 @@ module ics20Test {
   pure val channelCounterparties: str -> Channel -> Channel = connections.keys().mapBy(chain => {
     pure val connectedChains = connections.get(chain).keys()
     connectedChains.map(counterpartyChain => {
-      pure val localIdentifier = connections.get(chain).get(counterpartyChain)
-      pure val counterpartyIdentifier = connections.get(counterpartyChain).get(chain)
-      (localIdentifier, counterpartyIdentifier)
+      pure val localChannel = connections.get(chain).get(counterpartyChain)
+      pure val counterpartyChannel = connections.get(counterpartyChain).get(chain)
+      (localChannel, counterpartyChannel)
     }).setToMap()
   })
 

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -51,7 +51,7 @@ module ics20 {
     val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
       // burn vouchers
       (moduleState.bank).BurnCoins(sender, denomination, amount)
-    } else { 
+    } else {
       // escrow tokens
       val escrowAccount = moduleState.channelEscrowAddresses.get(sourceChannel)
       moduleState.bank.TransferCoins(sender, escrowAccount, denomination, amount)
@@ -67,8 +67,13 @@ module ics20 {
     }
   }
 
+  type ReceiveTokenPacketResult = {
+    moduleState: ModuleState,
+    acknowledgement: FungibleTokenPacketAcknowledgement
+  }
+
   pure def onRecvPacket(moduleState: ModuleState,
-                        packet: Packet): FungibleTokenPacketAcknowledgement = {
+                        packet: Packet): ReceiveTokenPacketResult = {
     val data = packet.data
     if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
       // unescrow tokens to receiver
@@ -77,11 +82,14 @@ module ics20 {
 
       val bankResult = moduleState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
 
-      if (bankResult.success) {
+      val newModuleState = moduleState.with("bank", bankResult.accounts)
+      val ack = if (bankResult.success) {
         { success: true, errorMessage: "" }
       } else {
-        { success: true, errorMessage: "transfer coins failed" }
+        { success: false, errorMessage: "transfer coins failed" }
       }
+
+      { moduleState: newModuleState, acknowledgement: ack }
     } else {
       // mint vouchers to receiver
       val prefix = [packet.destPort, packet.destChannel]
@@ -89,11 +97,14 @@ module ics20 {
 
       val bankResult = moduleState.bank.MintCoins(data.receiver, newDenom, data.amount)
 
-      if (bankResult.success) {
+      val newModuleState = moduleState.with("bank", bankResult.accounts)
+      val ack = if (bankResult.success) {
         { success: true, errorMessage: "" }
       } else {
         { success: false, errorMessage: "mint coins failed" }
       }
+
+      { moduleState: newModuleState, acknowledgement: ack }
     }
   }
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -2,8 +2,8 @@
 
 module ics20 {
   import base.* from "./base"
-  import denomTrace.* from "./denomTrace"
   import bank.* from "./bank"
+  import denomTrace.* from "./denomTrace"
 
   /* ***************************************************************************
    * TYPES
@@ -41,11 +41,9 @@ module ics20 {
     channelEscrowAddresses: Channel -> Address,
   }
 
-  type SendFungibleTokensResult = {
-    moduleState: ModuleState,
-    inFlightPackets: Set[Packet]
-  }
-
+  /// From a module `M` and one of its channels `C`, the counterparty for `C` is
+  /// the channel name for `C` in the chain it connects to. Handling channels
+  /// should be extracted to a new spec.
   pure def getCounterparty(moduleName: str, sourceChannel: Channel): Channel = {
     pure val channels = Map(
       "A" -> "channelToA",
@@ -54,6 +52,13 @@ module ics20 {
     )
 
     channels.get(moduleName)
+  }
+
+  /// `sendFugibleTokens` returns the updated module state and the updated set
+  /// of in flight packets. This is the type for its returned value.
+  type SendFungibleTokensResult = {
+    moduleState: ModuleState,
+    inFlightPackets: Set[Packet]
   }
 
   pure def sendFungibleTokens(moduleName: str, moduleState: ModuleState, packets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
@@ -90,13 +95,15 @@ module ics20 {
     }
   }
 
+  /// `onRecvPacket` should return an acknowledgment, but it also has to update
+  /// the module state, so the return type is the updated value for the module
+  /// state and the acknowledgment
   type ReceiveTokenPacketResult = {
     moduleState: ModuleState,
     acknowledgement: FungibleTokenPacketAcknowledgement
   }
 
-  pure def onRecvPacket(moduleState: ModuleState,
-                        packet: Packet): ReceiveTokenPacketResult = {
+  pure def onRecvPacket(moduleState: ModuleState, packet: Packet): ReceiveTokenPacketResult = {
     val data = packet.data
     if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
       // unescrow tokens to receiver
@@ -137,11 +144,15 @@ module ics20Test {
   import ics20.*
 
   val modules = Set("A", "B", "C")
+
+  /// Set o addresses for random simulation
   val addresses = Set("alice", "bob", "charlie")
 
   var moduleStates: str -> ModuleState
   var inFlightPackets: Set[Packet]
 
+  /// All channels available in a module. Should be extracted to a channels
+  /// quint module.
   pure def channelsForModule(mod: str): Set[Channel] = {
     pure val channels = Map(
       "A" -> Set("channelToB", "channelToC"),
@@ -152,6 +163,22 @@ module ics20Test {
     channels.get(mod)
   }
 
+  /// A channel for a transfer from one module to another. Should be extracted
+  /// to a channels quint module.
+  pure def getChannelsForTransfer(sourceModule: str, destModule: str): { sourceChannel: str, destChannel: str } =
+    pure val channels = Map(
+      "A" -> "channelToA",
+      "B" -> "channelToB",
+      "C" -> "channelToC"
+    )
+    ({
+      // If this is a transfer from A -> B, then the source channel is `channelToB`
+      sourceChannel: channels.get(destModule),
+      // If this is a transfer from A -> B, then the dest channel is `channelToA`
+      destChannel: channels.get(sourceModule),
+    })
+
+
   action init = all {
     moduleStates' = modules.mapBy(_ => {
       bank: Map(),
@@ -160,6 +187,11 @@ module ics20Test {
     inFlightPackets' = Set()
   }
 
+  /// A set of all possible combinations of module, account and denom with
+  /// ammount greater than 0, to be used to send a valid transfer. If we just
+  /// pick these values at random, it is most likely that the bank module will
+  /// refuse the transfer for lack of funds, and we won't be able to find a
+  // valid example in the random simulator.
   val bankEntriesAsRecords = modules.map(m =>
     moduleStates.get(m).bank.keys().map(acc =>
       moduleStates.get(m).bank.get(acc).keys().map(denom =>
@@ -169,10 +201,8 @@ module ics20Test {
     ).flatten()
   ).flatten().filter(r => r.amount > 0)
 
+  /// Sends random valid transfer. Used for simulation.
   action sendSomeTransfer = {
-    // Find some existing ammount, sender and denom
-    // pure val modulesWithTokens = modules.filter(m =>
-    // moduleStates.get(mod).bank.keys().exists(k => ))
     nondet bankEntry = bankEntriesAsRecords.oneOf()
     pure val sourcePort = "transfer"
     nondet receiver = addresses.oneOf()
@@ -185,12 +215,18 @@ module ics20Test {
     }
   }
 
+  /// A set of all possible combinations of module and packet such that the
+  /// packet is being sent to that module. This has to check for both
+  /// `sourceChannel` and `destChannel` of the packet since channel names are
+  /// not globally unique.
   val packetsToReceiveAsRecords = inFlightPackets.filter(p => p.destPort == "transfer").map(p =>
     modules.filter(mod => p.sourceChannel == getCounterparty(mod, p.destChannel) and p.destChannel.in(channelsForModule(mod))).map(mod =>
       { mod: mod, packet: p }
     )
   ).flatten()
 
+  /// Receives some packet from `inFlightPacket` in its proper module. This is
+  /// used for both simulation and tests.
   action receivePacket = {
     nondet packetEntry = packetsToReceiveAsRecords.oneOf()
     val mod = packetEntry.mod
@@ -209,30 +245,20 @@ module ics20Test {
     }
   }
 
-  pure def getChannelsForTransfer(sourceChain: str, destChain: str): { sourceChannel: str, destChannel: str } =
-    pure val channels = Map(
-      "A" -> "channelToA",
-      "B" -> "channelToB",
-      "C" -> "channelToC"
-    )
-    ({
-      // If this is a transfer from A -> B, then the source channel is `channelToB`
-      sourceChannel: channels.get(destChain),
-      // If this is a transfer from A -> B, then the dest channel is `channelToA`
-      destChannel: channels.get(sourceChain),
-    })
-
-
-  run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
-    pure val channels = getChannelsForTransfer(sourceChain, destChain)
-    val result = sendFungibleTokens(sourceChain, moduleStates.get(sourceChain), inFlightPackets, denom, 1, sender, receiver, "transfer", channels.sourceChannel, 0, 0)
+  /// Sends 1 `denom` token from `sender` in `sourceModule` to `receiver` in
+  /// `destModule`. This is a composition of two actions: one that sends the
+  /// packet from `sourceModule` and other that receives the packet in `destModule`
+  run sendTransfer(denom: DenomTrace, sourceModule: str, destModule: str, sender: Address, receiver: Address): bool = (
+    pure val channels = getChannelsForTransfer(sourceModule, destModule)
+    val result = sendFungibleTokens(sourceModule, moduleStates.get(sourceModule), inFlightPackets, denom, 1, sender, receiver, "transfer", channels.sourceChannel, 0, 0)
     all {
-      moduleStates' = moduleStates.set(sourceChain, result.moduleState),
+      moduleStates' = moduleStates.set(sourceModule, result.moduleState),
       inFlightPackets' = result.inFlightPackets
     }).then(
       receivePacket
     )
 
+  // These steps of transfer occur: A -> B -> C -> A -> C -> B -> A
   run ABCACBATest = init.then(
     sendTransfer(toDenom("atom"), "A", "B", "alice", "bob")
   ).then(

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -15,7 +15,6 @@ module ics20 {
    * **************************************************************************/
 
   // Fundamental types
-  type Channel = str
   type Height = int
 
   // IBC packet types
@@ -40,33 +39,28 @@ module ics20 {
     destChannel: Channel,
   }
 
-  // State of the IBC module
-  type ModuleState = {
+  // State of the IBC module in a chain
+  type ChainState = {
     bank: Accounts,
+    channels: Channels,
+    outPackets: Set[Packet],
     channelEscrowAddresses: Channel -> Address,
   }
 
-  /// From a module `M` and one of its channels `C`, the counterparty for `C` is
-  /// the channel name for `C` in the chain it connects to. Handling channels
-  /// should be extracted to a new spec.
-  pure def getCounterparty(moduleName: str, sourceChannel: Channel): Channel = {
-    pure val channels = Map(
-      "A" -> "channelToA",
-      "B" -> "channelToB",
-      "C" -> "channelToC"
-    )
-
-    channels.get(moduleName)
+  /// The counterparty for a channel `C` in a chain is the channel identifier of
+  /// the channel `C` connects to, in the other chain.
+  pure def getCounterparty(chainState: ChainState, sourceChannel: Channel): Channel = {
+    chainState.channels.get(sourceChannel)
   }
 
-  /// `sendFugibleTokens` returns the updated module state and the updated set
+  /// `sendFugibleTokens` returns the updated chain state and the updated set
   /// of in flight packets. This is the type for its returned value.
   type SendFungibleTokensResult = {
-    moduleState: ModuleState,
+    chainState: ChainState,
     inFlightPackets: Set[Packet]
   }
 
-  pure def sendFungibleTokens(moduleName: str, moduleState: ModuleState, packets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
+  pure def sendFungibleTokens(chainState: ChainState, packets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
                               denomination: DenomTrace, amount: UINT256,
                               sender: Address, receiver: Address,
                               sourcePort: str, sourceChannel: Channel,
@@ -74,11 +68,11 @@ module ics20 {
                               timeoutTimestamp: uint64): SendFungibleTokensResult = {
     val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
       // burn vouchers
-      (moduleState.bank).BurnCoins(sender, denomination, amount)
+      (chainState.bank).BurnCoins(sender, denomination, amount)
     } else {
       // escrow tokens
-      val escrowAccount = moduleState.channelEscrowAddresses.get(sourceChannel)
-      moduleState.bank.TransferCoins(sender, escrowAccount, denomination, amount)
+      val escrowAccount = chainState.channelEscrowAddresses.get(sourceChannel)
+      chainState.bank.TransferCoins(sender, escrowAccount, denomination, amount)
     }
 
     if (bankResult.success) {
@@ -90,56 +84,56 @@ module ics20 {
         sourcePort: sourcePort,
         sourceChannel: sourceChannel,
         destPort: "transfer",
-        destChannel: getCounterparty(moduleName, sourceChannel)
+        destChannel: getCounterparty(chainState, sourceChannel)
       }
 
-      { moduleState: moduleState.with("bank", bankResult.accounts),
+      { chainState: chainState.with("bank", bankResult.accounts),
         inFlightPackets: packets.union(Set(packet)) }
     } else {
-      { moduleState: moduleState, inFlightPackets: packets }
+      { chainState: chainState, inFlightPackets: packets }
     }
   }
 
   /// `onRecvPacket` should return an acknowledgment, but it also has to update
-  /// the module state, so the return type is the updated value for the module
+  /// the chain state, so the return type is the updated value for the chain
   /// state and the acknowledgment
   type ReceiveTokenPacketResult = {
-    moduleState: ModuleState,
+    chainState: ChainState,
     acknowledgement: FungibleTokenPacketAcknowledgement
   }
 
-  pure def onRecvPacket(moduleState: ModuleState, packet: Packet): ReceiveTokenPacketResult = {
+  pure def onRecvPacket(chainState: ChainState, packet: Packet): ReceiveTokenPacketResult = {
     val data = packet.data
     if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
       // unescrow tokens to receiver
-      val escrowAccount = moduleState.channelEscrowAddresses.get(packet.destChannel)
+      val escrowAccount = chainState.channelEscrowAddresses.get(packet.destChannel)
       val receiverDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
-      val bankResult = moduleState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
+      val bankResult = chainState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
 
-      val newModuleState = moduleState.with("bank", bankResult.accounts)
+      val newChainState = chainState.with("bank", bankResult.accounts)
       val ack = if (bankResult.success) {
         { success: true, errorMessage: "" }
       } else {
         { success: false, errorMessage: "transfer coins failed" }
       }
 
-      { moduleState: newModuleState, acknowledgement: ack }
+      { chainState: newChainState, acknowledgement: ack }
     } else {
       // mint vouchers to receiver
       val prefix = [packet.destPort, packet.destChannel]
       val newDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
-      val bankResult = moduleState.bank.MintCoins(data.receiver, newDenom, data.amount)
+      val bankResult = chainState.bank.MintCoins(data.receiver, newDenom, data.amount)
 
-      val newModuleState = moduleState.with("bank", bankResult.accounts)
+      val newChainState = chainState.with("bank", bankResult.accounts)
       val ack = if (bankResult.success) {
         { success: true, errorMessage: "" }
       } else {
         { success: false, errorMessage: "mint coins failed" }
       }
 
-      { moduleState: newModuleState, acknowledgement: ack }
+      { chainState: newChainState, acknowledgement: ack }
     }
   }
 }
@@ -150,10 +144,11 @@ module ics20Test {
 
   val modules = Set("A", "B", "C")
 
-  /// Set o addresses for random simulation
+  /// Set of addresses for random simulation
   val addresses = Set("alice", "bob", "charlie")
 
-  var moduleStates: str -> ModuleState
+  /// Map from chain identifiers to their state
+  var chainStates: str -> ChainState
   var inFlightPackets: Set[Packet]
 
   /// All channels available in a module. Should be extracted to a channels
@@ -168,9 +163,8 @@ module ics20Test {
     channels.get(mod)
   }
 
-  /// A channel for a transfer from one module to another. Should be extracted
-  /// to a channels quint module.
-  pure def getChannelsForTransfer(sourceModule: str, destModule: str): { sourceChannel: str, destChannel: str } =
+  /// A channel for a transfer from one chain to another
+  pure def getChannelsForTransfer(sourceChain: str, destChain: str): { sourceChannel: str, destChannel: str } =
     pure val channels = Map(
       "A" -> "channelToA",
       "B" -> "channelToB",
@@ -178,89 +172,65 @@ module ics20Test {
     )
     ({
       // If this is a transfer from A -> B, then the source channel is `channelToB`
-      sourceChannel: channels.get(destModule),
+      sourceChannel: channels.get(destChain),
       // If this is a transfer from A -> B, then the dest channel is `channelToA`
-      destChannel: channels.get(sourceModule),
+      destChannel: channels.get(sourceChain),
     })
 
 
   action init = all {
-    moduleStates' = modules.mapBy(_ => {
-      bank: Map(),
-      channelEscrowAddresses: Set("channelToA", "channelToB", "channelToC").mapBy(_ => "escrow_account"),
-    }).setBy("A", st => st.with("bank", Map("alice" -> Map(toDenom("atom") -> 100)))),
+    chainStates' = Map(
+      "A" -> {
+        bank: Map("alice" -> Map(toDenom("atom") -> 100)),
+        channels: Map(
+          "channelToB" -> "channelToA",
+          "channelToC" -> "channelToA"
+        ),
+        channelEscrowAddresses: Set("channelToB", "channelToC").mapBy(_ => "escrow_account"),
+        outPackets: Set()
+      },
+      "B" -> {
+        bank: Map(),
+        channels: Map(
+          "channelToA" -> "channelToB",
+          "channelToC" -> "channelToB"
+        ),
+        channelEscrowAddresses: Set("channelToA", "channelToC").mapBy(_ => "escrow_account"),
+        outPackets: Set()
+      },
+      "C" -> {
+        bank: Map(),
+        channels: Map(
+          "channelToA" -> "channelToC",
+          "channelToB" -> "channelToC"
+        ),
+        channelEscrowAddresses: Set("channelToA", "channelToB").mapBy(_ => "escrow_account"),
+        outPackets: Set()
+      }
+    ),
     inFlightPackets' = Set()
   }
 
-  /// A set of all possible combinations of module, account and denom with
-  /// ammount greater than 0, to be used to send a valid transfer. If we just
-  /// pick these values at random, it is most likely that the bank module will
-  /// refuse the transfer for lack of funds, and we won't be able to find a
-  // valid example in the random simulator.
-  val bankEntriesAsRecords = modules.map(m =>
-    moduleStates.get(m).bank.keys().map(acc =>
-      moduleStates.get(m).bank.get(acc).keys().map(denom =>
-        val amount = moduleStates.get(m).bank.get(acc).get(denom)
-        { mod: m, account: acc, denom: denom, amount: amount }
-      )
-    ).flatten()
-  ).flatten().filter(r => r.amount > 0)
-
-  /// Sends random valid transfer. Used for simulation.
-  action sendSomeTransfer = {
-    nondet bankEntry = bankEntriesAsRecords.oneOf()
-    pure val sourcePort = "transfer"
-    nondet receiver = addresses.oneOf()
-    nondet sourceChannel = channelsForModule(bankEntry.mod).oneOf()
-    val result = sendFungibleTokens(bankEntry.mod, moduleStates.get(bankEntry.mod), inFlightPackets, bankEntry.denom, bankEntry.amount,
-                                    bankEntry.account, receiver, sourcePort, sourceChannel, 0, 0)
+  /// Receives a packet in a specific chain
+  action receivePacket(chain: str, packet: Packet): bool = {
+    val result = onRecvPacket(chainStates.get(chain), packet)
     all {
-      moduleStates' = moduleStates.set(bankEntry.mod, result.moduleState),
-      inFlightPackets' = result.inFlightPackets
-    }
-  }
-
-  /// A set of all possible combinations of module and packet such that the
-  /// packet is being sent to that module. This has to check for both
-  /// `sourceChannel` and `destChannel` of the packet since channel names are
-  /// not globally unique.
-  val packetsToReceiveAsRecords = inFlightPackets.filter(p => p.destPort == "transfer").map(p =>
-    modules.filter(mod => p.sourceChannel == getCounterparty(mod, p.destChannel) and p.destChannel.in(channelsForModule(mod))).map(mod =>
-      { mod: mod, packet: p }
-    )
-  ).flatten()
-
-  /// Receives some packet from `inFlightPacket` in its proper module. This is
-  /// used for both simulation and tests.
-  action receivePacket = {
-    nondet packetEntry = packetsToReceiveAsRecords.oneOf()
-    val mod = packetEntry.mod
-    val packet = packetEntry.packet
-    val result = onRecvPacket(moduleStates.get(mod), packet)
-    all {
-      moduleStates' = moduleStates.set(mod, result.moduleState),
+      chainStates' = chainStates.set(chain, result.chainState),
       inFlightPackets' = inFlightPackets.exclude(Set(packet))
     }
   }
 
-  action step = {
-    any {
-      sendSomeTransfer,
-      receivePacket,
-    }
-  }
-
-  /// Sends 1 `denom` token from `sender` in `sourceModule` to `receiver` in
-  /// `destModule`. This is a composition of two actions: one that sends the
-  /// packet from `sourceModule` and other that receives the packet in `destModule`
-  run sendTransfer(denom: DenomTrace, sourceModule: str, destModule: str, sender: Address, receiver: Address): bool = (
-    pure val channels = getChannelsForTransfer(sourceModule, destModule)
-    val result = sendFungibleTokens(sourceModule, moduleStates.get(sourceModule), inFlightPackets, denom, 1, sender, receiver, "transfer", channels.sourceChannel, 0, 0)
+  /// Sends 1 `denom` token from `sender` in `sourceChain` to `receiver` in
+  /// `destChain`. This is a composition of two actions: one that sends the
+  /// packet from `sourceChain` and other that receives the packet in `destChain`
+  run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
+    val result = sendFungibleTokens(chainStates.get(sourceChain), inFlightPackets, denom, 1, sender, receiver, "transfer", getChannelsForTransfer(sourceChain, destChain).sourceChannel, 0, 0)
     all {
-      moduleStates' = moduleStates.set(sourceModule, result.moduleState),
+      chainStates' = chainStates.set(sourceChain, result.chainState),
       inFlightPackets' = result.inFlightPackets
     }).then(
-      receivePacket
+      nondet packet = inFlightPackets.oneOf()
+      receivePacket(destChain, packet)
     )
 
   // These steps of transfer occur: A -> B -> C -> A -> C -> B -> A
@@ -298,10 +268,10 @@ module ics20Test {
 
     sendTransfer(denom, "B", "A", "charlie", "darwin")
   ).then(all {
-      assert(moduleStates.get("A").bank.get("alice").get(toDenom("atom")) == 99),
-      assert(moduleStates.get("A").bank.get("darwin").get(toDenom("atom")) == 1),
+      assert(chainStates.get("A").bank.get("alice").get(toDenom("atom")) == 99),
+      assert(chainStates.get("A").bank.get("darwin").get(toDenom("atom")) == 1),
 
-      moduleStates' = moduleStates,
+      chainStates' = chainStates,
       inFlightPackets' = inFlightPackets,
     }
   )

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -1,0 +1,98 @@
+// -*- mode: Bluespec; -*-
+
+module ics20 {
+  import denomTrace.*
+
+  /* ***************************************************************************
+   * TYPES
+   * **************************************************************************/
+
+  // Fundamental types
+  type Channel = str
+  type Address = str
+  type Height = int
+
+  // IBC packet types
+  type FungibleTokenPacketAcknowledgement = {
+    success: bool,
+    errorMessage: str
+  }
+
+  type FungibleTokenPacket = {
+    denom: DenomTrace,
+    amount: uint256,
+    sender: Address,
+    receiver: Address,
+    memo: str
+  }
+
+  type Packet = {
+    data: FungibleTokenPacket,
+    sourcePort: str,
+    sourceChannel: Channel,
+    destPort: str,
+    destChannel: Channel,
+  }
+
+  // State of the IBC module
+  type ModuleState = {
+    channelEscrowAddresses: Channel -> Address,
+    inFlightPackets: Set[FungibleTokenPacket]
+  }
+
+  pure def sendFungibleTokens(moduleState: ModuleState,
+                              denomination: DenomTrace, amount: uint256,
+                              sender: Address, receiver: Address,
+                              sourcePort: str, sourceChannel: Channel,
+                              timeoutHeight: Height,
+                              timeoutTimestamp: uint64): ModuleState = {
+    val isSource = senderIsSource(sourcePort, sourceChannel, ModuleState)
+    val bankResult = if (isSource) {
+      // escrow tokens
+      val escrowAccount = moduleState.channelEscrowAddresses.get(sourceChannel)
+      bank.TransferCoins(sender, escrowAccount, denomination, amount)
+    } else {
+      // burn vouchers
+      bank.BurnCoins(sender, denomination, amount)
+    }
+
+    if (bankResult.success) {
+      val packet = { denom: denomination, amount: amount, sender: sender, receiver: receiver }
+
+      // handler.sendPacket
+      moduleState.with("inFlightPackets", moduleState.inFlightPackets.union(Set(packet)))
+    } else {
+      moduleState
+    }
+  }
+
+  pure def onRecvPacket(moduleState: ModuleState,
+                        packet: Packet): FungibleTokenPacketAcknowledgement = {
+    val data = packet.data
+    if (receiverIsSource(packet.sourcePort, packet.sourceChannel, data.denom)) {
+      // unescrow tokens to receiver
+      val escrowAccount = moduleState.channelEscrowAddresses.get(packet.destChannel)
+      val receiverDenom = data.denom.tail()
+
+      val bankResult = bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
+
+      if (bankResult.success) {
+        { success: true, errorMessage: "" }
+      } else {
+        { success: true, errorMessage: "transfer coins failed" }
+      }
+    } else {
+      // mint vouchers to receiver
+      val prefix = [packet.destPort, packet.destChannel]
+      val prefixedDenom = prefix.append(data.denom)
+
+      val bankResult = bank.MintCoins(data.receiver, prefixedDenomination, data.amount)
+
+      if (bankResult.success) {
+        { success: true, errorMessage: "" }
+      } else {
+        { success: false, errorMessage: "mint coins failed" }
+      }
+    }
+  }
+}

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -53,19 +53,9 @@ module ics20 {
     chainState.channels.get(sourceChannel)
   }
 
-  /// `sendFugibleTokens` returns the updated chain state and the updated set
-  /// of in flight packets. This is the type for its returned value.
-  type SendFungibleTokensResult = {
-    chainState: ChainState,
-    inFlightPackets: Set[Packet]
-  }
-
-  pure def sendFungibleTokens(chainState: ChainState, packets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
-                              denomination: DenomTrace, amount: UINT256,
-                              sender: Address, receiver: Address,
-                              sourcePort: str, sourceChannel: Channel,
-                              timeoutHeight: Height,
-                              timeoutTimestamp: uint64): SendFungibleTokensResult = {
+  pure def sendFungibleTokens(chainState: ChainState, denomination: DenomTrace, amount: UINT256,
+                              sender: Address, receiver: Address, sourcePort: str, sourceChannel: Channel,
+                              timeoutHeight: Height, timeoutTimestamp: uint64): ChainState = {
     val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
       // burn vouchers
       (chainState.bank).BurnCoins(sender, denomination, amount)
@@ -87,10 +77,11 @@ module ics20 {
         destChannel: getCounterparty(chainState, sourceChannel)
       }
 
-      { chainState: chainState.with("bank", bankResult.accounts),
-        inFlightPackets: packets.union(Set(packet)) }
+      chainState
+        .with("bank", bankResult.accounts)
+        .with("outPackets", chainState.outPackets.union(Set(packet)))
     } else {
-      { chainState: chainState, inFlightPackets: packets }
+      chainState
     }
   }
 
@@ -149,7 +140,6 @@ module ics20Test {
 
   /// Map from chain identifiers to their state
   var chainStates: str -> ChainState
-  var inFlightPackets: Set[Packet]
 
   /// All channels available in a module. Should be extracted to a channels
   /// quint module.
@@ -178,7 +168,7 @@ module ics20Test {
     })
 
 
-  action init = all {
+  action init = {
     chainStates' = Map(
       "A" -> {
         bank: Map("alice" -> Map(toDenom("atom") -> 100)),
@@ -207,16 +197,18 @@ module ics20Test {
         channelEscrowAddresses: Set("channelToA", "channelToB").mapBy(_ => "escrow_account"),
         outPackets: Set()
       }
-    ),
-    inFlightPackets' = Set()
+    )
   }
 
-  /// Receives a packet in a specific chain
-  action receivePacket(chain: str, packet: Packet): bool = {
-    val result = onRecvPacket(chainStates.get(chain), packet)
+  /// Receives a packet sent from `sourceChain` to `destChain`
+  action receivePacket(sourceChain: str, destChain: str): bool = {
+    val sourceChainState = chainStates.get(sourceChain)
+    nondet packet = sourceChainState.outPackets.oneOf()
+    val result = onRecvPacket(chainStates.get(destChain), packet)
     all {
-      chainStates' = chainStates.set(chain, result.chainState),
-      inFlightPackets' = inFlightPackets.exclude(Set(packet))
+      chainStates' = chainStates
+        .set(destChain, result.chainState)
+        .set(sourceChain, sourceChainState.with("outPackets", sourceChainState.outPackets.exclude(Set(packet))))
     }
   }
 
@@ -224,13 +216,11 @@ module ics20Test {
   /// `destChain`. This is a composition of two actions: one that sends the
   /// packet from `sourceChain` and other that receives the packet in `destChain`
   run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
-    val result = sendFungibleTokens(chainStates.get(sourceChain), inFlightPackets, denom, 1, sender, receiver, "transfer", getChannelsForTransfer(sourceChain, destChain).sourceChannel, 0, 0)
+    val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", getChannelsForTransfer(sourceChain, destChain).sourceChannel, 0, 0)
     all {
-      chainStates' = chainStates.set(sourceChain, result.chainState),
-      inFlightPackets' = result.inFlightPackets
+      chainStates' = chainStates.set(sourceChain, result),
     }).then(
-      nondet packet = inFlightPackets.oneOf()
-      receivePacket(destChain, packet)
+      receivePacket(sourceChain, destChain)
     )
 
   // These steps of transfer occur: A -> B -> C -> A -> C -> B -> A
@@ -272,7 +262,6 @@ module ics20Test {
       assert(chainStates.get("A").bank.get("darwin").get(toDenom("atom")) == 1),
 
       chainStates' = chainStates,
-      inFlightPackets' = inFlightPackets,
     }
   )
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -133,71 +133,40 @@ module ics20Test {
   import base.* from "./base"
   import ics20.*
 
-  val modules = Set("A", "B", "C")
-
-  /// Set of addresses for random simulation
-  val addresses = Set("alice", "bob", "charlie")
-
   /// Map from chain identifiers to their state
   var chainStates: str -> ChainState
 
-  /// All channels available in a module. Should be extracted to a channels
-  /// quint module.
-  pure def channelsForModule(mod: str): Set[Channel] = {
-    pure val channels = Map(
-      "A" -> Set("channelToB", "channelToC"),
-      "B" -> Set("channelToA", "channelToC"),
-      "C" -> Set("channelToA", "channelToB")
-    )
-
-    channels.get(mod)
-  }
-
-  /// A channel for a transfer from one chain to another
-  pure def getChannelsForTransfer(sourceChain: str, destChain: str): { sourceChannel: str, destChannel: str } =
-    pure val channels = Map(
-      "A" -> "channelToA",
+  pure val connections = Map(
+    "A" -> Map(
       "B" -> "channelToB",
       "C" -> "channelToC"
+    ),
+    "B" -> Map(
+      "A" -> "channelToA",
+      "C" -> "channelToC"
+    ),
+    "C" -> Map(
+      "A" -> "channelToA",
+      "B" -> "channelToB"
     )
-    ({
-      // If this is a transfer from A -> B, then the source channel is `channelToB`
-      sourceChannel: channels.get(destChain),
-      // If this is a transfer from A -> B, then the dest channel is `channelToA`
-      destChannel: channels.get(sourceChain),
-    })
+  )
 
+  pure val channelCounterparties = connections.keys().mapBy(chain => {
+    val connectedChains = connections.get(chain).keys()
+    connectedChains.map(counterpartyChain => {
+      val localIdentifier = connections.get(chain).get(counterpartyChain)
+      val counterpartyIdentifier = connections.get(counterpartyChain).get(chain)
+      (localIdentifier, counterpartyIdentifier)
+    }).setToMap()
+  })
 
   action init = {
-    chainStates' = Map(
-      "A" -> {
-        bank: Map("alice" -> Map(toDenom("atom") -> 100)),
-        channels: Map(
-          "channelToB" -> "channelToA",
-          "channelToC" -> "channelToA"
-        ),
-        channelEscrowAddresses: Set("channelToB", "channelToC").mapBy(_ => "escrow_account"),
-        outPackets: Set()
-      },
-      "B" -> {
-        bank: Map(),
-        channels: Map(
-          "channelToA" -> "channelToB",
-          "channelToC" -> "channelToB"
-        ),
-        channelEscrowAddresses: Set("channelToA", "channelToC").mapBy(_ => "escrow_account"),
-        outPackets: Set()
-      },
-      "C" -> {
-        bank: Map(),
-        channels: Map(
-          "channelToA" -> "channelToC",
-          "channelToB" -> "channelToC"
-        ),
-        channelEscrowAddresses: Set("channelToA", "channelToB").mapBy(_ => "escrow_account"),
-        outPackets: Set()
-      }
-    )
+    chainStates' = connections.keys().mapBy(chain => {
+      bank: if (chain == "A") Map("alice" -> Map(toDenom("atom") -> 100)) else Map(),
+      channels: channelCounterparties.get(chain),
+      channelEscrowAddresses: channelCounterparties.get(chain).keys().mapBy(_ => "escrow_account"),
+      outPackets: Set()
+    })
   }
 
   /// Receives a packet sent from `sourceChain` to `destChain`
@@ -216,7 +185,7 @@ module ics20Test {
   /// `destChain`. This is a composition of two actions: one that sends the
   /// packet from `sourceChain` and other that receives the packet in `destChain`
   run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
-    val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", getChannelsForTransfer(sourceChain, destChain).sourceChannel, 0, 0)
+    val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", connections.get(sourceChain).get(destChain), 0, 0)
     all {
       chainStates' = chainStates.set(sourceChain, result),
     }).then(

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -19,7 +19,7 @@ module ics20 {
     errorMessage: str
   }
 
-  type FungibleTokenPacket = {
+  type FungibleTokenData = {
     denom: DenomTrace,
     amount: UINT256,
     sender: Address,
@@ -28,7 +28,7 @@ module ics20 {
   }
 
   type Packet = {
-    data: FungibleTokenPacket,
+    data: FungibleTokenData,
     sourcePort: str,
     sourceChannel: Channel,
     destPort: str,
@@ -39,15 +39,19 @@ module ics20 {
   type ModuleState = {
     bank: Accounts,
     channelEscrowAddresses: Channel -> Address,
-    inFlightPackets: Set[FungibleTokenPacket]
   }
 
-  pure def sendFungibleTokens(moduleState: ModuleState,
+  type SendFungibleTokensResult = {
+    moduleState: ModuleState,
+    inFlightPackets: Set[Packet]
+  }
+
+  pure def sendFungibleTokens(moduleState: ModuleState, inFlightPackets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
                               denomination: DenomTrace, amount: UINT256,
                               sender: Address, receiver: Address,
                               sourcePort: str, sourceChannel: Channel,
                               timeoutHeight: Height,
-                              timeoutTimestamp: uint64): ModuleState = {
+                              timeoutTimestamp: uint64): SendFungibleTokensResult = {
     val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
       // burn vouchers
       (moduleState.bank).BurnCoins(sender, denomination, amount)
@@ -58,12 +62,21 @@ module ics20 {
     }
 
     if (bankResult.success) {
-      val packet = { denom: denomination, amount: amount, sender: sender, receiver: receiver, memo: "" }
+      val data = { denom: denomination, amount: amount, sender: sender, receiver: receiver, memo: "" }
 
       // handler.sendPacket
-      moduleState.with("inFlightPackets", moduleState.inFlightPackets.union(Set(packet)))
+      val packet = {
+        data: data,
+        sourcePort: sourcePort,
+        sourceChannel: sourceChannel,
+        destPort: "transfer",
+        destChannel: "A1"
+      }
+
+      { moduleState: moduleState.with("bank", bankResult.accounts),
+        inFlightPackets: inFlightPackets.union(Set(packet)) }
     } else {
-      moduleState
+      { moduleState: moduleState, inFlightPackets: inFlightPackets }
     }
   }
 
@@ -105,6 +118,57 @@ module ics20 {
       }
 
       { moduleState: newModuleState, acknowledgement: ack }
+    }
+  }
+}
+
+module ics20Test {
+  import base.* from "./base"
+  import ics20.*
+
+  val modules = Set("A", "B", "C")
+  val addresses = Set("alice", "bob", "charlie")
+
+  var moduleStates: str -> ModuleState
+  var inFlightPackets: Set[Packet]
+
+  pure def channelsForModule(mod: str): Set[Channel] = {
+    Set("A1", "A2", "A3")
+  }
+
+  action init = all {
+    moduleStates' = modules.mapBy(_ => {
+      bank: addresses.mapBy(_ => Map()).set("alice", Map(toDenom("denomA") -> 100, toDenom("denomB") -> 100)),
+      channelEscrowAddresses: Map(),
+    }),
+    inFlightPackets' = Set()
+  }
+
+  action sendSomeTransfer(mod) = {
+    nondet amount = Int.oneOf()
+    nondet sender = addresses.oneOf()
+    // Some denom that the sender has
+    nondet denom = moduleStates.get(mod).bank.get(sender).keys().oneOf()
+    nondet receiver = addresses.oneOf()
+    pure val sourcePort = "transfer"
+    nondet sourceChannel = channelsForModule(mod).oneOf()
+    val result = sendFungibleTokens(moduleStates.get(mod), inFlightPackets, denom, amount, sender, receiver, sourcePort, sourceChannel, 0, 0)
+    all {
+      moduleStates' = moduleStates.set(mod, result.moduleState),
+      inFlightPackets' = result.inFlightPackets
+    }
+  }
+
+  action step = {
+    nondet mod = modules.oneOf()
+    any {
+      nondet packet = inFlightPackets.filter(p => p.destPort == "transfer" and p.destChannel.in(channelsForModule(mod))).oneOf()
+      val result = onRecvPacket(moduleStates.get(mod), packet)
+      all {
+        moduleStates' = moduleStates.set(mod, result.moduleState),
+        inFlightPackets' = inFlightPackets.exclude(Set(packet))
+      },
+      sendSomeTransfer(mod),
     }
   }
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -47,6 +47,14 @@ module ics20 {
     channelEscrowAddresses: Channel -> Address,
   }
 
+  /// `onRecvPacket` should return an acknowledgment, but it also has to update
+  /// the chain state, so the return type is the updated value for the chain
+  /// state and the acknowledgment
+  type ReceiveTokenPacketResult = {
+    chainState: ChainState,
+    acknowledgement: FungibleTokenPacketAcknowledgement
+  }
+
   /// The counterparty for a channel `C` in a chain is the channel identifier of
   /// the channel `C` connects to, in the other chain.
   pure def getCounterparty(chainState: ChainState, sourceChannel: Channel): Channel = {
@@ -85,14 +93,6 @@ module ics20 {
     }
   }
 
-  /// `onRecvPacket` should return an acknowledgment, but it also has to update
-  /// the chain state, so the return type is the updated value for the chain
-  /// state and the acknowledgment
-  type ReceiveTokenPacketResult = {
-    chainState: ChainState,
-    acknowledgement: FungibleTokenPacketAcknowledgement
-  }
-
   pure def onRecvPacket(chainState: ChainState, packet: Packet): ReceiveTokenPacketResult = {
     val data = packet.data
     if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
@@ -112,7 +112,6 @@ module ics20 {
       { chainState: newChainState, acknowledgement: ack }
     } else {
       // mint vouchers to receiver
-      val prefix = [packet.destPort, packet.destChannel]
       val newDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
       val bankResult = chainState.bank.MintCoins(data.receiver, newDenom, data.amount)

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -1,7 +1,9 @@
 // -*- mode: Bluespec; -*-
 
 module ics20 {
-  import denomTrace.*
+  import base.* from "./base"
+  import denomTrace.* from "./denomTrace"
+  import bank.* from "./bank"
 
   /* ***************************************************************************
    * TYPES
@@ -9,7 +11,6 @@ module ics20 {
 
   // Fundamental types
   type Channel = str
-  type Address = str
   type Height = int
 
   // IBC packet types
@@ -20,7 +21,7 @@ module ics20 {
 
   type FungibleTokenPacket = {
     denom: DenomTrace,
-    amount: uint256,
+    amount: UINT256,
     sender: Address,
     receiver: Address,
     memo: str
@@ -36,28 +37,28 @@ module ics20 {
 
   // State of the IBC module
   type ModuleState = {
+    bank: Accounts,
     channelEscrowAddresses: Channel -> Address,
     inFlightPackets: Set[FungibleTokenPacket]
   }
 
   pure def sendFungibleTokens(moduleState: ModuleState,
-                              denomination: DenomTrace, amount: uint256,
+                              denomination: DenomTrace, amount: UINT256,
                               sender: Address, receiver: Address,
                               sourcePort: str, sourceChannel: Channel,
                               timeoutHeight: Height,
                               timeoutTimestamp: uint64): ModuleState = {
-    val isSource = senderIsSource(sourcePort, sourceChannel, ModuleState)
-    val bankResult = if (isSource) {
+    val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
+      // burn vouchers
+      (moduleState.bank).BurnCoins(sender, denomination, amount)
+    } else { 
       // escrow tokens
       val escrowAccount = moduleState.channelEscrowAddresses.get(sourceChannel)
-      bank.TransferCoins(sender, escrowAccount, denomination, amount)
-    } else {
-      // burn vouchers
-      bank.BurnCoins(sender, denomination, amount)
+      moduleState.bank.TransferCoins(sender, escrowAccount, denomination, amount)
     }
 
     if (bankResult.success) {
-      val packet = { denom: denomination, amount: amount, sender: sender, receiver: receiver }
+      val packet = { denom: denomination, amount: amount, sender: sender, receiver: receiver, memo: "" }
 
       // handler.sendPacket
       moduleState.with("inFlightPackets", moduleState.inFlightPackets.union(Set(packet)))
@@ -69,12 +70,12 @@ module ics20 {
   pure def onRecvPacket(moduleState: ModuleState,
                         packet: Packet): FungibleTokenPacketAcknowledgement = {
     val data = packet.data
-    if (receiverIsSource(packet.sourcePort, packet.sourceChannel, data.denom)) {
+    if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
       // unescrow tokens to receiver
       val escrowAccount = moduleState.channelEscrowAddresses.get(packet.destChannel)
-      val receiverDenom = data.denom.tail()
+      val receiverDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
-      val bankResult = bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
+      val bankResult = moduleState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
 
       if (bankResult.success) {
         { success: true, errorMessage: "" }
@@ -84,9 +85,9 @@ module ics20 {
     } else {
       // mint vouchers to receiver
       val prefix = [packet.destPort, packet.destChannel]
-      val prefixedDenom = prefix.append(data.denom)
+      val newDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
-      val bankResult = bank.MintCoins(data.receiver, prefixedDenomination, data.amount)
+      val bankResult = moduleState.bank.MintCoins(data.receiver, newDenom, data.amount)
 
       if (bankResult.success) {
         { success: true, errorMessage: "" }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -1,5 +1,10 @@
 // -*- mode: Bluespec; -*-
 
+/**
+ * A specification for the ICS20 fungible token transfer protocol.
+ *
+ * Gabriela Moreira and Thomas Pani, Informal Systems, 2023
+ */
 module ics20 {
   import base.* from "./base"
   import bank.* from "./bank"

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -39,7 +39,7 @@ module ics20 {
     destChannel: Channel,
   }
 
-  // State of the IBC module in a chain
+  /// State of the IBC module in a chain
   type ChainState = {
     bank: Accounts,
     channels: Channels,
@@ -135,6 +135,9 @@ module ics20Test {
   /// Map from chain identifiers to their state
   var chainStates: str -> ChainState
 
+  /// Map from chain identifiers to their connections, which are maps from
+  /// counterparty chain identifiers to channel identifiers. For example, chain
+  /// A connects to chain B through channel "channelToB".
   pure val connections = Map(
     "A" -> Map(
       "B" -> "channelToB",
@@ -150,7 +153,10 @@ module ics20Test {
     )
   )
 
-  pure val channelCounterparties = connections.keys().mapBy(chain => {
+  /// For each chain, a map from channel to their channel counterparties,
+  /// derived from `connections`. For example, in chain A, channel "channelToB"
+  /// has the counterparty "channelToA".
+  pure val channelCounterparties: str -> Channel -> Channel = connections.keys().mapBy(chain => {
     val connectedChains = connections.get(chain).keys()
     connectedChains.map(counterpartyChain => {
       val localIdentifier = connections.get(chain).get(counterpartyChain)
@@ -161,6 +167,7 @@ module ics20Test {
 
   action init = {
     chainStates' = connections.keys().mapBy(chain => {
+      // All accounts are empty, except for Alice in chain A who has 100 atoms
       bank: if (chain == "A") Map("alice" -> Map(toDenom("atom") -> 100)) else Map(),
       channels: channelCounterparties.get(chain),
       channelEscrowAddresses: channelCounterparties.get(chain).keys().mapBy(_ => "escrow_account"),
@@ -184,8 +191,8 @@ module ics20Test {
   /// `destChain`. This is a composition of two actions: one that sends the
   /// packet from `sourceChain` and other that receives the packet in `destChain`
   run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
-    val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", connections.get(sourceChain).get(destChain), 0, 0)
     all {
+      val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", connections.get(sourceChain).get(destChain), 0, 0)
       chainStates' = chainStates.set(sourceChain, result),
     }).then(
       receivePacket(sourceChain, destChain)

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -46,7 +46,17 @@ module ics20 {
     inFlightPackets: Set[Packet]
   }
 
-  pure def sendFungibleTokens(moduleState: ModuleState, inFlightPackets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
+  pure def getCounterparty(moduleName: str, sourceChannel: Channel): Channel = {
+    pure val channels = Map(
+      "A" -> "channelToA",
+      "B" -> "channelToB",
+      "C" -> "channelToC"
+    )
+
+    channels.get(moduleName)
+  }
+
+  pure def sendFungibleTokens(moduleName: str, moduleState: ModuleState, packets: Set[Packet], // this could be an `sendPacket` operator when higher-order operators are supported
                               denomination: DenomTrace, amount: UINT256,
                               sender: Address, receiver: Address,
                               sourcePort: str, sourceChannel: Channel,
@@ -70,13 +80,13 @@ module ics20 {
         sourcePort: sourcePort,
         sourceChannel: sourceChannel,
         destPort: "transfer",
-        destChannel: "A1"
+        destChannel: getCounterparty(moduleName, sourceChannel)
       }
 
       { moduleState: moduleState.with("bank", bankResult.accounts),
-        inFlightPackets: inFlightPackets.union(Set(packet)) }
+        inFlightPackets: packets.union(Set(packet)) }
     } else {
-      { moduleState: moduleState, inFlightPackets: inFlightPackets }
+      { moduleState: moduleState, inFlightPackets: packets }
     }
   }
 
@@ -133,42 +143,142 @@ module ics20Test {
   var inFlightPackets: Set[Packet]
 
   pure def channelsForModule(mod: str): Set[Channel] = {
-    Set("A1", "A2", "A3")
+    pure val channels = Map(
+      "A" -> Set("channelToB", "channelToC"),
+      "B" -> Set("channelToA", "channelToC"),
+      "C" -> Set("channelToA", "channelToB")
+    )
+
+    channels.get(mod)
   }
 
   action init = all {
     moduleStates' = modules.mapBy(_ => {
-      bank: addresses.mapBy(_ => Map()).set("alice", Map(toDenom("denomA") -> 100, toDenom("denomB") -> 100)),
-      channelEscrowAddresses: Map(),
-    }),
+      bank: Map(),
+      channelEscrowAddresses: Set("channelToA", "channelToB", "channelToC").mapBy(_ => "escrow_account"),
+    }).setBy("A", st => st.with("bank", Map("alice" -> Map(toDenom("atom") -> 100)))),
     inFlightPackets' = Set()
   }
 
-  action sendSomeTransfer(mod) = {
-    nondet amount = Int.oneOf()
-    nondet sender = addresses.oneOf()
-    // Some denom that the sender has
-    nondet denom = moduleStates.get(mod).bank.get(sender).keys().oneOf()
-    nondet receiver = addresses.oneOf()
+  val bankEntriesAsRecords = modules.map(m =>
+    moduleStates.get(m).bank.keys().map(acc =>
+      moduleStates.get(m).bank.get(acc).keys().map(denom =>
+        val amount = moduleStates.get(m).bank.get(acc).get(denom)
+        { mod: m, account: acc, denom: denom, amount: amount }
+      )
+    ).flatten()
+  ).flatten().filter(r => r.amount > 0)
+
+  action sendSomeTransfer = {
+    // Find some existing ammount, sender and denom
+    // pure val modulesWithTokens = modules.filter(m =>
+    // moduleStates.get(mod).bank.keys().exists(k => ))
+    nondet bankEntry = bankEntriesAsRecords.oneOf()
     pure val sourcePort = "transfer"
-    nondet sourceChannel = channelsForModule(mod).oneOf()
-    val result = sendFungibleTokens(moduleStates.get(mod), inFlightPackets, denom, amount, sender, receiver, sourcePort, sourceChannel, 0, 0)
+    nondet receiver = addresses.oneOf()
+    nondet sourceChannel = channelsForModule(bankEntry.mod).oneOf()
+    val result = sendFungibleTokens(bankEntry.mod, moduleStates.get(bankEntry.mod), inFlightPackets, bankEntry.denom, bankEntry.amount,
+                                    bankEntry.account, receiver, sourcePort, sourceChannel, 0, 0)
     all {
-      moduleStates' = moduleStates.set(mod, result.moduleState),
+      moduleStates' = moduleStates.set(bankEntry.mod, result.moduleState),
       inFlightPackets' = result.inFlightPackets
     }
   }
 
-  action step = {
-    nondet mod = modules.oneOf()
-    any {
-      nondet packet = inFlightPackets.filter(p => p.destPort == "transfer" and p.destChannel.in(channelsForModule(mod))).oneOf()
-      val result = onRecvPacket(moduleStates.get(mod), packet)
-      all {
-        moduleStates' = moduleStates.set(mod, result.moduleState),
-        inFlightPackets' = inFlightPackets.exclude(Set(packet))
-      },
-      sendSomeTransfer(mod),
+  val packetsToReceiveAsRecords = inFlightPackets.filter(p => p.destPort == "transfer").map(p =>
+    modules.filter(mod => p.destChannel.in(channelsForModule(mod))).map(mod =>
+      { mod: mod, packet: p }
+    )
+  ).flatten()
+
+  action receivePacket = {
+    nondet packetEntry = packetsToReceiveAsRecords.oneOf()
+    val mod = packetEntry.mod
+    val packet = packetEntry.packet
+    val result = onRecvPacket(moduleStates.get(mod), packet)
+    all {
+      moduleStates' = moduleStates.set(mod, result.moduleState),
+      inFlightPackets' = inFlightPackets.exclude(Set(packet))
     }
   }
+
+  action step = {
+    any {
+      sendSomeTransfer,
+      receivePacket,
+    }
+  }
+
+  pure def getChannelsForTransfer(sourceChain: str, destChain: str): { sourceChannel: str, destChannel: str } =
+    pure val channels = Map(
+      "A" -> "channelToA",
+      "B" -> "channelToB",
+      "C" -> "channelToC"
+    )
+    ({
+      // If this is a transfer from A -> B, then the source channel is `channelToB`
+      sourceChannel: channels.get(destChain),
+      // If this is a transfer from A -> B, then the dest channel is `channelToA`
+      destChannel: channels.get(sourceChain),
+    })
+
+  def print(a) = true
+
+  run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
+    pure val channels = getChannelsForTransfer(sourceChain, destChain)
+    val result = sendFungibleTokens(sourceChain, moduleStates.get(sourceChain), inFlightPackets, denom, 1, sender, receiver, "transfer", channels.sourceChannel, 0, 0)
+    all {
+      moduleStates' = moduleStates.set(sourceChain, result.moduleState),
+      inFlightPackets' = result.inFlightPackets
+    })
+    .then(all {
+      print(inFlightPackets),
+      receivePacket
+    }
+    )
+
+  run tTest = init.then(
+    sendTransfer(toDenom("atom"), "A", "B", "alice", "bob"))
+
+  run ABCACBATest = init.then(
+    sendTransfer(toDenom("atom"), "A", "B", "alice", "bob")
+  ).then(
+    pure val denom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    sendTransfer(denom, "B", "C", "bob", "charlie")
+  ).then(
+    pure val denom: DenomTrace = { baseDenom: "atom", path: [
+      { port: "transfer", channel: "channelToB" },
+      { port: "transfer", channel: "channelToA" }
+    ] }
+
+    sendTransfer(denom, "C", "A", "charlie", "alice")
+  ).then(
+    pure val denom: DenomTrace = { baseDenom: "atom", path: [
+      { port: "transfer", channel: "channelToC" },
+      { port: "transfer", channel: "channelToB" },
+      { port: "transfer", channel: "channelToA" }
+    ] }
+
+    sendTransfer(denom, "A", "C", "alice", "bob")
+  ).then(
+    pure val denom: DenomTrace = { baseDenom: "atom", path: [
+      { port: "transfer", channel: "channelToB" },
+      { port: "transfer", channel: "channelToA" }
+    ] }
+
+    sendTransfer(denom, "C", "B", "bob", "charlie")
+  ).then(
+    pure val denom: DenomTrace = { baseDenom: "atom", path: [
+      { port: "transfer", channel: "channelToA" }
+    ] }
+
+    sendTransfer(denom, "B", "A", "charlie", "darwin")
+  ).then(all {
+      assert(moduleStates.get("A").bank.get("alice").get(toDenom("atom")) == 99),
+      assert(moduleStates.get("A").bank.get("darwin").get(toDenom("atom")) == 1),
+
+      moduleStates' = moduleStates,
+      inFlightPackets' = inFlightPackets,
+    }
+  )
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -64,20 +64,20 @@ module ics20 {
   pure def sendFungibleTokens(chainState: ChainState, denomination: DenomTrace, amount: UINT256,
                               sender: Address, receiver: Address, sourcePort: str, sourceChannel: Channel,
                               timeoutHeight: Height, timeoutTimestamp: uint64): ChainState = {
-    val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
+    pure val bankResult = if (movingBackAlongTrace({port: sourcePort, channel: sourceChannel}, denomination)) {
       // burn vouchers
       (chainState.bank).BurnCoins(sender, denomination, amount)
     } else {
       // escrow tokens
-      val escrowAccount = chainState.channelEscrowAddresses.get(sourceChannel)
+      pure val escrowAccount = chainState.channelEscrowAddresses.get(sourceChannel)
       chainState.bank.TransferCoins(sender, escrowAccount, denomination, amount)
     }
 
     if (bankResult.success) {
-      val data = { denom: denomination, amount: amount, sender: sender, receiver: receiver, memo: "" }
+      pure val data = { denom: denomination, amount: amount, sender: sender, receiver: receiver, memo: "" }
 
       // handler.sendPacket
-      val packet = {
+      pure val packet = {
         data: data,
         sourcePort: sourcePort,
         sourceChannel: sourceChannel,
@@ -94,16 +94,16 @@ module ics20 {
   }
 
   pure def onRecvPacket(chainState: ChainState, packet: Packet): ReceiveTokenPacketResult = {
-    val data = packet.data
+    pure val data = packet.data
     if (movingBackAlongTrace({port: packet.sourcePort, channel: packet.sourceChannel}, data.denom)) {
       // unescrow tokens to receiver
-      val escrowAccount = chainState.channelEscrowAddresses.get(packet.destChannel)
-      val receiverDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
+      pure val escrowAccount = chainState.channelEscrowAddresses.get(packet.destChannel)
+      pure val receiverDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
-      val bankResult = chainState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
+      pure val bankResult = chainState.bank.TransferCoins(escrowAccount, data.receiver, receiverDenom, data.amount)
 
-      val newChainState = chainState.with("bank", bankResult.accounts)
-      val ack = if (bankResult.success) {
+      pure val newChainState = chainState.with("bank", bankResult.accounts)
+      pure val ack = if (bankResult.success) {
         { success: true, errorMessage: "" }
       } else {
         { success: false, errorMessage: "transfer coins failed" }
@@ -112,12 +112,12 @@ module ics20 {
       { chainState: newChainState, acknowledgement: ack }
     } else {
       // mint vouchers to receiver
-      val newDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
+      pure val newDenom = updateTrace(data.denom, packet.sourcePort, packet.sourceChannel, packet.destPort, packet.destChannel)
 
-      val bankResult = chainState.bank.MintCoins(data.receiver, newDenom, data.amount)
+      pure val bankResult = chainState.bank.MintCoins(data.receiver, newDenom, data.amount)
 
-      val newChainState = chainState.with("bank", bankResult.accounts)
-      val ack = if (bankResult.success) {
+      pure val newChainState = chainState.with("bank", bankResult.accounts)
+      pure val ack = if (bankResult.success) {
         { success: true, errorMessage: "" }
       } else {
         { success: false, errorMessage: "mint coins failed" }
@@ -157,10 +157,10 @@ module ics20Test {
   /// derived from `connections`. For example, in chain A, channel "channelToB"
   /// has the counterparty "channelToA".
   pure val channelCounterparties: str -> Channel -> Channel = connections.keys().mapBy(chain => {
-    val connectedChains = connections.get(chain).keys()
+    pure val connectedChains = connections.get(chain).keys()
     connectedChains.map(counterpartyChain => {
-      val localIdentifier = connections.get(chain).get(counterpartyChain)
-      val counterpartyIdentifier = connections.get(counterpartyChain).get(chain)
+      pure val localIdentifier = connections.get(chain).get(counterpartyChain)
+      pure val counterpartyIdentifier = connections.get(counterpartyChain).get(chain)
       (localIdentifier, counterpartyIdentifier)
     }).setToMap()
   })

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -242,12 +242,16 @@ Temporarily disabled.
 
 <!-- !test check erc20::erc20Tests - Syntax/Types & Effects/Unit tests -->
     quint test --main=erc20Tests ../examples/solidity/ERC20/erc20.qnt
-    
+
 ### OK on test ics20 bank
 
 <!-- !test check ics20 bank - Syntax/Types & Effects/Unit tests -->
-    quint test ../examples/cosmos/ics20/bank.qnt
-    
+    quint test --main bankTests ../examples/cosmos/ics20/bank.qnt
+
+### OK on test ics20
+<!-- !test check ics20 - Syntax/Types & Effects/Unit tests -->
+    quint test --main ics20Test ../examples/cosmos/ics20/ics20.qnt
+
 ### OK on test importFrom
 
 <!-- !test check importFrom - Syntax/Types & Effects/Unit tests -->


### PR DESCRIPTION
Hello :octocat: 

This adds a first complete version of the ICS20 spec, integrating with the existing `bank.qnt` and `denomTrace.qnt` specs. I've also extracted some common definitions to `base.qnt`.

The commit history is a mess because I'm afraid of rebasing this (since I've started working on top of two existing branches), but the diff is correct.

I'll do some other iterations on this spec, adding invariants and some non-happy-path examples.

Closes https://github.com/informalsystems/apalache-team-services/issues/4

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
