### PR TITLE
Ensure parsing diagnostics are not overwritten

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fix bug where errors would disappear (#893)
+
 ### Security
 
 ## v0.4.0 -- 2023-05-04


### PR DESCRIPTION
Hello :octocat: 

I introduced a bad bug when optimizing the plugin. The static analysis result was overwriting the parsing results. This ensures the diagnostics are accumulated properly between the two phases.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
