### PR TITLE
fix the bug 843

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `quint run` to output compile errors again (#812)
 - Fix the record constructor, so the key order does not matter (#839)
 - `quint test` shows compile errors, if they occur (#841)
+- Fix the bug that occurred when caching `pure val` (#844)
 
 ### Security
 

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -291,3 +291,8 @@ fi
 
 <!-- !test check rareSpells - Syntax/Types & Effects/Unit tests -->
     quint test ../examples/spells/rareSpells.qnt
+
+### OK on test bug843pureValCache
+
+<!-- !test check bug843pureValCache - Syntax/Types & Effects/Unit tests -->
+    quint test ./testFixture/bug843pureValCache.qnt

--- a/quint/testFixture/bug843pureValCache.qnt
+++ b/quint/testFixture/bug843pureValCache.qnt
@@ -1,0 +1,16 @@
+// a regression test for:
+// https://github.com/informalsystems/quint/issues/843
+module bug843pureValCache {
+  def foo(x) = {
+    pure val bar = x + 1
+    bar
+  }
+
+  var t: int
+
+  run aTest = (t' = foo(1)).then(t' = foo(2)).then(all{
+    assert(t == 3),
+    t' = t,
+  })
+
+}


### PR DESCRIPTION
Closes #843. Fixed the bug with spurious caching of nested `pure val`s.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
