### PR TITLE
Print counterexamples on variant violations and deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- The `verify` command prints counterexamples on deadlocks and invariant
+  violations (#914)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -141,31 +141,31 @@ completely implementing every pass.
 
 | Language feature                  | Parser             | Name resolution    | Effects            | Type checker       | Simulator          | To-Apalache        | Tutorials          |
 |:----------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
-| [Booleans][]                      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Integers][]                      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| [Booleans][]                      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Integers][]                      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [if-then-else][]                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Operator definitions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Modes][]                         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Sets][]                          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [nondet][]                        | :white_check_mark: | :white_check_mark: | :green_circle:     | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Maps][]                          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| [Operator definitions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Modes][]                         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Sets][]                          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [nondet][]                        | :white_check_mark: | :white_check_mark: | :green_circle:     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Maps][]                          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | [Lists][]                         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| [Records][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| [Records][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | [Discriminated unions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: [244][]        | :x: [539][]        | :x:                | :x:                |
-| [Tuples][]                        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| [Tuples][]                        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :green_circle:     | :white_check_mark: |
 | [Imports][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Module definitions][]            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| [Module definitions][]            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Module instances][]              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
-| [Multiple files][] | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Multiple files][]                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Constant declarations][]         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
-| [Variable definitions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Assumptions][]                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :green_circle:     | :x: [235][]        | :x:                | :x:                |
-| [Lambdas][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Multiline disjunctions][]        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| [Multiline conjunctions][]        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| [Variable definitions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Assumptions][]                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :green_circle:     | :x: [235][]        | :white_check_mark: | :x:                |
+| [Lambdas][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Multiline disjunctions][]        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Multiline conjunctions][]        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Delayed assignment][]            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
-| Invariant checking                | -                  | -                  | -                  | -                  | :white_check_mark: | :x:                | :white_check_mark: |
-| [Higher-order definitions][]      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| Invariant checking                | -                  | -                  | -                  | -                  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [Higher-order definitions][]      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | [Runs][]                          | :white_check_mark: | :white_check_mark: | :green_circle:     | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
 | [Temporal operators][]            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | *non-goal*         | :x:                | :x:                |
 | [Fairness][]                      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | *non-goal*         | :x:                | :x:                |

--- a/examples/verification/README.md
+++ b/examples/verification/README.md
@@ -1,0 +1,3 @@
+The specs in this directory demonstrate features of quint's `verify` command,
+which is based on integration with
+[Apalache](https://github.com/informalsystems/apalache).

--- a/examples/verification/defaultOpNames.qnt
+++ b/examples/verification/defaultOpNames.qnt
@@ -1,0 +1,32 @@
+module defaultOpNames {
+  // The default name for the state initialization action is `init`.
+  action init = true
+
+  // The state initialization action can be configured from the CLI using the --init flag.
+  // E.g.,
+  //
+  // quint verify --init myInit ./defaultOpNames.qnt
+  action myInit = true
+
+  // The default name for the state transition action is `step`.
+  action step = true
+
+  // The state transition action can be configured from the CLI using the --step flag.
+  // E.g.,
+  //
+  // quint verify --step myStep ./defaultOpNames.qnt
+  action myStep = true
+
+  // There is no default name for invariants.
+  // These must be specified using the --invariant flag
+  // E.g.,
+  //
+  // quint verify --invariant inv ./defaultOpNames.qnt
+  def inv = true
+
+  // Multile invariants can be specified by separating them with a comma
+  // E.g.,
+  //
+  // quint verify --invariant inv,inv2 ./defaultOpNames.qnt
+  def inv2 = true
+}

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -106,7 +106,7 @@ quint verify --invariant inv ./testFixture/apalache/violateOnFive.qnt
 <!-- !test exit 1 -->
 <!-- !test err prints a trace on invariant violation -->
 ```
-error: A counterexample was found
+error: found a counterexample
 ```
 
 <!-- !test out prints a trace on invariant violation -->
@@ -136,10 +136,40 @@ rm ./violateOnFive.itf.json
 
 <!-- !test err writes an ITF trace to file -->
 ```
-error: A counterexample was found
+error: found a counterexample
 ```
 
 <!-- !test out writes an ITF trace to file -->
 ```
 "ITF"
+```
+
+## Deadlocks
+
+
+<!-- !test in reports deadlock -->
+```
+quint verify ./testFixture/apalache/deadlock.qnt
+```
+
+<!-- !test exit 1 -->
+<!-- !test err reports deadlock -->
+```
+error: reached a deadlock
+```
+
+<!-- !test out reports deadlock -->
+```
+An example execution:
+
+[State 0] { n: 1 }
+
+[State 1] { n: 2 }
+
+[State 2] { n: 3 }
+
+[State 3] { n: 4 }
+
+[State 4] { n: 5 }
+
 ```

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -106,4 +106,40 @@ quint verify --invariant inv ./testFixture/apalache/violateOnFive.qnt
 <!-- !test exit 1 -->
 <!-- !test err prints a trace on invariant violation -->
 ```
+error: A counterexample was found
+```
+
+<!-- !test out prints a trace on invariant violation -->
+```
+An example execution:
+
+[State 0] { n: 1 }
+
+[State 1] { n: 2 }
+
+[State 2] { n: 3 }
+
+[State 3] { n: 4 }
+
+[State 4] { n: 5 }
+
+```
+
+### Variant violations write ITF to file when `--out-itf` is specified
+
+<!-- !test in writes an ITF trace to file -->
+```
+quint verify --out-itf violateOnFive.itf.json --invariant inv ./testFixture/apalache/violateOnFive.qnt
+jq '.[0]."#meta".format' violateOnFive.itf.json
+rm ./violateOnFive.itf.json
+```
+
+<!-- !test err writes an ITF trace to file -->
+```
+error: A counterexample was found
+```
+
+<!-- !test out writes an ITF trace to file -->
+```
+"ITF"
 ```

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -73,3 +73,37 @@ quint verify --init Init --step Next ../examples/language-features/lists.qnt
 quint verify --init Init --step Next ../examples/language-features/maps.qnt
 ```
 
+### Default `step` and `init` operators are found
+
+<!-- !test check can find default operator names -->
+```
+quint verify ../examples/verification/defaultOpNames.qnt
+```
+
+### Can verify with single invariant
+
+<!-- !test check can specify --invariant -->
+```
+quint verify --invariant inv ../examples/verification/defaultOpNames.qnt
+```
+
+### Can verify with two invariants
+
+<!-- !test check can specify multiple invariants -->
+```
+quint verify --invariant inv,inv2 ../examples/verification/defaultOpNames.qnt
+```
+
+## Violations
+
+### Variant violations are reported with traces
+
+<!-- !test in prints a trace on invariant violation -->
+```
+quint verify --invariant inv ./testFixture/apalache/violateOnFive.qnt
+```
+
+<!-- !test exit 1 -->
+<!-- !test err prints a trace on invariant violation -->
+```
+```

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -227,8 +227,9 @@ const verifyCmd = {
         default: 'step',
       })
       .option('invariant', {
-        desc: 'invariant to check: a definition name or an expression',
+        desc: 'the invariants to check, separated by a comma',
         type: 'string',
+        coerce: (s: string) => s.split(','),
       })
       .option('apalache-config', {
         desc: 'Filename of the additional Apalache configuration (in the HOCON format, a superset of JSON)',

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -629,9 +629,6 @@ export function outputResult(result: CLIProcedure<ProcedureStage>) {
       } else {
         const finder = lineColumn(sourceCode!)
         errors.forEach(err => console.error(formatError(sourceCode, finder, err)))
-        // if (stage.trace) {
-        //   console.error(stage.trace)
-        // }
         console.error(`error: ${msg}`)
       }
       process.exit(1)

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -432,7 +432,6 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
   const mainArg = prev.args.main
   const mainName = mainArg ? mainArg : basename(prev.args.input, '.qnt')
   const verbosityLevel = !prev.args.out && !prev.args.outItf ? prev.args.verbosity : 0
-  const columns = !prev.args.out ? terminalWidth() : 80
   const rngOrError = mkRng(prev.args.seed)
   if (rngOrError.isLeft()) {
     return cliErr(rngOrError.value, { ...simulator, errors: [] })
@@ -461,7 +460,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
       if (verbosity.hasStateOutput(options.verbosity)) {
         console.log(chalk.gray('An example execution:\n'))
         const myConsole = {
-          width: columns,
+          width: terminalWidth(),
           out: (s: string) => process.stdout.write(s),
         }
         printTrace(myConsole, result.states, result.frames)

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -560,7 +560,7 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
       .map(_ => ({ ...verifying, status: 'ok', errors: [] } as VerifiedStage))
       .mapLeft(err => ({
         msg: err.explanation,
-        stage: { ...verifying, status: 'failure', errors: err.errors },
+        stage: { ...verifying, status: 'failure', errors: err.errors, trace: err.trace },
       }))
   )
 }
@@ -612,6 +612,9 @@ export function outputResult(result: CLIProcedure<ProcedureStage>) {
       } else {
         const finder = lineColumn(sourceCode!)
         errors.forEach(err => console.error(formatError(sourceCode, finder, err)))
+        if (stage.trace) {
+          console.error(stage.trace)
+        }
         console.error(`error: ${msg}`)
       }
       process.exit(1)

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -24,6 +24,7 @@ import * as grpc from '@grpc/grpc-js'
 import * as proto from '@grpc/proto-loader'
 import { setTimeout } from 'timers/promises'
 import { promisify } from 'util'
+import { ItfTrace } from './itf'
 
 const APALACHE_SERVER_URI = 'localhost:8822'
 // These will be addressed as we work out the packaging for apalche
@@ -31,13 +32,11 @@ const APALACHE_SERVER_URI = 'localhost:8822'
 // TODO const APALACHE_VERSION = "0.30.8"
 // TODO const DEFAULT_HOME = path.join(__dirname, 'apalache')
 
-type ItfTrace = any
-
 // The structure used to report errors
 type VerifyError = {
   explanation: string
   errors: ErrorMessage[]
-  trace?: ItfTrace
+  traces?: ItfTrace[]
 }
 
 export type VerifyResult<T> = Either<VerifyError, T>
@@ -60,7 +59,7 @@ function handleVerificationFailure(failure: { pass_name: string; error_data: any
   switch (failure.pass_name) {
     case 'BoundedChecker':
       if (failure.error_data.checking_result == 'Error') {
-        return { explanation: 'A counterexample was found', trace: failure.error_data.counterexamples, errors: [] }
+        return { explanation: 'A counterexample was found', traces: failure.error_data.counterexamples, errors: [] }
       } else {
         // TODO
         throw new Error(`internal error: unhandled verification error ${failure}`)
@@ -136,8 +135,8 @@ type ShaiPkg = {
 }
 
 // Helper to construct errors results
-function err<A>(explanation: string, errors: ErrorMessage[] = [], trace?: ItfTrace): VerifyResult<A> {
-  return left({ explanation, errors, trace })
+function err<A>(explanation: string, errors: ErrorMessage[] = [], traces?: ItfTrace[]): VerifyResult<A> {
+  return left({ explanation, errors, traces })
 }
 
 function findApalacheDistribution(): VerifyResult<ApalacheDist> {

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -58,14 +58,16 @@ type Apalache = {
 function handleVerificationFailure(failure: { pass_name: string; error_data: any }): VerifyError {
   switch (failure.pass_name) {
     case 'BoundedChecker':
-      if (failure.error_data.checking_result == 'Error') {
-        return { explanation: 'A counterexample was found', traces: failure.error_data.counterexamples, errors: [] }
-      } else {
-        // TODO
-        throw new Error(`internal error: unhandled verification error ${failure}`)
+      switch (failure.error_data.checking_result) {
+        case 'Error':
+          return { explanation: 'found a counterexample', traces: failure.error_data.counterexamples, errors: [] }
+        case 'Deadlock':
+          return { explanation: 'reached a deadlock', traces: failure.error_data.counterexamples, errors: [] }
+        default:
+          throw new Error(`internal error: unhandled verification error ${failure.error_data.checking_result}`)
       }
     default:
-      throw new Error(`internal error: unhandled verification error ${failure}`)
+      throw new Error(`internal error: unhandled verification error at pass ${failure.pass_name}`)
   }
 }
 

--- a/quint/testFixture/apalache/README.md
+++ b/quint/testFixture/apalache/README.md
@@ -1,0 +1,3 @@
+Specs used only to test the Apalache integration.
+
+See [../../apalache-tests.md](../../apalache-tests.md) for the test cases.

--- a/quint/testFixture/apalache/deadlock.qnt
+++ b/quint/testFixture/apalache/deadlock.qnt
@@ -1,0 +1,10 @@
+// This spec defines a model that is deadlocked on the 5th step.
+module deadlock {
+  var n: int
+
+  action init = n' = 1
+  action step = all {
+    n < 5,
+    n' = n + 1
+  }
+}

--- a/quint/testFixture/apalache/violateOnFive.qnt
+++ b/quint/testFixture/apalache/violateOnFive.qnt
@@ -1,0 +1,9 @@
+// This spec defines a model with an invariant
+// that will be violated on the 5th step.
+module violateOnFive {
+  var n: int
+
+  action init = n' = 1
+  action step = n' = n + 1
+  def inv = n < 5
+}


### PR DESCRIPTION
Towards #888

This adds handling for variant violations and deadlocked errors reported by Apalache.

There are also tests added for CLI configuration via `--step` and `--init` flags.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [x] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
