### PR TITLE
Extend ICS-20 spec with failed acks

### DIFF
--- a/examples/cosmos/ics20/bank.qnt
+++ b/examples/cosmos/ics20/bank.qnt
@@ -140,7 +140,11 @@ module bankTests {
   var error: bool  // true iff a previous bank operation has been unsuccessful
 
   pure val Addresses : Set[Address] = Set("alice", "bob", "charlie")
-  pure val Denoms : Set[Denomination] = Set(toDenom("atom"), toDenom("eth"), toDenom("osmo"))
+
+  pure val ATOM = toDenom("atom")
+  pure val ETH  = toDenom("eth")
+  pure val OSMO = toDenom("osmo")
+  pure val Denoms : Set[Denomination] = Set(ATOM, ETH, OSMO)
 
   // Trivial action defs for the bank module operations
   action burn(sender: Address, denom: Denomination, amount: Amount): bool =
@@ -170,7 +174,7 @@ module bankTests {
    * Alice, Bob and Charlie initially hold 10 ATOMs, and no other coins.
    */
   action init = all {
-    state' = Addresses.mapBy(_ => Map(toDenom("atom") -> 10)),
+    state' = Addresses.mapBy(_ => Map(ATOM -> 10)),
     error' = false
   }
 
@@ -199,16 +203,16 @@ module bankTests {
     // last operation successful
     assert(not(error)),
     // everybody holds 10 ATOM
-    assert(state.getBalances("alice").getBalance(toDenom("atom")) == 10),
-    assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
-    assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+    assert(state.getBalances("alice").getBalance(ATOM) == 10),
+    assert(state.getBalances("bob").getBalance(ATOM) == 10),
+    assert(state.getBalances("charlie").getBalance(ATOM) == 10),
     // nobody holds ETH
-    assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
-    assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
-    assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 0),
+    assert(state.getBalances("alice").getBalance(ETH) == 0),
+    assert(state.getBalances("bob").getBalance(ETH) == 0),
+    assert(state.getBalances("charlie").getBalance(ETH) == 0),
     // "noAccount" holds nothing
-    assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
-    assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
+    assert(state.getBalances("noAccount").getBalance(ATOM) == 0),
+    assert(state.getBalances("noAccount").getBalance(ETH) == 0),
   }
 
   // Do some mint, burn, transfer steps and check that account balances are correct.
@@ -217,76 +221,76 @@ module bankTests {
       .then(all {
         initialState,
         // now mint alice 15 ATOMs
-        mint("alice", toDenom("atom"), 15)
+        mint("alice", ATOM, 15)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // alice received her 15 ATOM
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 25),
+        assert(state.getBalances("bob").getBalance(ATOM) == 10),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
         // still nobody holds ETH
-        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("alice").getBalance(ETH) == 0),
+        assert(state.getBalances("bob").getBalance(ETH) == 0),
+        assert(state.getBalances("charlie").getBalance(ETH) == 0),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
-        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("noAccount").getBalance(ATOM) == 0),
+        assert(state.getBalances("noAccount").getBalance(ETH) == 0),
 
         // now burn bob 6 ATOMs
-        burn("bob", toDenom("atom"), 6)
+        burn("bob", ATOM, 6)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // bob lost 42 ATOM
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 4),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 25),
+        assert(state.getBalances("bob").getBalance(ATOM) == 4),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
         // still nobody holds ETH
-        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("alice").getBalance(ETH) == 0),
+        assert(state.getBalances("bob").getBalance(ETH) == 0),
+        assert(state.getBalances("charlie").getBalance(ETH) == 0),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
-        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("noAccount").getBalance(ATOM) == 0),
+        assert(state.getBalances("noAccount").getBalance(ETH) == 0),
 
         // now mint charlie 6 ETH
-        mint("charlie", toDenom("eth"), 6)
+        mint("charlie", ETH, 6)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // ATOM balances remain the same
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 4),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 25),
+        assert(state.getBalances("bob").getBalance(ATOM) == 4),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
         // now charlie holds 6 ETH
-        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 6),
+        assert(state.getBalances("alice").getBalance(ETH) == 0),
+        assert(state.getBalances("bob").getBalance(ETH) == 0),
+        assert(state.getBalances("charlie").getBalance(ETH) == 6),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
-        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("noAccount").getBalance(ATOM) == 0),
+        assert(state.getBalances("noAccount").getBalance(ETH) == 0),
 
         // now transfer 4 of charlie's ETH to bob
-        transfer("charlie", "bob", toDenom("eth"), 4)
+        transfer("charlie", "bob", ETH, 4)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // ATOM balances remain the same
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 25),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 4),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 25),
+        assert(state.getBalances("bob").getBalance(ATOM) == 4),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
         // bob got 4 of charlie's ETH
-        assert(state.getBalances("alice").getBalance(toDenom("eth")) == 0),
-        assert(state.getBalances("bob").getBalance(toDenom("eth")) == 4),
-        assert(state.getBalances("charlie").getBalance(toDenom("eth")) == 2),
+        assert(state.getBalances("alice").getBalance(ETH) == 0),
+        assert(state.getBalances("bob").getBalance(ETH) == 4),
+        assert(state.getBalances("charlie").getBalance(ETH) == 2),
         // "noAccount" holds nothing
-        assert(state.getBalances("noAccount").getBalance(toDenom("atom")) == 0),
-        assert(state.getBalances("noAccount").getBalance(toDenom("eth")) == 0),
+        assert(state.getBalances("noAccount").getBalance(ATOM) == 0),
+        assert(state.getBalances("noAccount").getBalance(ETH) == 0),
 
         // nothing changes
         state' = state,
@@ -301,18 +305,18 @@ module bankTests {
         initialState,
 
         // now burn alice 10 ATOMs
-        burn("alice", toDenom("atom"), 10)
+        burn("alice", ATOM, 10)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // alice lost 10 ATOM
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 0),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 0),
+        assert(state.getBalances("bob").getBalance(ATOM) == 10),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
 
         // now burn bob 11 ATOMs
-        burn("bob", toDenom("atom"), 11)
+        burn("bob", ATOM, 11)
       })
       .then(all{
         // burning over balance failed
@@ -331,18 +335,18 @@ module bankTests {
         initialState,
 
         // now transfer 10 ATOMs from alice to bob
-        transfer("alice", "bob", toDenom("atom"), 10)
+        transfer("alice", "bob", ATOM, 10)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // alice -- 10 ATOM --> bob
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 0),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 20),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 0),
+        assert(state.getBalances("bob").getBalance(ATOM) == 20),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
 
         // now transfer 21 ATOMs from bob to charlie
-        transfer("bob", "charlie", toDenom("atom"), 21)
+        transfer("bob", "charlie", ATOM, 21)
       })
       .then(all{
         // transfer over balance failed
@@ -361,18 +365,18 @@ module bankTests {
         initialState,
 
         // now mint alice 0 ATOMs
-        mint("alice", toDenom("atom"), 0)
+        mint("alice", ATOM, 0)
       })
       .then(all {
         // last operation successful
         assert(not(error)),
         // balances remain
-        assert(state.getBalances("alice").getBalance(toDenom("atom")) == 10),
-        assert(state.getBalances("bob").getBalance(toDenom("atom")) == 10),
-        assert(state.getBalances("charlie").getBalance(toDenom("atom")) == 10),
+        assert(state.getBalances("alice").getBalance(ATOM) == 10),
+        assert(state.getBalances("bob").getBalance(ATOM) == 10),
+        assert(state.getBalances("charlie").getBalance(ATOM) == 10),
 
         // now mint alice -1 ATOMs
-        mint("alice", toDenom("atom"), -1)
+        mint("alice", ATOM, -1)
       })
       .then(all{
         // negative minting failed

--- a/examples/cosmos/ics20/bank.qnt
+++ b/examples/cosmos/ics20/bank.qnt
@@ -60,10 +60,6 @@ module bank {
     if (balances.keys().contains(denom)) balances.get(denom) else 0
   }
 
-  /****************************/
-  /*     public interface     */
-  /****************************/
-
   /* Return `accounts`, where `address` is updated to hold
    * `currentAmount + amount` tokens of denomination `denom`.
    *
@@ -79,6 +75,10 @@ module bank {
     val newCoins = accountCoins.put(denom, accountCoins.getBalance(denom) + amount)
     accounts.put(address, newCoins)
   }
+
+  /****************************/
+  /*     public interface     */
+  /****************************/
 
   /* Return `accounts`, where `amount`-many tokens of denomination `denom`
    * vanished out of `sender`'s account into thin air.

--- a/examples/cosmos/ics20/base.qnt
+++ b/examples/cosmos/ics20/base.qnt
@@ -35,4 +35,16 @@ module base {
   pure def toDenom(baseDenom: str): DenomTrace = {
     { baseDenom: baseDenom, path: [] }
   }
+
+  // TODO(#879): Remove and import ../../spells/basicSpells
+  // The following is only here to work around a failing integration test on Windows.
+
+  /// Test whether a key is present in a map
+  ///
+  /// - @param __map a map to query
+  /// - @param __key the key to look for
+  /// - @returns true if and only __map has an entry associated with __key
+  pure def has(__map: a -> b, __key: a): bool = {
+    __map.keys().contains(__key)
+  }
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -192,7 +192,6 @@ module ics20Test {
   import base.* from "./base"
   import bank.getBalance from "./bank"
   import bank.getBalances from "./bank"
-  import basicSpells.has from "../../spells/basicSpells"
   import ics20.*
 
   /****************************************************************************

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -235,12 +235,22 @@ module ics20Test {
     }).setToMap()
   })
 
+  /// Return true iff there is a channel from `sourceChain` to `destChain` defined in `CHANNEL_TOPOLOGY`.
+  ///
+  /// In particular, this returns false if `sourceChain == destChain`.
+  pure def hasChannelBetween(sourceChain: str, destChain: str): bool = all {
+    // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
+    sourceChain != destChain,
+    // there is a channel between `sourceChain` and `destChain`
+    CHANNEL_TOPOLOGY.has(sourceChain),
+    CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
+  }
+
   /// Return true iff there is a channel from `sourceChain` to `destChain` defined in `CHANNEL_TOPOLOGY`
   /// that corresponds to the channel endpoints of `packet`.
   pure def isTravelingBetween(packet: Packet, sourceChain: str, destChain: str): bool = all {
     // there is a channel between `sourceChain` and `destChain`
-    CHANNEL_TOPOLOGY.has(sourceChain),
-    CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
+    hasChannelBetween(sourceChain, destChain),
     // packet endpoints correspond to channel ends
     channelCounterparties.get(sourceChain).has(packet.sourceChannel),
     channelCounterparties.get(sourceChain).get(packet.sourceChannel) == packet.destChannel
@@ -264,11 +274,8 @@ module ics20Test {
                     denom: DenomTrace, amount: UINT256,
                     sender: Address, receiver: Address): bool = all {
     // (1) Pre-condition:
-    // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
-    sourceChain != destChain,
     // there is a channel between `sourceChain` and `destChain`
-    CHANNEL_TOPOLOGY.has(sourceChain),
-    CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
+    hasChannelBetween(sourceChain, destChain),
 
     // (2) Send the packet using `sendFungibleTokens`:
     val sourceChainState = chainStates.get(sourceChain)
@@ -282,21 +289,16 @@ module ics20Test {
   }
 
   /// Receive a packet sent from `sourceChain` to `destChain`:
-  /// - Pick an arbitrary, previously unreceived packet sent from `sourceChain`
-  ///   to `destChain`.
+  /// - Pick an arbitrary, previously unreceived packet sent from `sourceChain` to `destChain`.
   /// - Call the `onRecvPacket` callback on it.
   /// - Update the chain states to record the packet as received.
-  /// - Record (but not receive) the acknowledgement produced by `onRecvPacket`
-  ///   on `destChain`.
+  /// - Record (but not receive) the acknowledgement produced by `onRecvPacket` on `destChain`.
   action receivePacket(sourceChain: str, destChain: str): bool =
     val sourceChainState = chainStates.get(sourceChain)
     all {
       // (1) Pre-condition:
-      // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
-      sourceChain != destChain,
       // there is a channel between `sourceChain` and `destChain`
-      CHANNEL_TOPOLOGY.has(sourceChain),
-      CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
+      hasChannelBetween(sourceChain, destChain),
       // there is an unreceived packet traveling from `sourceChain` to `destChain`
       sourceChainState.outPackets.exists(packet => packet.isTravelingBetween(sourceChain, destChain)),
 

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -254,6 +254,9 @@ module ics20Test {
     // (1) Pre-condition:
     // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
     sourceChain != destChain,
+    // there is a channel between `sourceChain` and `destChain`
+    CHANNEL_TOPOLOGY.keys().contains(sourceChain),
+    CHANNEL_TOPOLOGY.get(sourceChain).keys().contains(destChain),
 
     // (2) Send the packet using `sendFungibleTokens`:
     val sourceChainState = chainStates.get(sourceChain)

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -168,6 +168,8 @@ module ics20 {
 
 module ics20Test {
   import base.* from "./base"
+  import bank.getBalance from "./bank"
+  import bank.getBalances from "./bank"
   import ics20.*
 
   /// Map from chain identifiers to their state
@@ -300,4 +302,55 @@ module ics20Test {
       chainStates' = chainStates,
     }
   )
+
+  // Test producing a failed acknowledgement:
+  //
+  // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
+  // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
+  // 3. Transfer the 50 tokens back from Bob to Alice.
+  //    3.1 First, this burns Bob's 50 vouchers on chain B, and sends a packet to chain A.
+  //    3.2 Receipt of the packet on chain A calls the `onRecvPacket` callback.
+  //    3.3 `onRecvPacket` calls the bank module's `TransferCoins` to unescrow 50 tokens to Alice.
+  //    3.4 `TransferCoins` returns an error, because -- after manipulating it in (2) -- the escrow account has insufficient funds.
+  //    3.5 The bank module error causes `onRecvPacket` to return a failed acknowledgement.
+  //    3.6 `onAcknowledgePacket` on chain "B" re-mints the burned vouchers to Bob.
+  run FailedAckTest = init.then(all {
+    assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 100),
+    assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 0),
+    assert(chainStates.get("B").bank.getBalances("bob").getBalance(ATOM) == 0),
+
+    // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
+    sendTransfer(ATOM, 50, "A", "B", "alice", "bob")
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
+      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 50),
+      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
+
+      // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
+      val chainState = chainStates.get("A")
+      val manipulatedEscrowAccount = chainState.bank.get(ESCROW_ACCOUNT).set(ATOM, 49)
+      val manipulatedBank = chainState.bank.set(ESCROW_ACCOUNT, manipulatedEscrowAccount)
+      chainStates' = chainStates.set("A", chainState.with("bank", manipulatedBank))
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
+      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
+      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
+
+      // 3. Transfer the 50 tokens back from Bob to Alice.
+      sendTransfer(voucherDenom, 50, "B", "A", "bob", "alice")
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      // Assert that the vouchers have been minted back
+      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
+      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
+      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
+
+      // noop
+      chainStates' = chainStates
+  })
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -120,6 +120,50 @@ module ics20 {
 
     (newChainState, ack)
   }
+
+  /// Refund tokens from a token transfer initiated by `packet`.
+  ///
+  /// Should be called if the token transfer fails on the receiver chain
+  /// (due to a packet acknowledgement indicating failure, or due to a timeout).
+  ///
+  /// In particular, `refundTokens` is called by both `onAcknowledgePacket` (on
+  /// failure) and by `onTimeoutPacket`, to refund burnt or escrowed tokens to
+  /// the original sender.
+  ///
+  /// `packet`: The packet (originally sent from the local chain) that initiated the token transfer.
+  ///           Packet `packet` should have resulted in a failed acknowledgement or timeout.
+  pure def refundTokens(chainState: ChainState, packet: Packet): ChainState = {
+    pure val data: FungibleTokenData = packet.data
+    pure val source: HopElement = { port: packet.sourcePort, channel: packet.sourceChannel }
+    pure val bankResult =
+      if (movingBackAlongTrace(source, data.denom)) {
+        // The (failed) transfer attempt was moving the token back along its denom trace.
+        // For this, we originally burnt vouchers in `sendFungibleTokens`, so mint them back.
+        chainState.bank.MintCoins(data.sender, data.denom, data.amount)
+      } else {
+        // The (failed) transfer attempt was moving the token further along its denom trace.
+        // For this, we originally escrowed tokens in `sendFungibleTokens`, so unescrow them back.
+        pure val escrowAccount = chainState.channelEscrowAddresses.get(packet.srcChannel)
+        chainState.bank.TransferCoins(escrowAccount, data.sender, data.denom, data.amount)
+      }
+    if (bankResult.success) {
+      chainState.with("bank", bankResult.accounts)
+    } else {
+      // TODO: ICS 20 does not specify what happens if the bank modules return an error.
+      //       We treat bank failure as a noop.
+      chainState
+    }
+  }
+
+  /// Called by the routing module when a packet sent by this module has been acknowledged.
+  pure def onAcknowledgePacket(chainState: ChainState, packet: Packet,
+                               acknowledgement: FungibleTokenPacketAcknowledgement) : ChainState = {
+    if (acknowledgement.success) {
+      chainState  // transfer successful, nothing to do
+    } else {
+      refundTokens(chainState, packet)
+    }
+  }
 }
 
 module ics20Test {
@@ -172,16 +216,31 @@ module ics20Test {
     })
   }
 
-  /// Receives a packet sent from `sourceChain` to `destChain`
-  action receivePacket(sourceChain: str, destChain: str): bool = {
+  /// Receives a packet sent from `sourceChain` to `destChain`, and delivers
+  /// the acknowledgement back to `sourceChain`.
+  action receiveAndAckPacket(sourceChain: str, destChain: str): bool = all {
+    // (1) Pre-condition:
+    // ICS 4: "a channel is a pipeline for exactly-once packet delivery between specific modules on **separate** blockchains"
+    sourceChain != destChain,
+
+    // (2) Compute updated chain states:
     val sourceChainState = chainStates.get(sourceChain)
+    // non-deterministically pick a packet from `sourceChain` to receive on `destChain`
     nondet packet = sourceChainState.outPackets.oneOf()
-    val result = onRecvPacket(chainStates.get(destChain), packet)
-    all {
-      chainStates' = chainStates
-        .set(destChain, result._1)
-        .set(sourceChain, sourceChainState.with("outPackets", sourceChainState.outPackets.exclude(Set(packet))))
-    }
+    // call the `onRecvPacket` callback
+    val recvResult = onRecvPacket(chainStates.get(destChain), packet)
+    val newDestChainState = recvResult._1
+    val acknowledgement   = recvResult._2
+    // deliver the acknowledgement on `sourceChain`, clean up the sent packet
+    // TODO(thpani): split this into a separate action
+    val newSourceChainPackets = sourceChainState.outPackets.exclude(Set(packet))
+    val newSourceChainState   = onAcknowledgePacket(sourceChainState, packet, acknowledgement)
+                                      .with("outPackets", newSourceChainPackets)
+
+    // (3) Quint state transition:
+    chainStates' = chainStates
+                      .set(destChain, newDestChainState)
+                      .set(sourceChain, newSourceChainState)
   }
 
   /// Send `amount`-many `denom` tokens from `sender` in `sourceChain` to
@@ -195,7 +254,7 @@ module ics20Test {
       val result = sendFungibleTokens(chainStates.get(sourceChain), denom, amount, sender, receiver, "transfer", channelTopology.get(sourceChain).get(destChain), 0, 0)
       chainStates' = chainStates.set(sourceChain, result),
     }).then(
-      receivePacket(sourceChain, destChain)
+      receiveAndAckPacket(sourceChain, destChain)
     )
 
   // Transfer a single token across these chains: A -> B -> C -> A -> C -> B -> A

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -204,7 +204,7 @@ module ics20Test {
   /// Map from chain identifiers to a map of the chain identifiers it can
   /// communicate with and the channel to be used to send packets. For example,
   /// chain A connects to chain B through channel "channelToB".
-  pure val channelTopology = Map(
+  pure val CHANNEL_TOPOLOGY = Map(
     "A" -> Map(
       "B" -> "channelToB",
       "C" -> "channelToC"
@@ -223,19 +223,19 @@ module ics20Test {
   pure val ESCROW_ACCOUNT = "escrow_account"
 
   /// For each chain, a map from channel to their channel counterparties,
-  /// derived from `channelTopology`. For example, in chain A, channel "channelToB"
+  /// derived from `CHANNEL_TOPOLOGY`. For example, in chain A, channel "channelToB"
   /// has the counterparty "channelToA".
-  pure val channelCounterparties: str -> Channel -> Channel = channelTopology.keys().mapBy(chain => {
-    pure val connectedChains = channelTopology.get(chain).keys()
+  pure val channelCounterparties: str -> Channel -> Channel = CHANNEL_TOPOLOGY.keys().mapBy(chain => {
+    pure val connectedChains = CHANNEL_TOPOLOGY.get(chain).keys()
     connectedChains.map(counterpartyChain => {
-      pure val localChannel = channelTopology.get(chain).get(counterpartyChain)
-      pure val counterpartyChannel = channelTopology.get(counterpartyChain).get(chain)
+      pure val localChannel = CHANNEL_TOPOLOGY.get(chain).get(counterpartyChain)
+      pure val counterpartyChannel = CHANNEL_TOPOLOGY.get(counterpartyChain).get(chain)
       (localChannel, counterpartyChannel)
     }).setToMap()
   })
 
   action init = {
-    chainStates' = channelTopology.keys().mapBy(chain => {
+    chainStates' = CHANNEL_TOPOLOGY.keys().mapBy(chain => {
       // All accounts are empty, except for Alice in chain A who has 100 atoms
       bank: if (chain == "A") Map("alice" -> Map(ATOM -> 100)) else Map(),
       channels: channelCounterparties.get(chain),
@@ -259,7 +259,7 @@ module ics20Test {
     val sourceChainState = chainStates.get(sourceChain)
     val newSourceChainState = sendFungibleTokens(sourceChainState, denom, amount,
                                                  sender, receiver,
-                                                 "transfer", channelTopology.get(sourceChain).get(destChain),
+                                                 "transfer", CHANNEL_TOPOLOGY.get(sourceChain).get(destChain),
                                                  0, 0)
 
     // (3) Quint state transition:

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -329,7 +329,7 @@ module ics20Test {
       }
     }
 
-  /// Receive an acknowledgement for `packet` on `chain`:
+  /// Receive a pending acknowledgement on `chain`:
   /// - Pick an arbitrary, previously unreceived acknowledgement on `chain`.
   /// - Call the `onAcknowledgePacket` callback on it.
   /// - Update the chain state to record the acknowledgement as received.

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -234,6 +234,17 @@ module ics20Test {
     }).setToMap()
   })
 
+  /// Return true iff there is a channel from `sourceChain` to `destChain` defined in `CHANNEL_TOPOLOGY`
+  /// that corresponds to the channel endpoints of `packet`.
+  pure def isTravelingBetween(packet: Packet, sourceChain: str, destChain: str): bool = all {
+    // there is a channel between `sourceChain` and `destChain`
+    CHANNEL_TOPOLOGY.keys().contains(sourceChain),
+    CHANNEL_TOPOLOGY.get(sourceChain).keys().contains(destChain),
+    // packet endpoints correspond to channel ends
+    channelCounterparties.get(sourceChain).keys().contains(packet.sourceChannel),
+    channelCounterparties.get(sourceChain).get(packet.sourceChannel) == packet.destChannel
+  }
+
   action init = {
     chainStates' = CHANNEL_TOPOLOGY.keys().mapBy(chain => {
       // All accounts are empty, except for Alice in chain A who has 100 atoms
@@ -276,38 +287,47 @@ module ics20Test {
   /// - Update the chain states to record the packet as received.
   /// - Record (but not receive) the acknowledgement produced by `onRecvPacket`
   ///   on `destChain`.
-  action receivePacket(sourceChain: str, destChain: str): bool = all {
-    // (1) Pre-condition:
-    // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
-    sourceChain != destChain,
-
-    // (2) Non-deterministically pick a packet from `sourceChain` to receive on `destChain`:
+  action receivePacket(sourceChain: str, destChain: str): bool =
     val sourceChainState = chainStates.get(sourceChain)
-    nondet packet = sourceChainState.outPackets.oneOf()
+    all {
+      // (1) Pre-condition:
+      // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
+      sourceChain != destChain,
+      // there is a channel between `sourceChain` and `destChain`
+      CHANNEL_TOPOLOGY.keys().contains(sourceChain),
+      CHANNEL_TOPOLOGY.get(sourceChain).keys().contains(destChain),
+      // there is an unreceived packet traveling from `sourceChain` to `destChain`
+      sourceChainState.outPackets.exists(packet => packet.isTravelingBetween(sourceChain, destChain)),
 
-    // (3) Compute updated destination chain state: call `onRecvPacket` callback:
-    val recvResult = onRecvPacket(chainStates.get(destChain), packet)
-    val newDestChainState = recvResult._1
-    val acknowledgement   = recvResult._2
+      // (2) Non-deterministically pick a packet from `sourceChain` to receive on `destChain`:
+      nondet packet = sourceChainState.outPackets.oneOf()
+      all {
+        packet.isTravelingBetween(sourceChain, destChain),
 
-    // (4) Compute updated source chain state:
-    // Update packet sets, moving `packet` from `outPackets` to `receivedButUnacknowledgedPackets`
-    // (this simulates ICS 4 exactly-once packet delivery)
-    val newSourceChainOutPackets = sourceChainState.outPackets.exclude(Set(packet))
-    val newSourceChainUnackPackets = sourceChainState.receivedButUnacknowledgedPackets.union(Set(packet))
-    // Update set `inAcknowledgements` to include the sent but (yet) unprocessed `acknowledgement`
-    val newSourceChainInAcknowledgements = sourceChainState.inAcknowledgements.union(Set(acknowledgement))
-    // Update source chain state with new packet/acknowledgement sets
-    val newSourceChainState   = sourceChainState
-                                      .with("outPackets", newSourceChainOutPackets)
-                                      .with("receivedButUnacknowledgedPackets", newSourceChainUnackPackets)
-                                      .with("inAcknowledgements", newSourceChainInAcknowledgements)
+        // (3) Compute updated destination chain state: call `onRecvPacket` callback:
+        val recvResult = onRecvPacket(chainStates.get(destChain), packet)
+        val newDestChainState = recvResult._1
+        val acknowledgement   = recvResult._2
 
-    // (5) Quint state transition:
-    chainStates' = chainStates
-                      .set(destChain, newDestChainState)
-                      .set(sourceChain, newSourceChainState)
-  }
+        // (4) Compute updated source chain state:
+        // Update packet sets, moving `packet` from `outPackets` to `receivedButUnacknowledgedPackets`
+        // (this simulates ICS 4 exactly-once packet delivery)
+        val newSourceChainOutPackets = sourceChainState.outPackets.exclude(Set(packet))
+        val newSourceChainUnackPackets = sourceChainState.receivedButUnacknowledgedPackets.union(Set(packet))
+        // Update set `inAcknowledgements` to include the sent but (yet) unprocessed `acknowledgement`
+        val newSourceChainInAcknowledgements = sourceChainState.inAcknowledgements.union(Set(acknowledgement))
+        // Update source chain state with new packet/acknowledgement sets
+        val newSourceChainState   = sourceChainState
+                                          .with("outPackets", newSourceChainOutPackets)
+                                          .with("receivedButUnacknowledgedPackets", newSourceChainUnackPackets)
+                                          .with("inAcknowledgements", newSourceChainInAcknowledgements)
+
+        // (5) Quint state transition:
+        chainStates' = chainStates
+                          .set(destChain, newDestChainState)
+                          .set(sourceChain, newSourceChainState)
+      }
+    }
 
   /// Receive an acknowledgement for `packet` on `chain`:
   /// - Pick an arbitrary, previously unreceived acknowledgement on `chain`.

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -19,11 +19,6 @@ module ics20 {
   type Height = int
 
   // IBC packet types
-  type FungibleTokenPacketAcknowledgement = {
-    success: bool,
-    errorMessage: str
-  }
-
   type FungibleTokenData = {
     denom: DenomTrace,
     amount: UINT256,
@@ -40,11 +35,19 @@ module ics20 {
     destChannel: Channel,
   }
 
+  type FungibleTokenPacketAcknowledgement = {
+    success: bool,
+    errorMessage: str,
+    packet: Packet  // the acknowledged packet
+  }
+
   /// State of the IBC module in a chain
   type ChainState = {
     bank: Accounts,
     channels: ChannelCounterparties,
     outPackets: Set[Packet],
+    receivedButUnacknowledgedPackets: Set[Packet],
+    inAcknowledgements: Set[FungibleTokenPacketAcknowledgement],
     channelEscrowAddresses: Channel -> Address,
   }
 
@@ -125,9 +128,9 @@ module ics20 {
 
     pure val newChainState = chainState.with("bank", bankResult.accounts)
     pure val ack = if (bankResult.success) {
-      { success: true, errorMessage: "" }
+      { success: true, errorMessage: "", packet: packet }
     } else {
-      { success: false, errorMessage: errorMessage }
+      { success: false, errorMessage: errorMessage, packet: packet }
     }
 
     (newChainState, ack)
@@ -148,7 +151,7 @@ module ics20 {
     pure val data: FungibleTokenData = packet.data
     pure val source: HopElement = { port: packet.sourcePort, channel: packet.sourceChannel }
     pure val bankResult =
-      if (movingBackAlongTrace(source, data.denom)) {
+      if (movingBackAlongTrace(data.denom, source)) {
         // The (failed) transfer attempt was moving the token back along its denom trace.
         // For this, we originally burnt vouchers in `sendFungibleTokens`, so mint them back.
         chainState.bank.MintCoins(data.sender, data.denom, data.amount)
@@ -237,7 +240,9 @@ module ics20Test {
       bank: if (chain == "A") Map("alice" -> Map(ATOM -> 100)) else Map(),
       channels: channelCounterparties.get(chain),
       channelEscrowAddresses: channelCounterparties.get(chain).keys().mapBy(_ => ESCROW_ACCOUNT),
-      outPackets: Set()
+      outPackets: Set(),
+      receivedButUnacknowledgedPackets: Set(),
+      inAcknowledgements: Set()
     })
   }
 
@@ -261,44 +266,78 @@ module ics20Test {
     chainStates' = chainStates.set(sourceChain, newSourceChainState)
   }
 
-  /// Receives a packet sent from `sourceChain` to `destChain`, and delivers
-  /// the acknowledgement back to `sourceChain`.
-  action receiveAndAckPacket(sourceChain: str, destChain: str): bool = all {
+  /// Receive a packet sent from `sourceChain` to `destChain`:
+  /// - Pick an arbitrary, previously unreceived packet sent from `sourceChain`
+  ///   to `destChain`.
+  /// - Call the `onRecvPacket` callback on it.
+  /// - Update the chain states to record the packet as received.
+  /// - Record (but not receive) the acknowledgement produced by `onRecvPacket`
+  ///   on `destChain`.
+  action receivePacket(sourceChain: str, destChain: str): bool = all {
     // (1) Pre-condition:
-    // ICS 4: "a channel is a pipeline for exactly-once packet delivery between specific modules on **separate** blockchains"
+    // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
     sourceChain != destChain,
 
-    // (2) Compute updated chain states:
+    // (2) Non-deterministically pick a packet from `sourceChain` to receive on `destChain`:
     val sourceChainState = chainStates.get(sourceChain)
-    // non-deterministically pick a packet from `sourceChain` to receive on `destChain`
     nondet packet = sourceChainState.outPackets.oneOf()
-    // call the `onRecvPacket` callback
+
+    // (3) Compute updated destination chain state: call `onRecvPacket` callback:
     val recvResult = onRecvPacket(chainStates.get(destChain), packet)
     val newDestChainState = recvResult._1
     val acknowledgement   = recvResult._2
-    // deliver the acknowledgement on `sourceChain`, clean up the sent packet
-    // TODO(thpani): split this into a separate action
-    val newSourceChainPackets = sourceChainState.outPackets.exclude(Set(packet))
-    val newSourceChainState   = onAcknowledgePacket(sourceChainState, packet, acknowledgement)
-                                      .with("outPackets", newSourceChainPackets)
 
-    // (3) Quint state transition:
+    // (4) Compute updated source chain state:
+    // Update packet sets, moving `packet` from `outPackets` to `receivedButUnacknowledgedPackets`
+    // (this simulates ICS 4 exactly-once packet delivery)
+    val newSourceChainOutPackets = sourceChainState.outPackets.exclude(Set(packet))
+    val newSourceChainUnackPackets = sourceChainState.receivedButUnacknowledgedPackets.union(Set(packet))
+    // Update set `inAcknowledgements` to include the sent but (yet) unprocessed `acknowledgement`
+    val newSourceChainInAcknowledgements = sourceChainState.inAcknowledgements.union(Set(acknowledgement))
+    // Update source chain state with new packet/acknowledgement sets
+    val newSourceChainState   = sourceChainState
+                                      .with("outPackets", newSourceChainOutPackets)
+                                      .with("receivedButUnacknowledgedPackets", newSourceChainUnackPackets)
+                                      .with("inAcknowledgements", newSourceChainInAcknowledgements)
+
+    // (5) Quint state transition:
     chainStates' = chainStates
                       .set(destChain, newDestChainState)
                       .set(sourceChain, newSourceChainState)
   }
 
-  /// Send `amount`-many `denom` tokens from `sender` in `sourceChain` to
-  /// `receiver` in `destChain`.
+  /// Receive an acknowledgement for `packet` on `chain`:
+  /// - Pick an arbitrary, previously unreceived acknowledgement on `chain`.
+  /// - Call the `onAcknowledgePacket` callback on it.
+  /// - Update the chain state to record the acknowledgement as received.
+  action receiveAck(chain: str): bool = all {
+    // (1) Compute updated chain state:
+    // non-deterministically pick an acknowledgement
+    val chainState = chainStates.get(chain)
+    nondet acknowledgement = chainState.inAcknowledgements.oneOf()
+    // call the `onAcknowledgePacket` callback and
+    val ackedChainState = onAcknowledgePacket(chainState, acknowledgement.packet, acknowledgement)
+    // remove `ack` from incoming acknowledgements
+    val newInAcknowledgements = chainState.inAcknowledgements.exclude(Set(acknowledgement))
+    val newChainState = ackedChainState.with("inAcknowledgements", newInAcknowledgements)
+
+    // (2) Quint state transition:
+    chainStates' = chainStates.set(chain, newChainState)
+  }
+
+  /// Send `amount`-many `denom` tokens from `sender` on `sourceChain` to
+  /// `receiver` on `destChain`.
   ///
-  /// This is a composition of two actions: one that sends the packet from
-  /// `sourceChain` and another that receives the packet in `destChain` and
-  /// returns an acknowldgement to `sourceChain`.
+  /// This is a composition of three actions:
+  /// 1. sends the packet from `sourceChain` to `destChain`,
+  /// 2. receives the packet on `destChain` and produces an acknowledgement, and
+  /// 3. receives and processes the acknowledgement on `sourceChain`.
   run sendTransfer(denom: DenomTrace, amount: UINT256, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
-    all {
       sendPacket(sourceChain, destChain, denom, amount, sender, receiver)
-    }).then(
-      receiveAndAckPacket(sourceChain, destChain)
+    ).then(
+      receivePacket(sourceChain, destChain)
+    ).then(
+      receiveAck(sourceChain)
     )
 
   /****************************************************************************
@@ -353,7 +392,8 @@ module ics20Test {
   //
   // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
   // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
-  // 3. Transfer the 50 tokens back from Bob to Alice.
+  //    This will provoke the transfer below to produce a failed acknowledgement.
+  // 3. Try to transfer the 50 tokens back from Bob to Alice.
   //    3.1 First, this burns Bob's 50 vouchers on chain B, and sends a packet to chain A.
   //    3.2 Receipt of the packet on chain A calls the `onRecvPacket` callback.
   //    3.3 `onRecvPacket` calls the bank module's `TransferCoins` to unescrow 50 tokens to Alice.
@@ -386,12 +426,29 @@ module ics20Test {
       assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
       assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
 
-      // 3. Transfer the 50 tokens back from Bob to Alice.
-      sendTransfer(voucherDenom, 50, "B", "A", "bob", "alice")
+      // 3. Try to transfer the 50 tokens back from Bob to Alice.
+      // Send and receive the ICS 20 packet; this triggers steps 3.1–3.5 above.
+      sendPacket("B", "A", voucherDenom, 50, "bob", "alice").then(receivePacket("B", "A"))
   }).then(
     pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     all {
-      // Assert that the vouchers have been minted back
+      // Check that bob's vouchers were burned – nothing changed on chain A
+      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
+      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
+      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 0),
+
+      // Check that there is a single incoming acknowledgement on chain A,
+      // that indicates failure.
+      assert(chainStates.get("B").inAcknowledgements.size() == 1),
+      val ack = chainStates.get("B").inAcknowledgements.oneOf()
+      assert(ack.success == false and ack.errorMessage == "transfer coins failed"),
+
+      // Process the acknowledgement on chain A; this triggers step 3.6 above.
+      receiveAck("B")
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      // Check that bob's vouchers were minted back – nothing changed on chain A
       assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
       assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
       assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -317,7 +317,7 @@ module ics20Test {
     nondet acknowledgement = chainState.inAcknowledgements.oneOf()
     // call the `onAcknowledgePacket` callback and
     val ackedChainState = onAcknowledgePacket(chainState, acknowledgement.packet, acknowledgement)
-    // remove `ack` from incoming acknowledgements
+    // remove `acknowledgement` from incoming acknowledgements
     val newInAcknowledgements = chainState.inAcknowledgements.exclude(Set(acknowledgement))
     val newChainState = ackedChainState.with("inAcknowledgements", newInAcknowledgements)
 

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -225,6 +225,26 @@ module ics20Test {
     })
   }
 
+  /// Send a packet from `sourceChain` to `destChain`, indicating a transfer
+  /// of `amount`-many tokens of `denom` from `sender` to `receiver`.
+  action sendPacket(sourceChain: str, destChain: str,
+                    denom: DenomTrace, amount: UINT256,
+                    sender: Address, receiver: Address): bool = all {
+    // (1) Pre-condition:
+    // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
+    sourceChain != destChain,
+
+    // (2) Send the packet using `sendFungibleTokens`:
+    val sourceChainState = chainStates.get(sourceChain)
+    val newSourceChainState = sendFungibleTokens(sourceChainState, denom, amount,
+                                                 sender, receiver,
+                                                 "transfer", channelTopology.get(sourceChain).get(destChain),
+                                                 0, 0)
+
+    // (3) Quint state transition:
+    chainStates' = chainStates.set(sourceChain, newSourceChainState)
+  }
+
   /// Receives a packet sent from `sourceChain` to `destChain`, and delivers
   /// the acknowledgement back to `sourceChain`.
   action receiveAndAckPacket(sourceChain: str, destChain: str): bool = all {
@@ -260,8 +280,7 @@ module ics20Test {
   /// returns an acknowldgement to `sourceChain`.
   run sendTransfer(denom: DenomTrace, amount: UINT256, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
     all {
-      val result = sendFungibleTokens(chainStates.get(sourceChain), denom, amount, sender, receiver, "transfer", channelTopology.get(sourceChain).get(destChain), 0, 0)
-      chainStates' = chainStates.set(sourceChain, result),
+      sendPacket(sourceChain, destChain, denom, amount, sender, receiver)
     }).then(
       receiveAndAckPacket(sourceChain, destChain)
     )

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -1,7 +1,8 @@
 // -*- mode: Bluespec; -*-
 
 /**
- * A specification for the ICS20 fungible token transfer protocol.
+ * A specification for the ICS20 fungible token transfer protocol:
+ * https://github.com/cosmos/ibc/tree/main/spec/app/ics-020-fungible-token-transfer
  *
  * Gabriela Moreira and Thomas Pani, Informal Systems, 2023
  */

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -164,6 +164,13 @@ module ics20 {
       refundTokens(chainState, packet)
     }
   }
+
+  /// Called by the routing module when a packet sent by this module has timed out
+  /// (such that it will not be received on the destination chain).
+  pure def onTimeoutPacket(chainState: ChainState, packet: Packet): ChainState = {
+    // the packet timed out, so refund the tokens
+    refundTokens(chainState, packet)
+  }
 }
 
 module ics20Test {
@@ -353,4 +360,6 @@ module ics20Test {
       // noop
       chainStates' = chainStates
   })
+
+  // TODO(thpani): add a test for packet timeout
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -184,30 +184,35 @@ module ics20Test {
     }
   }
 
-  /// Sends 1 `denom` token from `sender` in `sourceChain` to `receiver` in
-  /// `destChain`. This is a composition of two actions: one that sends the
-  /// packet from `sourceChain` and other that receives the packet in `destChain`
-  run sendTransfer(denom: DenomTrace, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
+  /// Send `amount`-many `denom` tokens from `sender` in `sourceChain` to
+  /// `receiver` in `destChain`.
+  ///
+  /// This is a composition of two actions: one that sends the packet from
+  /// `sourceChain` and another that receives the packet in `destChain` and
+  /// returns an acknowldgement to `sourceChain`.
+  run sendTransfer(denom: DenomTrace, amount: UINT256, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
     all {
-      val result = sendFungibleTokens(chainStates.get(sourceChain), denom, 1, sender, receiver, "transfer", channelTopology.get(sourceChain).get(destChain), 0, 0)
+      val result = sendFungibleTokens(chainStates.get(sourceChain), denom, amount, sender, receiver, "transfer", channelTopology.get(sourceChain).get(destChain), 0, 0)
       chainStates' = chainStates.set(sourceChain, result),
     }).then(
       receivePacket(sourceChain, destChain)
     )
 
-  // These steps of transfer occur: A -> B -> C -> A -> C -> B -> A
-  run ABCACBATest = init.then(
-    sendTransfer(ATOM, "A", "B", "alice", "bob")
-  ).then(
+  // Transfer a single token across these chains: A -> B -> C -> A -> C -> B -> A
+  // All transfers are acknowledged as successful.
+  run ABCACBATest = init.then(all {
+    assert(chainStates.get("A").bank.get("alice").get(ATOM) == 100),
+    sendTransfer(ATOM, 1, "A", "B", "alice", "bob")
+  }).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
-    sendTransfer(denom, "B", "C", "bob", "charlie")
+    sendTransfer(denom, 1,  "B", "C", "bob", "charlie")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToB" },
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, "C", "A", "charlie", "alice")
+    sendTransfer(denom, 1, "C", "A", "charlie", "alice")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToC" },
@@ -215,20 +220,20 @@ module ics20Test {
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, "A", "C", "alice", "bob")
+    sendTransfer(denom, 1, "A", "C", "alice", "bob")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToB" },
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, "C", "B", "bob", "charlie")
+    sendTransfer(denom, 1, "C", "B", "bob", "charlie")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, "B", "A", "charlie", "darwin")
+    sendTransfer(denom, 1, "B", "A", "charlie", "darwin")
   ).then(all {
       assert(chainStates.get("A").bank.get("alice").get(ATOM) == 99),
       assert(chainStates.get("A").bank.get("darwin").get(ATOM) == 1),

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -332,7 +332,7 @@ module ics20Test {
   /// 1. sends the packet from `sourceChain` to `destChain`,
   /// 2. receives the packet on `destChain` and produces an acknowledgement, and
   /// 3. receives and processes the acknowledgement on `sourceChain`.
-  run sendTransfer(denom: DenomTrace, amount: UINT256, sourceChain: str, destChain: str, sender: Address, receiver: Address): bool = (
+  run sendTransfer(sourceChain: str, destChain: str, denom: DenomTrace, amount: UINT256, sender: Address, receiver: Address): bool = (
       sendPacket(sourceChain, destChain, denom, amount, sender, receiver)
     ).then(
       receivePacket(sourceChain, destChain)
@@ -348,17 +348,17 @@ module ics20Test {
   // All transfers are acknowledged as successful.
   run ABCACBATest = init.then(all {
     assert(chainStates.get("A").bank.get("alice").get(ATOM) == 100),
-    sendTransfer(ATOM, 1, "A", "B", "alice", "bob")
+    sendTransfer("A", "B", ATOM, 1, "alice", "bob")
   }).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
-    sendTransfer(denom, 1,  "B", "C", "bob", "charlie")
+    sendTransfer("B", "C", denom, 1, "bob", "charlie")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToB" },
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, 1, "C", "A", "charlie", "alice")
+    sendTransfer("C", "A", denom, 1, "charlie", "alice")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToC" },
@@ -366,20 +366,20 @@ module ics20Test {
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, 1, "A", "C", "alice", "bob")
+    sendTransfer("A", "C", denom, 1, "alice", "bob")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToB" },
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, 1, "C", "B", "bob", "charlie")
+    sendTransfer("C", "B", denom, 1, "bob", "charlie")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [
       { port: "transfer", channel: "channelToA" }
     ] }
 
-    sendTransfer(denom, 1, "B", "A", "charlie", "darwin")
+    sendTransfer("B", "A", denom, 1, "charlie", "darwin")
   ).then(all {
       assert(chainStates.get("A").bank.get("alice").get(ATOM) == 99),
       assert(chainStates.get("A").bank.get("darwin").get(ATOM) == 1),
@@ -406,7 +406,7 @@ module ics20Test {
     assert(chainStates.get("B").bank.getBalances("bob").getBalance(ATOM) == 0),
 
     // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
-    sendTransfer(ATOM, 50, "A", "B", "alice", "bob")
+    sendTransfer("A", "B", ATOM, 50, "alice", "bob")
   }).then(
     pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     all {

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -11,9 +11,9 @@ module ics20 {
   import bank.* from "./bank"
   import denomTrace.* from "./denomTrace"
 
-  /* ***************************************************************************
+  /****************************************************************************
    * TYPES
-   * **************************************************************************/
+   ***************************************************************************/
 
   // Fundamental types
   type Height = int
@@ -48,11 +48,23 @@ module ics20 {
     channelEscrowAddresses: Channel -> Address,
   }
 
+  /****************************************************************************
+   * FUNCTIONAL LAYER
+   ***************************************************************************/
+
+  /****************************/
+  /*     helper functions     */
+  /****************************/
+
   /// The counterparty for a channel `C` in a chain is the channel identifier of
   /// the channel `C` connects to, in the other chain.
   pure def getCounterparty(chainState: ChainState, sourceChannel: Channel): Channel = {
     chainState.channels.get(sourceChannel)
   }
+
+  /****************************/
+  /*     public interface     */
+  /****************************/
 
   pure def sendFungibleTokens(chainState: ChainState, denomination: DenomTrace, amount: UINT256,
                               sender: Address, receiver: Address, sourcePort: str, sourceChannel: Channel,
@@ -179,6 +191,10 @@ module ics20Test {
   import bank.getBalances from "./bank"
   import ics20.*
 
+  /****************************************************************************
+   * STATE MACHINE
+   ***************************************************************************/
+
   /// Map from chain identifiers to their state
   var chainStates: str -> ChainState
 
@@ -284,6 +300,10 @@ module ics20Test {
     }).then(
       receiveAndAckPacket(sourceChain, destChain)
     )
+
+  /****************************************************************************
+   * TESTS
+   ***************************************************************************/
 
   // Transfer a single token across these chains: A -> B -> C -> A -> C -> B -> A
   // All transfers are acknowledged as successful.

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -146,6 +146,9 @@ module ics20Test {
     )
   )
 
+  pure val ATOM = toDenom("atom")
+  pure val ESCROW_ACCOUNT = "escrow_account"
+
   /// For each chain, a map from channel to their channel counterparties,
   /// derived from `channelTopology`. For example, in chain A, channel "channelToB"
   /// has the counterparty "channelToA".
@@ -161,9 +164,9 @@ module ics20Test {
   action init = {
     chainStates' = channelTopology.keys().mapBy(chain => {
       // All accounts are empty, except for Alice in chain A who has 100 atoms
-      bank: if (chain == "A") Map("alice" -> Map(toDenom("atom") -> 100)) else Map(),
+      bank: if (chain == "A") Map("alice" -> Map(ATOM -> 100)) else Map(),
       channels: channelCounterparties.get(chain),
-      channelEscrowAddresses: channelCounterparties.get(chain).keys().mapBy(_ => "escrow_account"),
+      channelEscrowAddresses: channelCounterparties.get(chain).keys().mapBy(_ => ESCROW_ACCOUNT),
       outPackets: Set()
     })
   }
@@ -193,7 +196,7 @@ module ics20Test {
 
   // These steps of transfer occur: A -> B -> C -> A -> C -> B -> A
   run ABCACBATest = init.then(
-    sendTransfer(toDenom("atom"), "A", "B", "alice", "bob")
+    sendTransfer(ATOM, "A", "B", "alice", "bob")
   ).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     sendTransfer(denom, "B", "C", "bob", "charlie")
@@ -226,8 +229,8 @@ module ics20Test {
 
     sendTransfer(denom, "B", "A", "charlie", "darwin")
   ).then(all {
-      assert(chainStates.get("A").bank.get("alice").get(toDenom("atom")) == 99),
-      assert(chainStates.get("A").bank.get("darwin").get(toDenom("atom")) == 1),
+      assert(chainStates.get("A").bank.get("alice").get(ATOM) == 99),
+      assert(chainStates.get("A").bank.get("darwin").get(ATOM) == 1),
 
       chainStates' = chainStates,
     }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -303,10 +303,10 @@ module ics20Test {
       sourceChainState.outPackets.exists(packet => packet.isTravelingBetween(sourceChain, destChain)),
 
       // (2) Non-deterministically pick a packet from `sourceChain` to receive on `destChain`:
-      nondet packet = sourceChainState.outPackets.oneOf()
+      nondet packet = sourceChainState.outPackets
+                                  .filter(p => p.isTravelingBetween(sourceChain, destChain))
+                                  .oneOf()
       all {
-        packet.isTravelingBetween(sourceChain, destChain),
-
         // (3) Compute updated destination chain state: call `onRecvPacket` callback:
         val recvResult = onRecvPacket(chainStates.get(destChain), packet)
         val newDestChainState = recvResult._1

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -192,6 +192,7 @@ module ics20Test {
   import base.* from "./base"
   import bank.getBalance from "./bank"
   import bank.getBalances from "./bank"
+  import basicSpells.has from "../../spells/basicSpells"
   import ics20.*
 
   /****************************************************************************
@@ -238,10 +239,10 @@ module ics20Test {
   /// that corresponds to the channel endpoints of `packet`.
   pure def isTravelingBetween(packet: Packet, sourceChain: str, destChain: str): bool = all {
     // there is a channel between `sourceChain` and `destChain`
-    CHANNEL_TOPOLOGY.keys().contains(sourceChain),
-    CHANNEL_TOPOLOGY.get(sourceChain).keys().contains(destChain),
+    CHANNEL_TOPOLOGY.has(sourceChain),
+    CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
     // packet endpoints correspond to channel ends
-    channelCounterparties.get(sourceChain).keys().contains(packet.sourceChannel),
+    channelCounterparties.get(sourceChain).has(packet.sourceChannel),
     channelCounterparties.get(sourceChain).get(packet.sourceChannel) == packet.destChannel
   }
 
@@ -266,8 +267,8 @@ module ics20Test {
     // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
     sourceChain != destChain,
     // there is a channel between `sourceChain` and `destChain`
-    CHANNEL_TOPOLOGY.keys().contains(sourceChain),
-    CHANNEL_TOPOLOGY.get(sourceChain).keys().contains(destChain),
+    CHANNEL_TOPOLOGY.has(sourceChain),
+    CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
 
     // (2) Send the packet using `sendFungibleTokens`:
     val sourceChainState = chainStates.get(sourceChain)
@@ -294,8 +295,8 @@ module ics20Test {
       // ICS 4: "a channel is a pipeline [...] between specific modules on **separate** blockchains"
       sourceChain != destChain,
       // there is a channel between `sourceChain` and `destChain`
-      CHANNEL_TOPOLOGY.keys().contains(sourceChain),
-      CHANNEL_TOPOLOGY.get(sourceChain).keys().contains(destChain),
+      CHANNEL_TOPOLOGY.has(sourceChain),
+      CHANNEL_TOPOLOGY.get(sourceChain).has(destChain),
       // there is an unreceived packet traveling from `sourceChain` to `destChain`
       sourceChainState.outPackets.exists(packet => packet.isTravelingBetween(sourceChain, destChain)),
 


### PR DESCRIPTION
Towards https://github.com/informalsystems/apalache-team-services/issues/8

Handle failed acknowledgements in the ICS-20 spec:
- Add `refundTokens`, `onAcknowledgePacket`, `onTimeoutPacket` definitions from ICS 20
- Update the `receivePacket` action to produce an acknowledgement
- Add a `receiveAck` action to receive an in-flight acknowledgement on the source chain
- Add a test provoking a failed acknowledgement

This PR is interspersed with various refactorings, but they are isolated to principled separate commits.

Since this has grown a lot, I will add the timeout action + test in a separate PR.