### PR TITLE
handle compilation errors that occur in `quint test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper errors are now reported when a lambda returns an operator (#811)
 - Fix `quint run` to output compile errors again (#812)
 - Fix the record constructor, so the key order does not matter (#839)
+- `quint test` shows compile errors, if they occur (#841)
 
 ### Security
 

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -665,3 +665,25 @@ true
 >>> 16
 >>> 
 ```
+
+### Fail on test with compile error
+
+<!-- !test in test compile error -->
+```
+output=$(quint test testFixture/_1040compileError.qnt 2>&1)
+exit_code=$?
+echo "$output" | sed -e 's#^.*_1040compileError.qnt#      HOME/_1040compileError.qnt#g'
+exit $exit_code
+```
+
+<!-- !test exit 1 -->
+<!-- !test out test compile error -->
+```
+
+  _1040compileError
+      HOME/_1040compileError.qnt:5:12 - error: Name n not found
+5:     assert(n > 0)
+              ^
+
+error: Tests failed
+```

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -307,7 +307,9 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
     const testOut =
       compileAndTest(testing.modules, main,
                      testing.sourceMap, testing.table, testing.types, options)
-    if (testOut.isRight()) {
+    if (testOut.isLeft()) {
+      return cliErr("Tests failed", { ...testing, errors: testOut.value })
+    } else if (testOut.isRight()) {
       const elapsedMs = Date.now() - startMs
       const results = testOut.unwrap()
       // output the status for every test
@@ -381,14 +383,14 @@ export function runTests(prev: TypecheckedStage): CLIProcedure<TestedStage> {
           && !verbosity.hasActionTracking(options.verbosity)) {
         out(chalk.gray('\n  Use --verbosity=3 to show executions.'))
       }
-    } // else: we have handled the case of module not found already
+    }
 
     const errors = namedErrors.map(([_, e]) => e)
     const stage = { ...testing, passed, failed, ignored, errors }
     if (errors.length == 0 && failed.length == 0) {
       return right(stage)
     } else {
-      return left({msg: "Tests failed", stage})
+      return cliErr("Tests failed", stage)
     }
   }
 }

--- a/quint/testFixture/_1040compileError.qnt
+++ b/quint/testFixture/_1040compileError.qnt
@@ -1,0 +1,7 @@
+module _1040compileError {
+  const n: int
+
+  run myTest = {
+    assert(n > 0)
+  }
+}


### PR DESCRIPTION
Closes #828. This PR fixes the problem of compilation errors not being shown by `quint test`.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
