### PR TITLE
Add ofItf function

### DIFF
--- a/quint/src/itf.ts
+++ b/quint/src/itf.ts
@@ -175,7 +175,7 @@ export function toItf(vars: string[], states: QuintEx[]): Either<string, ItfTrac
 
 export function ofItf(itf: ItfTrace): QuintEx[] {
   // Benign state to synthesize ids for the Quint expressions
-  var nextId = 0n
+  let nextId = 0n
   // Produce the next ID in sequence
   const getId = (): bigint => {
     const id = nextId
@@ -184,23 +184,23 @@ export function ofItf(itf: ItfTrace): QuintEx[] {
   }
 
   const ofItfValue = (value: ItfValue): QuintEx => {
-    const withId = { id: getId() }
+    const id = getId()
     if (typeof value === 'boolean') {
-      return { ...withId, kind: 'bool', value }
+      return { id, kind: 'bool', value }
     } else if (typeof value === 'string') {
-      return { ...withId, kind: 'str', value }
+      return { id, kind: 'str', value }
     } else if (typeof value === 'number') {
-      return { ...withId, kind: 'int', value: BigInt(value) }
+      return { id, kind: 'int', value: BigInt(value) }
     } else if (Array.isArray(value)) {
-      return { ...withId, kind: 'app', opcode: 'List', args: value.map(ofItfValue) }
+      return { id, kind: 'app', opcode: 'List', args: value.map(ofItfValue) }
     } else if (isBigint(value)) {
-      return { ...withId, kind: 'int', value: BigInt(value['#bigint']) }
+      return { id, kind: 'int', value: BigInt(value['#bigint']) }
     } else if (isTup(value)) {
-      return { ...withId, kind: 'app', opcode: 'Tup', args: value['#tup'].map(ofItfValue) }
+      return { id, kind: 'app', opcode: 'Tup', args: value['#tup'].map(ofItfValue) }
     } else if (isSet(value)) {
-      return { ...withId, kind: 'app', opcode: 'Set', args: value['#set'].map(ofItfValue) }
+      return { id, kind: 'app', opcode: 'Set', args: value['#set'].map(ofItfValue) }
     } else if (isUnserializable(value)) {
-      return { ...withId, kind: 'name', name: value['#unserializable'] }
+      return { id, kind: 'name', name: value['#unserializable'] }
     } else if (isMap(value)) {
       const args = value['#map'].map(([key, value]) => {
         const k = ofItfValue(key)
@@ -208,7 +208,7 @@ export function ofItf(itf: ItfTrace): QuintEx[] {
         return { id: getId(), kind: 'app', opcode: 'Tup', args: [k, v] } as QuintApp
       })
       return {
-        ...withId,
+        id,
         kind: 'app',
         opcode: 'Map',
         args,
@@ -221,7 +221,7 @@ export function ofItf(itf: ItfTrace): QuintEx[] {
         .filter(key => key !== '#meta') // Must be removed from top-level ojects representing states
         .map(f => [{ id: getId(), kind: 'str', value: f }, ofItfValue(value[f])] as [QuintStr, QuintEx])
         .flat() // flatten the converted pairs of fields into a single array
-      return { ...withId, kind: 'app', opcode: 'Rec', args }
+      return { id, kind: 'app', opcode: 'Rec', args }
     } else {
       // This should be impossible, but TypeScript can't tell we've handled all cases
       throw new Error(`internal error: unhandled ITF value ${value}`)

--- a/quint/src/itf.ts
+++ b/quint/src/itf.ts
@@ -220,8 +220,7 @@ export function ofItf(itf: ItfTrace): QuintEx[] {
       const args = Object.keys(value)
         .filter(key => key !== '#meta') // Must be removed from top-level ojects representing states
         .map(f => [{ id: getId(), kind: 'str', value: f }, ofItfValue(value[f])] as [QuintStr, QuintEx])
-        .flat()
-      // flatten the converted pairs of fields into a single array to form the record
+        .flat() // flatten the converted pairs of fields into a single array
       return { ...withId, kind: 'app', opcode: 'Rec', args }
     } else {
       // This should be impossible, but TypeScript can't tell we've handled all cases

--- a/quint/src/itf.ts
+++ b/quint/src/itf.ts
@@ -11,26 +11,9 @@
 
 import { Either, left, merge, right } from '@sweet-monads/either'
 import { chunk } from 'lodash'
+import { QuintApp, QuintStr } from './quintIr'
 
 import { QuintEx } from './quintIr'
-
-export type ItfValue =
-  | boolean
-  | string
-  | number
-  | ItfValue[] // Sequence
-  | { '#bigint': string }
-  | { '#tup': ItfValue[] }
-  | { '#set': ItfValue[] }
-  | { '#map': [ItfValue, ItfValue][] }
-  | { '#unserializable': string }
-  | { [index: string]: ItfValue } // Record
-
-export type ItfState = {
-  '#meta'?: any
-  // Mapping of State variables to their values in a state
-  [index: string]: ItfValue
-}
 
 /** The type of IFT traces.
  * See https://github.com/informalsystems/apalache/blob/main/docs/src/adr/015adr-trace.md */
@@ -40,6 +23,52 @@ export type ItfTrace = {
   vars: string[]
   states: ItfState[]
   loop?: number
+}
+
+export type ItfState = {
+  '#meta'?: any
+  // Mapping of state variables to their values in a state
+  [index: string]: ItfValue
+}
+
+export type ItfValue =
+  | boolean
+  | string
+  | number
+  | ItfValue[] // Sequence
+  | ItfBigint
+  | ItfTup
+  | ItfSet
+  | ItfMap
+  | ItfUnserializable
+  | ItfRecord
+
+type ItfBigint = { '#bigint': string }
+type ItfTup = { '#tup': ItfValue[] }
+type ItfSet = { '#set': ItfValue[] }
+type ItfMap = { '#map': [ItfValue, ItfValue][] }
+type ItfUnserializable = { '#unserializable': string }
+type ItfRecord = { [index: string]: ItfValue }
+
+// Type predicates to help with type narrowing
+function isBigint(v: ItfValue): v is ItfBigint {
+  return (v as ItfBigint)['#bigint'] !== undefined
+}
+
+function isTup(v: ItfValue): v is ItfTup {
+  return (v as ItfTup)['#tup'] !== undefined
+}
+
+function isSet(v: ItfValue): v is ItfSet {
+  return (v as ItfSet)['#set'] !== undefined
+}
+
+function isMap(v: ItfValue): v is ItfMap {
+  return (v as ItfMap)['#map'] !== undefined
+}
+
+function isUnserializable(v: ItfValue): v is ItfUnserializable {
+  return (v as ItfUnserializable)['#unserializable'] !== undefined
 }
 
 const minJsInt: bigint = BigInt(Number.MIN_SAFE_INTEGER)
@@ -55,7 +84,7 @@ const maxJsInt: bigint = BigInt(Number.MAX_SAFE_INTEGER)
  * @returns an object that represent the trace in the ITF format
  */
 export function toItf(vars: string[], states: QuintEx[]): Either<string, ItfTrace> {
-  const exprToItf = (ex: QuintEx): Either<string, any> => {
+  const exprToItf = (ex: QuintEx): Either<string, ItfValue> => {
     switch (ex.kind) {
       case 'int':
         if (ex.value >= minJsInt && ex.value <= maxJsInt) {
@@ -90,18 +119,34 @@ export function toItf(vars: string[], states: QuintEx[]): Either<string, ItfTrac
               return left('record: expected an even number of arguments, found:' + ex.args.length)
             }
             return merge(ex.args.map(exprToItf)).mapRight(kvs => {
-              let obj: any = {}
+              let obj: ItfRecord = {}
               chunk(kvs, 2).forEach(([k, v]) => {
-                obj[k] = v
+                if (typeof k === 'string') {
+                  obj[k] = v
+                } else {
+                  left(`Invalid record field: ${ex}`)
+                }
               })
               return obj
             })
           }
 
           case 'Map':
-            return merge(ex.args.map(exprToItf)).mapRight(pairs => {
-              return { '#map': pairs.map(p => p['#tup']) }
-            })
+            return merge(
+              // Convert all the entries of the map
+              ex.args.map(exprToItf)
+            ).chain(pairs =>
+              merge(
+                // Quint represents map entries as tuples, but in ITF they are 2 element arrays,
+                // so we unpack all the ITF tuples into arrays
+                pairs.map(p => (isTup(p) ? right(p['#tup']) : left(`Invalid value in quint Map ${p}`)))
+              ).map(entries =>
+                // Finally, we can form the ITF representation of a map
+                ({
+                  '#map': entries,
+                })
+              )
+            )
 
           default:
             return left(`Unexpected operator type: ${ex.opcode}`)
@@ -114,9 +159,11 @@ export function toItf(vars: string[], states: QuintEx[]): Either<string, ItfTrac
 
   return merge(
     states.map((e, i) =>
-      exprToItf(e).mapRight(obj => {
-        return { '#meta': { index: i }, ...obj }
-      })
+      exprToItf(e).chain(obj =>
+        typeof obj === 'object'
+          ? right({ '#meta': { index: i }, ...obj } as ItfState)
+          : left(`Expected a valid ITF state, but found ${obj}`)
+      )
     )
   ).mapRight(s => {
     return {
@@ -126,6 +173,78 @@ export function toItf(vars: string[], states: QuintEx[]): Either<string, ItfTrac
   })
 }
 
-// export function ofItf(itf: any[]): Either<string, QuintEx[]> {
-//   const stateToExpr = (any: )
-// }
+export function ofItf(itf: ItfTrace): Either<string, QuintEx[]> {
+  // Benign state to synthesize ids for the Quint expressions
+  var nextId = 0n
+  // Produce the next ID in sequence
+  const getId = (): bigint => {
+    const id = nextId
+    nextId = nextId + 1n
+    return id
+  }
+
+  const ofItfValue = (value: ItfValue): Either<string, QuintEx> => {
+    const withId = { id: getId() }
+    if (typeof value === 'boolean') {
+      return right({ ...withId, kind: 'bool', value })
+    } else if (typeof value === 'string') {
+      return right({ ...withId, kind: 'str', value })
+    } else if (typeof value === 'number') {
+      return right({ ...withId, kind: 'int', value: BigInt(value) })
+    } else if (Array.isArray(value)) {
+      return merge(value.map(ofItfValue)).map(args => ({ ...withId, kind: 'app', opcode: 'List', args }))
+    } else if (isBigint(value)) {
+      return right({ ...withId, kind: 'int', value: BigInt(value['#bigint']) })
+    } else if (isTup(value)) {
+      return merge(value['#tup'].map(ofItfValue)).map(args => ({ ...withId, kind: 'app', opcode: 'Tup', args }))
+    } else if (isSet(value)) {
+      return merge(value['#set'].map(ofItfValue)).map(args => ({ ...withId, kind: 'app', opcode: 'Set', args }))
+    } else if (isUnserializable(value)) {
+      return right({ ...withId, kind: 'name', name: value['#unserializable'] })
+    } else if (isMap(value)) {
+      return (
+        merge(
+          value['#map'].map(([key, value]) =>
+            // Convert the key
+            ofItfValue(key)
+              // and if it goes well...
+              .chain(k =>
+                // Convert the value
+                ofItfValue(value)
+                  // and if that goes well...
+                  .map(
+                    v =>
+                      // Form a quint tuple of the converted key-value pair
+                      ({ id: getId(), kind: 'app', opcode: 'Tup', args: [k, v] } as QuintApp)
+                  )
+              )
+          )
+        )
+          // and if all that went well, make the quint Map.
+          .map(args => ({
+            ...withId,
+            kind: 'app',
+            opcode: 'Map',
+            args,
+          }))
+      )
+    } else if (typeof value === 'object') {
+      // Any other object must represent a record
+      return merge(
+        // For each key/value pair in the object, form the quint expressions representing
+        // the record field and value
+        Object.keys(value)
+          .filter(key => key !== '#meta') // Has to be removed from top-level ojects representing states
+          .map(f => ofItfValue(value[f]).map(v => [{ id: getId(), kind: 'str', value: f }, v] as [QuintStr, QuintEx]))
+      ).map(fields =>
+        // flatten the converted pairs of fields into a single array to form the record
+        ({ ...withId, kind: 'app', opcode: 'Rec', args: fields.flat() })
+      )
+    } else {
+      // This should be impossible, but TypeScript can't tell we've handled all cases
+      throw new Error(`internal error: unhandled ITF value ${value}`)
+    }
+  }
+
+  return merge(itf.states.map(ofItfValue))
+}

--- a/quint/test/itf.test.ts
+++ b/quint/test/itf.test.ts
@@ -1,10 +1,11 @@
 import { describe, it } from 'mocha'
 import { assert } from 'chai'
+import { quintExAreEqual, zip } from './util'
 
 import { buildExpression } from './builders/ir'
-import { toItf } from '../src/itf'
+import { ofItf, toItf } from '../src/itf'
 
-describe('itf', () => {
+describe('toItf', () => {
   it('converts two states', () => {
     const trace = ['{ x: 2, y: true }', '{ x: 3, y: false }'].map(buildExpression)
 
@@ -26,6 +27,13 @@ describe('itf', () => {
     }
     assert(itfTrace.isRight(), `invalid ITF trace: ${JSON.stringify(itfTrace.unwrap)}`)
     assert.deepEqual(itfTrace.unwrap(), expected)
+
+    const roundTripTrace = ofItf(itfTrace.unwrap())
+    assert(roundTripTrace.isRight(), `failed to convert ITF back to Quint: ${roundTripTrace.value}`)
+    assert(
+      zip(roundTripTrace.unwrap(), trace).every(([a, b]) => quintExAreEqual(a, b)),
+      `round trip conversion of trace failed`
+    )
   })
 
   it('converts all kinds', () => {
@@ -71,5 +79,12 @@ describe('itf', () => {
     }
     assert(itfTrace.isRight(), `invalid ITF trace: ${JSON.stringify(itfTrace.unwrap)}`)
     assert.deepEqual(itfTrace.unwrap(), expected)
+
+    const roundTripTrace = ofItf(itfTrace.unwrap())
+    assert(roundTripTrace.isRight(), `failed to convert ITF back to Quint: ${roundTripTrace.value}`)
+    assert(
+      zip(roundTripTrace.unwrap(), trace).every(([a, b]) => quintExAreEqual(a, b)),
+      `round trip conversion of trace failed`
+    )
   })
 })

--- a/quint/test/itf.test.ts
+++ b/quint/test/itf.test.ts
@@ -29,9 +29,8 @@ describe('toItf', () => {
     assert.deepEqual(itfTrace.unwrap(), expected)
 
     const roundTripTrace = ofItf(itfTrace.unwrap())
-    assert(roundTripTrace.isRight(), `failed to convert ITF back to Quint: ${roundTripTrace.value}`)
     assert(
-      zip(roundTripTrace.unwrap(), trace).every(([a, b]) => quintExAreEqual(a, b)),
+      zip(roundTripTrace, trace).every(([a, b]) => quintExAreEqual(a, b)),
       `round trip conversion of trace failed`
     )
   })
@@ -81,9 +80,8 @@ describe('toItf', () => {
     assert.deepEqual(itfTrace.unwrap(), expected)
 
     const roundTripTrace = ofItf(itfTrace.unwrap())
-    assert(roundTripTrace.isRight(), `failed to convert ITF back to Quint: ${roundTripTrace.value}`)
     assert(
-      zip(roundTripTrace.unwrap(), trace).every(([a, b]) => quintExAreEqual(a, b)),
+      zip(roundTripTrace, trace).every(([a, b]) => quintExAreEqual(a, b)),
       `round trip conversion of trace failed`
     )
   })

--- a/quint/test/util.ts
+++ b/quint/test/util.ts
@@ -3,10 +3,10 @@ import {
   QuintBool,
   QuintDef,
   QuintEx,
-  QuintLambda,
-  QuintModule,
   QuintInstance,
   QuintInt,
+  QuintLambda,
+  QuintModule,
   QuintStr,
   QuintTypeDef,
 } from '../src/quintIr'

--- a/quint/test/util.ts
+++ b/quint/test/util.ts
@@ -1,6 +1,17 @@
 import { IRVisitor, walkModule } from '../src/IRVisitor'
-import { QuintDef, QuintEx, QuintInstance, QuintLambda, QuintModule, QuintTypeDef } from '../src/quintIr'
+import {
+  QuintBool,
+  QuintDef,
+  QuintEx,
+  QuintLambda,
+  QuintModule,
+  QuintInstance,
+  QuintInt,
+  QuintStr,
+  QuintTypeDef,
+} from '../src/quintIr'
 import { QuintType } from '../src/quintTypes'
+import lodash from 'lodash'
 
 export function collectIds(module: QuintModule): bigint[] {
   const ids = new Set<bigint>()
@@ -32,4 +43,54 @@ export function collectIds(module: QuintModule): bigint[] {
 
   walkModule(visitor, module)
   return [...ids]
+}
+
+/**  A wrapper around lodash zip that ensures all zipped elements are defined
+ *
+ * Raises `Error` if the arrays are not the same length
+ */
+export function zip<A, B>(a: A[], b: B[]): [A, B][] {
+  return lodash.zip(a, b).map(([x, y]) => {
+    if (x === undefined || y === undefined) {
+      throw new Error('Illegal arguments to zepWell: array lengths unequal')
+    } else {
+      return [x, y]
+    }
+  })
+}
+
+// Type predicate that tells us when a QuintEx is a scalar with a `value`
+function isScalar(v: QuintEx): v is QuintBool | QuintInt | QuintStr {
+  return v.kind === 'bool' || v.kind === 'int' || v.kind === 'str'
+}
+
+/** `quinExAreEqual(a, b)` is `true` when the expressions `a` and `b` are structurally equal, modulo ids
+ *
+ * This tells us whether `a` and `b` represent the same expression,
+ * irrespective of when or where they were constructed.
+ */
+export function quintExAreEqual(a: QuintEx, b: QuintEx): boolean {
+  if (a.kind !== b.kind) {
+    return false
+  }
+
+  // The repeated checks on `kind` are for type narrowing
+  if (a.kind === 'name' && b.kind === 'name') {
+    return a.name === b.name
+  } else if (isScalar(a) && isScalar(b)) {
+    return a.value === b.value
+  } else if (a.kind === 'app' && b.kind === 'app') {
+    return a.args.length === b.args.length && zip(a.args, b.args).every(([x, y]) => quintExAreEqual(x, y))
+  } else if (a.kind === 'lambda' && b.kind === 'lambda') {
+    return (
+      a.qualifier === b.qualifier &&
+      a.params.length === b.params.length &&
+      zip(a.params, b.params).every(([x, y]) => x.name === y.name) &&
+      quintExAreEqual(a.expr, b.expr)
+    )
+  } else if (a.kind === 'let' && b.kind === 'let') {
+    return a.opdef.name === b.opdef.name && a.opdef.qualifier === b.opdef.qualifier && quintExAreEqual(a.expr, b.expr)
+  } else {
+    throw new Error(`internal error: case not handeled for quintExAreEqual over ${a.kind}`)
+  }
 }


### PR DESCRIPTION
Adds a function to convert ITF traces into trades represented as an array of
`QuintEx`s.

Required for #888

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [x] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality