### PR TITLE
fix trace selection in the simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
+
 ### Fixed
+
+- Fixed a bug in trace reporting by `quint run` (#913)
+
 ### Security
 
 ## v0.11.0 -- 2023-05-24

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -319,6 +319,6 @@ fi
 
 <!-- !test exit 1 -->
 <!-- !test check lottery - Run -->
-    quint run --max-samples=10000 --max-steps 10 --seed=0x29f8e8021fae9 \
-      --invariant noBuyInDrawingInv --main lotteryMempool \
+    quint run --max-samples=10000 --max-steps=10 --seed=0x29f8e8021fae9 \
+      --invariant=noBuyInDrawingInv --main=lotteryMempool \
       ../examples/solidity/icse23-fig7/lottery.qnt

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -314,3 +314,11 @@ fi
 
 <!-- !test check bug843pureValCache - Syntax/Types & Effects/Unit tests -->
     quint test ./testFixture/bug843pureValCache.qnt
+
+### OK on run lottery
+
+<!-- !test check lottery - Run -->
+    quint run --max-samples=10000 --max-steps 10 --seed=0x29f8e8021fae9 \
+      --invariant noBuyInDrawingInv --main lotteryMempool \
+      ../examples/solidity/icse23-fig7/lottery.qnt
+<!-- !test exit 1 -->

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -317,8 +317,8 @@ fi
 
 ### OK on run lottery
 
+<!-- !test exit 1 -->
 <!-- !test check lottery - Run -->
     quint run --max-samples=10000 --max-steps 10 --seed=0x29f8e8021fae9 \
       --invariant noBuyInDrawingInv --main lotteryMempool \
       ../examples/solidity/icse23-fig7/lottery.qnt
-<!-- !test exit 1 -->

--- a/quint/src/runtime/trace.ts
+++ b/quint/src/runtime/trace.ts
@@ -8,13 +8,14 @@
  * See License.txt in the project root for license information.
  */
 
-import { Maybe, none } from '@sweet-monads/maybe'
+import { Maybe, just, none } from '@sweet-monads/maybe'
 import { strict as assert } from 'assert'
 
 import { QuintApp } from '../quintIr'
 import { EvalResult } from './runtime'
 import { verbosity } from './../verbosity'
 import { Rng } from './../rng'
+import { rv } from './impl/runtimeValue'
 
 /**
  * A snapshot of how a single operator (e.g., an action) was executed.
@@ -149,7 +150,7 @@ export const newTraceRecorder = (verbosityLevel: number, rng: Rng) => {
       // we will store the sequence of states here
       args: [],
       // the result of the trace evaluation
-      result: none(),
+      result: just(rv.mkBool(true)),
       // and here we store the subframes for the top-level actions
       subframes: [],
     }
@@ -255,28 +256,32 @@ export const newTraceRecorder = (verbosityLevel: number, rng: Rng) => {
       assert(frameStack.length > 0)
       const bottom = frameStack[0]
 
-      let failureOrViolation = true
-      if (outcome.isJust()) {
-        const r = outcome.value.toQuintEx({ nextId: () => 0n })
-        failureOrViolation = r.kind === 'bool' && !r.value
+      const fromResult = (r: Maybe<EvalResult>) => {
+        if (r.isNone()) {
+          return true
+        } else {
+          const rex = r.value.toQuintEx({ nextId: () => 0n })
+          return rex.kind === 'bool' && !rex.value
+        }
       }
 
-      if (failureOrViolation) {
-        if (bestTrace.args.length === 0 || bestTrace.args.length >= bottom.args.length) {
-          // on error, prefer the shorter non-empty trace
-          bestTrace = bottom
-          bestTraceSeed = runSeed
-          bestTrace.result = outcome
-          bestTrace.args = trace
-        }
-      } else {
-        if (bestTrace.args.length <= bottom.args.length) {
-          // on success, prefer the longer trace
-          bestTrace = bottom
-          bestTraceSeed = runSeed
-          bestTrace.result = outcome
-          bestTrace.args = trace
-        }
+      const notOk = fromResult(outcome)
+      const prevNotOk = fromResult(bestTrace.result)
+
+      // override the best trace only if:
+      //  - there is an error, the new trace is shorter, or the old trace is non-error;
+      //  - there is no error, the new trace is longer, and there was no error before.
+      const override =
+        notOk
+        ? (bestTrace.args.length === 0 || !prevNotOk
+            || bestTrace.args.length >= bottom.args.length)
+        : !prevNotOk && bestTrace.args.length <= bottom.args.length
+
+      if (override) {
+        bestTrace = bottom
+        bestTraceSeed = runSeed
+        bestTrace.result = outcome
+        bestTrace.args = trace
       }
     },
   }

--- a/quint/src/runtime/trace.ts
+++ b/quint/src/runtime/trace.ts
@@ -271,10 +271,8 @@ export const newTraceRecorder = (verbosityLevel: number, rng: Rng) => {
       // override the best trace only if:
       //  - there is an error, the new trace is shorter, or the old trace is non-error;
       //  - there is no error, the new trace is longer, and there was no error before.
-      const override =
-        notOk
-        ? (bestTrace.args.length === 0 || !prevNotOk
-            || bestTrace.args.length >= bottom.args.length)
+      const override = notOk
+        ? bestTrace.args.length === 0 || !prevNotOk || bestTrace.args.length >= bottom.args.length
         : !prevNotOk && bestTrace.args.length <= bottom.args.length
 
       if (override) {

--- a/quint/src/runtime/trace.ts
+++ b/quint/src/runtime/trace.ts
@@ -268,7 +268,8 @@ export const newTraceRecorder = (verbosityLevel: number, rng: Rng) => {
       const notOk = fromResult(outcome)
       const prevNotOk = fromResult(bestTrace.result)
 
-      // override the best trace only if:
+      // Prefer short traces for error, and longer traces for non error.
+      // Therefore, override the best trace only if:
       //  - there is an error, the new trace is shorter, or the old trace is non-error;
       //  - there is no error, the new trace is longer, and there was no error before.
       const override = notOk


### PR DESCRIPTION
This PR fixes a bug in reporting by `quint run`, which I have introduced before the presentation in a rush in #890. The simulator was quickly finding a violation but it was reporting the trace as no-violation. Also, added a test to check that the found trace is reported properly.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

This is a critical fix actually. Can we cut a new release after this is merged?
