### PR TITLE
editor-plugins/vim: improve examples of how to adopt the provided syntax highlighting

### DIFF
--- a/editor-plugins/vim/quint.vim
+++ b/editor-plugins/vim/quint.vim
@@ -8,6 +8,9 @@
 " 2a. Either manually set syntax with :set syntax=quint
 " 2b. Or add the following in your ~/.vimrc
 "    au  BufNewFile,BufReadPost *.qnt runtime syntax/quint.vim
+" 2c. Use modelines, which should be enabled Vim (they are disabled
+"     by default in Mac OS), by adding at end of the Quint file:
+"    // vim: syntax=quint
 
 if exists("b:current_syntax")
   finish

--- a/editor-plugins/vim/quint.vim
+++ b/editor-plugins/vim/quint.vim
@@ -7,10 +7,7 @@
 " 1. Copy this file to ~/.vim/syntax/
 " 2a. Either manually set syntax with :set syntax=quint
 " 2b. Or add the following in your ~/.vimrc
-"    augroup syntax
-"    au! BufNewFile,BufReadPost *.qnt
-"    au  BufNewFile,BufReadPost *.qnt so ~/vim/syntax/quint.vim
-"    augroup END
+"    au  BufNewFile,BufReadPost *.qnt runtime syntax/quint.vim
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
Two minor contributions with this PR, both of them in the syntax file provided for Vim text editor. Each commit refers to one proposed change:

1. The `autogroup` setup can be much simple, 1 line instead of 4 on `~/.vimrc`. Also, using `runtime` is more adequate considering arbitrary setups. In any case, the previous version didn't work, as `~/vim` was used instead of the default `~/.vim`.
2. Syntax highlighting can be configured per file, using `modeline`. Namely, by adding `// vim: syntax=quint` to the end of a file, we instruct Vim to load the Quint syntax for the file. This could be a good practice for published Quint files.