### PR TITLE
Introduce an ItfTrace type

### DIFF
--- a/quint/src/itf.ts
+++ b/quint/src/itf.ts
@@ -2,7 +2,7 @@
  * Support for the Informal Trace Format (ITF):
  * https://apalache.informal.systems/docs/adr/015adr-trace.html
  *
- * Igor Konnov, Informal Systems, 2023
+ * Igor Konnov, Shon Feder, Informal Systems, 2023
  *
  * Copyright (c) Informal Systems 2021. All rights reserved.
  * Licensed under the Apache 2.0.
@@ -14,13 +14,37 @@ import { chunk } from 'lodash'
 
 import { QuintEx } from './quintIr'
 
-// The minimal value that can be reliably represented with number
-const minJsInt = -(2n ** 53n) + 1n
-// The maximal value that can be reliably represented with number
-const maxJsInt = 2n ** 53n - 1n
+export type ItfValue =
+  | boolean
+  | string
+  | number
+  | ItfValue[] // Sequence
+  | { '#bigint': string }
+  | { '#tup': ItfValue[] }
+  | { '#set': ItfValue[] }
+  | { '#map': [ItfValue, ItfValue][] }
+  | { '#unserializable': string }
+  | { [index: string]: ItfValue } // Record
+
+export type ItfState = {
+  '#meta'?: any
+  // Mapping of State variables to their values in a state
+  [index: string]: ItfValue
+}
+
+export type ItfTrace = {
+  '#meta'?: any
+  params?: string[]
+  vars: string[]
+  states: ItfState[]
+  loop?: number
+}
+
+const minJsInt: bigint = BigInt(Number.MIN_SAFE_INTEGER)
+const maxJsInt: bigint = BigInt(Number.MAX_SAFE_INTEGER)
 
 /**
- * Convert a typed Quint expression into an object that matches the JSON
+ * Convert a list of Quint expressions into an object that matches the JSON
  * representation of the ITF trace. This function does not add metadata
  * to the trace. This should be done by the caller.
  *
@@ -28,13 +52,13 @@ const maxJsInt = 2n ** 53n - 1n
  * @param states an array of expressions that represent the states
  * @returns an object that represent the trace in the ITF format
  */
-export function toItf(vars: string[], states: QuintEx[]): Either<string, any> {
+export function toItf(vars: string[], states: QuintEx[]): Either<string, ItfTrace> {
   const exprToItf = (ex: QuintEx): Either<string, any> => {
     switch (ex.kind) {
       case 'int':
         if (ex.value >= minJsInt && ex.value <= maxJsInt) {
-          // OK to convert to a number, when saving to JSON
-          return right(ex.value)
+          // We can represent safely as a JS number
+          return right(Number(ex.value))
         } else {
           // convert to a special structure, when saving to JSON
           return right({ '#bigint': `${ex.value}` })
@@ -99,3 +123,7 @@ export function toItf(vars: string[], states: QuintEx[]): Either<string, any> {
     }
   })
 }
+
+// export function ofItf(itf: any[]): Either<string, QuintEx[]> {
+//   const stateToExpr = (any: )
+// }

--- a/quint/src/itf.ts
+++ b/quint/src/itf.ts
@@ -32,6 +32,8 @@ export type ItfState = {
   [index: string]: ItfValue
 }
 
+/** The type of IFT traces.
+ * See https://github.com/informalsystems/apalache/blob/main/docs/src/adr/015adr-trace.md */
 export type ItfTrace = {
   '#meta'?: any
   params?: string[]

--- a/quint/test/itf.test.ts
+++ b/quint/test/itf.test.ts
@@ -14,17 +14,17 @@ describe('itf', () => {
       states: [
         {
           '#meta': { index: 0 },
-          x: 2n,
+          x: 2,
           y: true,
         },
         {
           '#meta': { index: 1 },
-          x: 3n,
+          x: 3,
           y: false,
         },
       ],
     }
-    assert(itfTrace.isRight(), itfTrace.unwrap())
+    assert(itfTrace.isRight(), `invalid ITF trace: ${JSON.stringify(itfTrace.unwrap)}`)
     assert.deepEqual(itfTrace.unwrap(), expected)
   })
 
@@ -51,25 +51,25 @@ describe('itf', () => {
           '#meta': {
             index: 0,
           },
-          a: 2n,
+          a: 2,
           b: 'hello',
           c: { '#bigint': '1000000000000000000' },
-          d: { '#set': [5n, 6n] },
-          e: { foo: 3n, bar: true },
-          f: { '#tup': [7n, 'myStr'] },
+          d: { '#set': [5, 6] },
+          e: { foo: 3, bar: true },
+          f: { '#tup': [7, 'myStr'] },
           g: {
             '#map': [
-              [1n, 'a'],
-              [2n, 'b'],
-              [3n, 'c'],
+              [1, 'a'],
+              [2, 'b'],
+              [3, 'c'],
             ],
           },
           h: { '#map': [] },
-          i: { '#map': [[1n, 'a']] },
+          i: { '#map': [[1, 'a']] },
         },
       ],
     }
-    assert(itfTrace.isRight(), itfTrace.value)
+    assert(itfTrace.isRight(), `invalid ITF trace: ${JSON.stringify(itfTrace.unwrap)}`)
     assert.deepEqual(itfTrace.unwrap(), expected)
   })
 })


### PR DESCRIPTION
For #888, we'll need to support converting ITF into `QuintEx`. Having a
type to specify the right shape for the ITF will make the conversion a
nobrainer, and help ease any other manipulation of ITF data in the
future.

This also adds some minor cleanup to the ITF representation to make it
more faithful: namely, number are numbers, and bitings are encoded as
strings.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [-] Entries added to the respective `CHANGELOG.md` for any new functionality
- [-] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality