### PR TITLE
ICS20 test based on `transfer_test.go`

### DIFF
--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -257,7 +257,7 @@ module ics20Test {
 
   /* Helper operators to manipulate bank state */
   /// Sets the balance of `account` in `chain` to `amount` of `denom`.
-  action SetBalanceIn(chain, account, denom, amount) = {
+  action setBalanceIn(chain, account, denom, amount) = {
     chainStates' = chainStates.setBy(chain, state =>
       state.with("bank", state.bank.setBy(account, balances => balances.set(denom, amount)))
     )
@@ -426,74 +426,6 @@ module ics20Test {
     }
   )
 
-  // Test producing a failed acknowledgement:
-  //
-  // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
-  // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
-  //    This will provoke the transfer below to produce a failed acknowledgement.
-  // 3. Try to transfer the 50 tokens back from Bob to Alice.
-  //    3.1 First, this burns Bob's 50 vouchers on chain B, and sends a packet to chain A.
-  //    3.2 Receipt of the packet on chain A calls the `onRecvPacket` callback.
-  //    3.3 `onRecvPacket` calls the bank module's `TransferCoins` to unescrow 50 tokens to Alice.
-  //    3.4 `TransferCoins` returns an error, because -- after manipulating it in (2) -- the escrow account has insufficient funds.
-  //    3.5 The bank module error causes `onRecvPacket` to return a failed acknowledgement.
-  //    3.6 `onAcknowledgePacket` on chain "B" re-mints the burned vouchers to Bob.
-  run FailedAckTest = init.then(all {
-    assert(getBalanceIn("A", "alice", ATOM) == 100),
-    assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 0),
-    assert(getBalanceIn("B", "bob", ATOM) == 0),
-
-    // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
-    sendTransfer("A", "B", ATOM, 50, "alice", "bob")
-  }).then(
-    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
-    all {
-      assert(getBalanceIn("A", "alice", ATOM) == 50),
-      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 50),
-      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
-
-      // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
-      SetBalanceIn("A", ESCROW_ACCOUNT, ATOM, 49)
-  }).then(
-    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
-    all {
-      assert(getBalanceIn("A", "alice", ATOM) == 50),
-      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
-      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
-
-      // 3. Try to transfer the 50 tokens back from Bob to Alice.
-      // Send and receive the ICS 20 packet; this triggers steps 3.1–3.5 above.
-      sendPacket("B", "A", voucherDenom, 50, "bob", "alice").then(receivePacket("B", "A"))
-  }).then(
-    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
-    all {
-      // Check that bob's vouchers were burned – nothing changed on chain A
-      assert(getBalanceIn("A", "alice", ATOM) == 50),
-      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
-      assert(getBalanceIn("B", "bob", voucherDenom) == 0),
-
-      // Check that there is a single incoming acknowledgement on chain A,
-      // that indicates failure.
-      assert(chainStates.get("B").inAcknowledgements.size() == 1),
-      val ack = chainStates.get("B").inAcknowledgements.oneOf()
-      assert(ack.success == false and ack.errorMessage == "transfer coins failed"),
-
-      // Process the acknowledgement on chain A; this triggers step 3.6 above.
-      receiveAck("B")
-  }).then(
-    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
-    all {
-      // Check that bob's vouchers were minted back – nothing changed on chain A
-      assert(getBalanceIn("A", "alice", ATOM) == 50),
-      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
-      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
-
-      // noop
-      chainStates' = chainStates
-  })
-
-  // TODO(thpani): add a test for packet timeout
-
   // From
   // https://github.com/cosmos/ibc-go/blob/a25f0d421c32b3a2b7e8168c9f030849797ff2e8/modules/apps/transfer/transfer_test.go#L44
   run TransferTest = {
@@ -506,7 +438,7 @@ module ics20Test {
     init.then(
       // Make sure that Alice has enough tokens on chain A. In the go test, this
       // is implicitly done somewhere in the test environment setup.
-      SetBalanceIn("A", "alice", ATOM, amount)
+      setBalanceIn("A", "alice", ATOM, amount)
     ).then(
       sendTransfer("A", "B", ATOM, amount, "alice", "bob")
     ).then(all {
@@ -549,4 +481,72 @@ module ics20Test {
       chainStates' = chainStates
     })
   }
+
+  // Test producing a failed acknowledgement:
+  //
+  // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
+  // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
+  //    This will provoke the transfer below to produce a failed acknowledgement.
+  // 3. Try to transfer the 50 tokens back from Bob to Alice.
+  //    3.1 First, this burns Bob's 50 vouchers on chain B, and sends a packet to chain A.
+  //    3.2 Receipt of the packet on chain A calls the `onRecvPacket` callback.
+  //    3.3 `onRecvPacket` calls the bank module's `TransferCoins` to unescrow 50 tokens to Alice.
+  //    3.4 `TransferCoins` returns an error, because -- after manipulating it in (2) -- the escrow account has insufficient funds.
+  //    3.5 The bank module error causes `onRecvPacket` to return a failed acknowledgement.
+  //    3.6 `onAcknowledgePacket` on chain "B" re-mints the burned vouchers to Bob.
+  run FailedAckTest = init.then(all {
+    assert(getBalanceIn("A", "alice", ATOM) == 100),
+    assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 0),
+    assert(getBalanceIn("B", "bob", ATOM) == 0),
+
+    // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
+    sendTransfer("A", "B", ATOM, 50, "alice", "bob")
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 50),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
+
+      // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
+      setBalanceIn("A", ESCROW_ACCOUNT, ATOM, 49)
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
+
+      // 3. Try to transfer the 50 tokens back from Bob to Alice.
+      // Send and receive the ICS 20 packet; this triggers steps 3.1–3.5 above.
+      sendPacket("B", "A", voucherDenom, 50, "bob", "alice").then(receivePacket("B", "A"))
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      // Check that bob's vouchers were burned – nothing changed on chain A
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 0),
+
+      // Check that there is a single incoming acknowledgement on chain A,
+      // that indicates failure.
+      assert(chainStates.get("B").inAcknowledgements.size() == 1),
+      val ack = chainStates.get("B").inAcknowledgements.oneOf()
+      assert(ack.success == false and ack.errorMessage == "transfer coins failed"),
+
+      // Process the acknowledgement on chain A; this triggers step 3.6 above.
+      receiveAck("B")
+  }).then(
+    pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
+    all {
+      // Check that bob's vouchers were minted back – nothing changed on chain A
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
+
+      // noop
+      chainStates' = chainStates
+  })
+
+  // TODO(thpani): add a test for packet timeout
 }

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -255,6 +255,19 @@ module ics20Test {
     channelCounterparties.get(sourceChain).get(packet.sourceChannel) == packet.destChannel
   }
 
+  /* Helper operators to manipulate bank state */
+  /// Sets the balance of `account` in `chain` to `amount` of `denom`.
+  action SetBalanceIn(chain, account, denom, amount) = {
+    chainStates' = chainStates.setBy(chain, state =>
+      state.with("bank", state.bank.setBy(account, balances => balances.set(denom, amount)))
+    )
+  }
+
+  /// Gets the balance of `account` in `chain` of `denom`.
+  def getBalanceIn(chain, account, denom) = {
+    chainStates.get(chain).bank.getBalances(account).getBalance(denom)
+  }
+
   action init = {
     chainStates' = CHANNEL_TOPOLOGY.keys().mapBy(chain => {
       // All accounts are empty, except for Alice in chain A who has 100 atoms
@@ -372,7 +385,7 @@ module ics20Test {
   // Transfer a single token across these chains: A -> B -> C -> A -> C -> B -> A
   // All transfers are acknowledged as successful.
   run ABCACBATest = init.then(all {
-    assert(chainStates.get("A").bank.get("alice").get(ATOM) == 100),
+    assert(getBalanceIn("A", "alice", ATOM) == 100),
     sendTransfer("A", "B", ATOM, 1, "alice", "bob")
   }).then(
     pure val denom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
@@ -406,8 +419,8 @@ module ics20Test {
 
     sendTransfer("B", "A", denom, 1, "charlie", "darwin")
   ).then(all {
-      assert(chainStates.get("A").bank.get("alice").get(ATOM) == 99),
-      assert(chainStates.get("A").bank.get("darwin").get(ATOM) == 1),
+      assert(getBalanceIn("A", "alice", ATOM) == 99),
+      assert(getBalanceIn("A", "darwin", ATOM) == 1),
 
       chainStates' = chainStates,
     }
@@ -426,30 +439,27 @@ module ics20Test {
   //    3.5 The bank module error causes `onRecvPacket` to return a failed acknowledgement.
   //    3.6 `onAcknowledgePacket` on chain "B" re-mints the burned vouchers to Bob.
   run FailedAckTest = init.then(all {
-    assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 100),
-    assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 0),
-    assert(chainStates.get("B").bank.getBalances("bob").getBalance(ATOM) == 0),
+    assert(getBalanceIn("A", "alice", ATOM) == 100),
+    assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 0),
+    assert(getBalanceIn("B", "bob", ATOM) == 0),
 
     // 1. Transfer 50 tokens from Alice on chain A to Bob on chain B.
     sendTransfer("A", "B", ATOM, 50, "alice", "bob")
   }).then(
     pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     all {
-      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
-      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 50),
-      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 50),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
 
       // 2. Manipulate the escrow account on chain A, to contain less than 50 tokens.
-      val chainState = chainStates.get("A")
-      val manipulatedEscrowAccount = chainState.bank.get(ESCROW_ACCOUNT).set(ATOM, 49)
-      val manipulatedBank = chainState.bank.set(ESCROW_ACCOUNT, manipulatedEscrowAccount)
-      chainStates' = chainStates.set("A", chainState.with("bank", manipulatedBank))
+      SetBalanceIn("A", ESCROW_ACCOUNT, ATOM, 49)
   }).then(
     pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     all {
-      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
-      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
-      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
 
       // 3. Try to transfer the 50 tokens back from Bob to Alice.
       // Send and receive the ICS 20 packet; this triggers steps 3.1–3.5 above.
@@ -458,9 +468,9 @@ module ics20Test {
     pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     all {
       // Check that bob's vouchers were burned – nothing changed on chain A
-      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
-      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
-      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 0),
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 0),
 
       // Check that there is a single incoming acknowledgement on chain A,
       // that indicates failure.
@@ -474,13 +484,15 @@ module ics20Test {
     pure val voucherDenom: DenomTrace = { baseDenom: "atom", path: [{ port: "transfer", channel: "channelToA" }] }
     all {
       // Check that bob's vouchers were minted back – nothing changed on chain A
-      assert(chainStates.get("A").bank.getBalances("alice").getBalance(ATOM) == 50),
-      assert(chainStates.get("A").bank.getBalances(ESCROW_ACCOUNT).getBalance(ATOM) == 49),
-      assert(chainStates.get("B").bank.getBalances("bob").getBalance(voucherDenom) == 50),
+      assert(getBalanceIn("A", "alice", ATOM) == 50),
+      assert(getBalanceIn("A", ESCROW_ACCOUNT, ATOM) == 49),
+      assert(getBalanceIn("B", "bob", voucherDenom) == 50),
 
       // noop
       chainStates' = chainStates
   })
+
+  // TODO(thpani): add a test for packet timeout
 
   // From
   // https://github.com/cosmos/ibc-go/blob/a25f0d421c32b3a2b7e8168c9f030849797ff2e8/modules/apps/transfer/transfer_test.go#L44
@@ -492,25 +504,25 @@ module ics20Test {
     pure val denomSentFromAToB = denomInA.with("path", [{ port: "transfer", channel: "channelToA" }].concat(denomInA.path))
     pure val denomSentFromBToC = denomSentFromAToB.with("path", [{ port: "transfer", channel: "channelToB" }].concat(denomSentFromAToB.path))
     init.then(
-      // Make sure that Alice has enough tokens on chain A. I did not understand
-      // how this is done in the go test.
-      chainStates' = chainStates.setBy("A", state => state.with("bank", state.bank.setBy("alice", balances => balances.set(ATOM, amount))))
+      // Make sure that Alice has enough tokens on chain A. In the go test, this
+      // is implicitly done somewhere in the test environment setup.
+      SetBalanceIn("A", "alice", ATOM, amount)
     ).then(
       sendTransfer("A", "B", ATOM, amount, "alice", "bob")
     ).then(all {
       // check that voucher exists on chain B
-      val balanceB = chainStates.get("B").bank.getBalances("bob").getBalance(denomSentFromAToB)
+      val balanceB = getBalanceIn("B", "bob", denomSentFromAToB)
       assert(balanceB == amount),
 
       sendTransfer("B", "C", denomSentFromAToB, amount, "bob", "charlie")
     }).then(
       all {
         // check that the balance is updated on chainC
-        val balanceC = chainStates.get("C").bank.getBalances("charlie").getBalance(denomSentFromBToC)
+        val balanceC = getBalanceIn("C", "charlie", denomSentFromBToC)
         assert(balanceC == amount),
 
         // check that balance on chain B is empty
-        val balanceB = chainStates.get("B").bank.getBalances("bob").getBalance(denomSentFromBToC)
+        val balanceB = getBalanceIn("B", "bob", denomSentFromAToB)
         assert(balanceB == 0),
 
         // send from chainC back to chainB
@@ -518,19 +530,19 @@ module ics20Test {
       }
     ).then(all {
       // check that the balance on chainA is zero
-      val balanceA = chainStates.get("A").bank.getBalances("alice").getBalance(denomInA)
+      val balanceA = getBalanceIn("A", "alice", denomInA)
       assert(balanceA == 0),
 
       // check that balance on chain B has the transfered amount
-      val balanceB = chainStates.get("B").bank.getBalances("bob").getBalance(denomSentFromAToB)
+      val balanceB = getBalanceIn("B", "bob", denomSentFromAToB)
       assert(balanceB == amount),
 
       // check that module account escrow address is empty
-      val balanceEscrow = chainStates.get("B").bank.getBalances(ESCROW_ACCOUNT).getBalance(denomSentFromAToB)
+      val balanceEscrow = getBalanceIn("B", ESCROW_ACCOUNT, denomSentFromAToB)
       assert(balanceEscrow == 0),
 
       // check that balance on chain C is empty
-      val balanceC = chainStates.get("C").bank.getBalances("charlie").getBalance(denomSentFromBToC)
+      val balanceC = getBalanceIn("C", "charlie", denomSentFromBToC)
       assert(balanceC == 0),
 
       // noop

--- a/examples/cosmos/ics20/ics20.qnt
+++ b/examples/cosmos/ics20/ics20.qnt
@@ -482,5 +482,59 @@ module ics20Test {
       chainStates' = chainStates
   })
 
-  // TODO(thpani): add a test for packet timeout
+  // From
+  // https://github.com/cosmos/ibc-go/blob/a25f0d421c32b3a2b7e8168c9f030849797ff2e8/modules/apps/transfer/transfer_test.go#L44
+  run TransferTest = {
+    pure val amount = 9223372036854775808
+
+    // NOTE: fungible token is prefixed with the full trace in order to verify the packet commitment
+    pure val denomInA = ATOM
+    pure val denomSentFromAToB = denomInA.with("path", [{ port: "transfer", channel: "channelToA" }].concat(denomInA.path))
+    pure val denomSentFromBToC = denomSentFromAToB.with("path", [{ port: "transfer", channel: "channelToB" }].concat(denomSentFromAToB.path))
+    init.then(
+      // Make sure that Alice has enough tokens on chain A. I did not understand
+      // how this is done in the go test.
+      chainStates' = chainStates.setBy("A", state => state.with("bank", state.bank.setBy("alice", balances => balances.set(ATOM, amount))))
+    ).then(
+      sendTransfer("A", "B", ATOM, amount, "alice", "bob")
+    ).then(all {
+      // check that voucher exists on chain B
+      val balanceB = chainStates.get("B").bank.getBalances("bob").getBalance(denomSentFromAToB)
+      assert(balanceB == amount),
+
+      sendTransfer("B", "C", denomSentFromAToB, amount, "bob", "charlie")
+    }).then(
+      all {
+        // check that the balance is updated on chainC
+        val balanceC = chainStates.get("C").bank.getBalances("charlie").getBalance(denomSentFromBToC)
+        assert(balanceC == amount),
+
+        // check that balance on chain B is empty
+        val balanceB = chainStates.get("B").bank.getBalances("bob").getBalance(denomSentFromBToC)
+        assert(balanceB == 0),
+
+        // send from chainC back to chainB
+        sendTransfer("C", "B", denomSentFromBToC, amount, "charlie", "bob")
+      }
+    ).then(all {
+      // check that the balance on chainA is zero
+      val balanceA = chainStates.get("A").bank.getBalances("alice").getBalance(denomInA)
+      assert(balanceA == 0),
+
+      // check that balance on chain B has the transfered amount
+      val balanceB = chainStates.get("B").bank.getBalances("bob").getBalance(denomSentFromAToB)
+      assert(balanceB == amount),
+
+      // check that module account escrow address is empty
+      val balanceEscrow = chainStates.get("B").bank.getBalances(ESCROW_ACCOUNT).getBalance(denomSentFromAToB)
+      assert(balanceEscrow == 0),
+
+      // check that balance on chain C is empty
+      val balanceC = chainStates.get("C").bank.getBalances("charlie").getBalance(denomSentFromBToC)
+      assert(balanceC == 0),
+
+      // noop
+      chainStates' = chainStates
+    })
+  }
 }


### PR DESCRIPTION
Hello :octocat: 

Closes https://github.com/informalsystems/apalache-team-services/issues/11 by adding a concrete test based on the test in the go implementation. Does not add a parametrization on top of this yet.

The comments on the go test are outdated (seems like they updated the test and forgot about the comments). I'll open a PR fixing that. For now, if you are going to review this while looking at the code, I suggest ignoring their comments since that can be very confusing.

Perhaps is a good idea o hold on reviewing this until I have the comments fixed there.

**UPDATE**: here's the test with updated comments and other improvements
https://github.com/cosmos/ibc-go/blob/ce6ee2661f068a36fc112b29aa81b6a9c79685e8/modules/apps/transfer/transfer_test.go#L46

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Ran `npm run format` (or had formatting run automatically on all files edited)
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
