### PR TITLE
Update type maps at flattening with new generated ids

### DIFF
--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -8,7 +8,6 @@
  * See License.txt in the project root for license information.
  */
 
-import { basename, dirname } from 'path'
 
 import { Either, left, right } from '@sweet-monads/either'
 import {
@@ -141,7 +140,7 @@ export function compile(
   let latestTable = lookupTable
 
   const flattenedModules = modules.map(m => {
-    const flattened = flatten(m, latestTable, modulesByName, idGenerator, sourceMap)
+    const flattened = flatten(m, latestTable, modulesByName, idGenerator, sourceMap, types)
 
     modulesByName.set(m.name, flattened)
 

--- a/quint/src/types/base.ts
+++ b/quint/src/types/base.ts
@@ -16,3 +16,7 @@ export interface TypeScheme {
 }
 
 export type Signature = (_arity: number) => TypeScheme
+
+export function toScheme(type: QuintType): TypeScheme {
+  return { typeVariables: new Set([]), rowVariables: new Set([]), type }
+}

--- a/quint/src/types/constraintGenerator.ts
+++ b/quint/src/types/constraintGenerator.ts
@@ -19,7 +19,7 @@ import { expressionToString, rowToString, typeToString } from '../IRprinting'
 import { Either, left, mergeInMany, right } from '@sweet-monads/either'
 import { Error, ErrorTree, buildErrorLeaf, buildErrorTree, errorTreeToString } from '../errorTree'
 import { getSignatures } from './builtinSignatures'
-import { Constraint, Signature, TypeScheme } from './base'
+import { Constraint, Signature, TypeScheme, toScheme } from './base'
 import { Substitutions, applySubstitution, compose } from './substitutions'
 import { LookupTable } from '../lookupTable'
 import { specialConstraints } from './specialConstraints'
@@ -282,10 +282,6 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
     const subs = compose(this.table, typeSubs, rowSubs)
     return applySubstitution(this.table, subs, t.type)
   }
-}
-
-function toScheme(type: QuintType): TypeScheme {
-  return { typeVariables: new Set([]), rowVariables: new Set([]), type }
 }
 
 function checkAnnotationGenerality(


### PR DESCRIPTION
Hello :octocat: 

This closes #846 by adding a type map update every time we generate a new id for an expression, the same way we did for the source map. Effects are not handled yet since they don't even make it to this step of compilation (the map is not available, so there's nothing to update).

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Ran `npm run format` (or had formatting run automatically on all files edited)
