### PR TITLE
Add LSP handler for `textDocument/documentSymbol`

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- Add support for outline view (#864)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/vscode/quint-vscode/server/src/documentSymbols.ts
+++ b/vscode/quint-vscode/server/src/documentSymbols.ts
@@ -1,0 +1,78 @@
+
+import {
+  DocumentSymbol,
+  SymbolKind
+} from 'vscode-languageserver/node'
+
+import {
+  Loc,
+  QuintConst,
+  QuintModule,
+  QuintOpDef,
+  QuintVar
+} from '@informalsystems/quint'
+import { locToRange } from './reporting'
+
+/**
+ * Get VSCode `SymbolKind` of a Quint def
+ */
+function symbolKind(def: QuintOpDef | QuintConst | QuintVar): SymbolKind {
+  switch (def.kind) {
+    case 'def':
+      return SymbolKind.Function
+    case 'const':
+      return SymbolKind.Constant
+    case 'var':
+      return SymbolKind.Variable
+  }
+}
+
+/**
+ * Return the def symbols defined in a module
+ */
+function getDefs(module: QuintModule, sourceMap: Map<bigint, Loc>) : DocumentSymbol[] {
+  return module.defs.reduce((symbols, def) => {
+    // skip certain kinds of defs
+    if (def.kind === 'assume' || def.kind === 'instance' || def.kind === 'import' ||
+        def.kind === 'export' || def.kind === 'typedef') {
+      return symbols
+    }
+    const loc = sourceMap.get(def.id)
+    if (!loc) {
+      return symbols
+    }
+    const range = locToRange(loc)
+    symbols.push({
+      name: def.name,
+      kind: symbolKind(def),
+      range: range,
+      selectionRange: range,
+    })
+    return symbols
+  }, [] as DocumentSymbol[])
+}
+
+/**
+ * Return all module symbols
+ */
+function getModules(modules: QuintModule[], sourceMap: Map<bigint, Loc>): DocumentSymbol[] {
+  return modules.reduce((symbols, module) => {
+    const loc = sourceMap.get(module.id)
+    if (!loc) {
+      return symbols
+    }
+    const range = locToRange(loc)
+    symbols.push({
+      name: module.name,
+      kind: SymbolKind.Module,
+      range: range,
+      selectionRange: range,
+      children: getDefs(module, sourceMap),
+    })
+    return symbols
+  }, [] as DocumentSymbol[])
+}
+
+export function getDocumentSymbols(modules: QuintModule[], sourceMap: Map<bigint, Loc>): DocumentSymbol[] {
+  return getModules(modules, sourceMap)
+}

--- a/vscode/quint-vscode/server/src/documentSymbols.ts
+++ b/vscode/quint-vscode/server/src/documentSymbols.ts
@@ -13,6 +13,10 @@ import {
 } from '@informalsystems/quint'
 import { locToRange } from './reporting'
 
+export function getDocumentSymbols(modules: QuintModule[], sourceMap: Map<bigint, Loc>): DocumentSymbol[] {
+  return getModules(modules, sourceMap)
+}
+
 /**
  * Get VSCode `SymbolKind` of a Quint def
  */
@@ -71,8 +75,4 @@ function getModules(modules: QuintModule[], sourceMap: Map<bigint, Loc>): Docume
     })
     return symbols
   }, [] as DocumentSymbol[])
-}
-
-export function getDocumentSymbols(modules: QuintModule[], sourceMap: Map<bigint, Loc>): DocumentSymbol[] {
-  return getModules(modules, sourceMap)
 }


### PR DESCRIPTION
I needed a little side project, and since I keep getting lost in the ICS-20 spec:
this adds an LSP endpoint to populate VSCode's outline view

<img width="188" alt="Screenshot 2023-05-05 at 08 16 43" src="https://user-images.githubusercontent.com/82047/236389376-6d279124-9ad0-4c12-8e4f-7b83d7ffdc4b.png">

Not sure if there's a meaningful way to test this.

- [ ] Tests added for any new code
- [x] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
