### PR TITLE
save ITF traces in tests

### DIFF
--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -596,6 +596,32 @@ rm out-itf-example.itf.json
 ]
 ```
 
+### Test outputs ITF
+
+TODO: output states after fix: https://github.com/informalsystems/quint/issues/288
+
+<!-- !test in test itf -->
+```
+quint test --out-itf=coin_ \
+  ../examples/solidity/Coin/coin.qnt
+cat coin_sendWithoutMintTest.itf.json | jq '.vars'
+rm coin_sendWithoutMintTest.itf.json
+cat coin_mintSendTest.itf.json | jq '.vars'
+rm coin_mintSendTest.itf.json
+```
+
+<!-- !test out test itf -->
+```
+[
+  "minter",
+  "balances"
+]
+[
+  "minter",
+  "balances"
+]
+```
+
 ### OK REPL tutorial
 
 The REPL tutorial is reproducible in REPL.

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -104,6 +104,10 @@ const testCmd = {
         desc: 'name of the main module (by default, computed from filename)',
         type: 'string',
       })
+      .option('out-itf', {
+        desc: 'specify the name prefix of test traces in the Informal Trace Format',
+        type: 'string',
+      })
       .option('max-samples', {
         desc: 'the maximum number of successful runs to try for every randomized test',
         type: 'number',

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -312,6 +312,17 @@ export async function runTests(prev: TypecheckedStage): Promise<CLIProcedure<Tes
       maxSamples: testing.args.maxSamples,
       rng,
       verbosity: verbosityLevel,
+      onTrace: (name: string, status: string, vars: string[], states: QuintEx[]) => {
+        if (testing.args.outItf) {
+          const trace = toItf(vars, states)
+          if (trace.isRight()) {
+            const jsonObj = addItfHeader(prev.args.input, status, trace.value)
+            writeToJson(`${prev.args.outItf}${name}.itf.json`, jsonObj)
+          } else {
+            console.error(`ITF conversion failed on ${name}: ${trace.value}`)
+         }
+        }
+      }
     }
     const testOut = compileAndTest(testing.modules, main, testing.sourceMap, testing.table, testing.types, options)
     if (testOut.isLeft()) {
@@ -469,17 +480,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
     if (prev.args.outItf) {
       const trace = toItf(result.vars, result.states)
       if (trace.isRight()) {
-        const jsonObj = {
-          '#meta': {
-            format: 'ITF',
-            'format-description': 'https://apalache.informal.systems/docs/adr/015adr-trace.html',
-            source: prev.args.input,
-            status: result.status,
-            description: 'Created by Quint on ' + new Date(),
-            timestamp: Date.now(),
-          },
-          ...trace.value,
-        }
+        const jsonObj = addItfHeader(prev.args.input, result.status, trace.value)
         writeToJson(prev.args.outItf, jsonObj)
       } else {
         const newStage = { ...simulator, errors: result.errors }
@@ -617,6 +618,20 @@ function mkRng(seedText?: string): Either<string, Rng> {
   }
 
   return right(seed ? newRng(seed) : newRng())
+}
+
+function addItfHeader(source: string, status: string, traceInJson: any): any {
+  return {
+    '#meta': {
+      format: 'ITF',
+      'format-description': 'https://apalache.informal.systems/docs/adr/015adr-trace.html',
+      source,
+      status,
+      description: 'Created by Quint on ' + new Date(),
+      timestamp: Date.now(),
+    },
+    ...traceInJson,
+  }
 }
 
 /**

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -11,7 +11,7 @@
 import { Either, left, merge, right } from '@sweet-monads/either'
 
 import { ErrorMessage, Loc, fromIrErrorMessage } from '../quintParserFrontend'
-import { QuintModule, QuintOpDef } from '../quintIr'
+import { QuintModule, QuintOpDef, QuintEx } from '../quintIr'
 import { TypeScheme } from '../types/base'
 
 import { CompilationContext, compile } from './compile'
@@ -29,6 +29,7 @@ export interface TestOptions {
   maxSamples: number
   rng: Rng
   verbosity: number
+  onTrace(name: string, status: string, vars: string[], states: QuintEx[]): void
 }
 
 /**
@@ -84,6 +85,13 @@ export function compileAndTest(
   const recorder = newTraceRecorder(options.verbosity, options.rng)
   const ctx = compile(modules, sourceMap, lookupTable, types, main.name, recorder, options.rng.next)
 
+  const saveTrace = (name: string, status: string) => {
+    // save the best traces are reported by the recorder
+    const states =
+      recorder.getBestTrace().args.map(e => e.toQuintEx(zerog))
+    options.onTrace(name, status, ctx.vars, states)
+  }
+
   if (!ctx.main) {
     return left([{ explanation: 'Cannot find main module', locs: [] }])
   }
@@ -138,6 +146,7 @@ export function compileAndTest(
               explanation: `${name} returns false`,
               refs: [def.id],
             })
+            saveTrace(name, 'failed')
             return {
               name,
               status: 'failed',
@@ -150,6 +159,7 @@ export function compileAndTest(
             if (options.rng.getState() === seed) {
               // This successful test did not use non-determinism.
               // Running it one time is sufficient.
+              saveTrace(name, 'passed')
               return {
                 name,
                 status: 'passed',
@@ -163,6 +173,7 @@ export function compileAndTest(
         }
 
         // the test was run maxSamples times, and no errors were found
+        saveTrace(name, 'passed')
         return {
           name,
           status: 'passed',


### PR DESCRIPTION
Closes #877. This PR adds the option `--out-itf` to `quint test`, which specifies the filename prefix. When this option is specified, `quint test` saves the best trace in ITF for every test, passing or failing.

Saving to ITF works. However, all traces generated by tests are empty now, since we have to fix #288. I will check today, how fast it could be fixed.

- [x] Tests added for any new code
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
