### PR TITLE
Fix pretty printing of lambdas

### DIFF
--- a/quint/src/IRprinting.ts
+++ b/quint/src/IRprinting.ts
@@ -111,7 +111,7 @@ export function expressionToString(expr: QuintEx): string {
     case 'app':
       return `${expr.opcode}(${expr.args.map(expressionToString).join(', ')})`
     case 'lambda':
-      return `(${expr.params.map(p => p.name).join(', ')} => ${expressionToString(expr.expr)})`
+      return `((${expr.params.map(p => p.name).join(', ')}) => ${expressionToString(expr.expr)})`
     case 'let':
       return `${definitionToString(expr.opdef)} { ${expressionToString(expr.expr)} }`
   }

--- a/quint/test/IRVisitor.test.ts
+++ b/quint/test/IRVisitor.test.ts
@@ -37,9 +37,9 @@ describe('walkModule', () => {
       'N',
       '1',
       '"rainbow"',
-      'filter(S, (x => iadd(x, 1)))',
+      'filter(S, ((x) => iadd(x, 1)))',
       'S',
-      '(x => iadd(x, 1))',
+      '((x) => iadd(x, 1))',
       'iadd(x, 1)',
       'x',
       '1',
@@ -57,8 +57,8 @@ describe('walkModule', () => {
       'x',
       '1',
       'iadd(x, 1)',
-      '(x => iadd(x, 1))',
-      'filter(S, (x => iadd(x, 1)))',
+      '((x) => iadd(x, 1))',
+      'filter(S, ((x) => iadd(x, 1)))',
       'false',
       'x',
       'val x = false { x }',
@@ -91,7 +91,7 @@ describe('walkModule', () => {
       'assume _ = igt(N, 1)',
       'import M.*',
       'import A(x = "rainbow") as A1',
-      'val f = filter(S, (x => iadd(x, 1)))',
+      'val f = filter(S, ((x) => iadd(x, 1)))',
       'def l = val x = false { x }',
       'val x = false', // From the let definition
     ]
@@ -103,7 +103,7 @@ describe('walkModule', () => {
       'assume _ = igt(N, 1)',
       'import M.*',
       'import A(x = "rainbow") as A1',
-      'val f = filter(S, (x => iadd(x, 1)))',
+      'val f = filter(S, ((x) => iadd(x, 1)))',
       'val x = false', // From the let definition
       'def l = val x = false { x }',
     ]
@@ -164,13 +164,13 @@ describe('walkModule', () => {
       }
 
       const enteredDefinitions = [
-        'val f = filter(S, (x => iadd(x, 1)))',
+        'val f = filter(S, ((x) => iadd(x, 1)))',
         'def l = val x = false { x }',
         'val x = false', // From the let definition
       ]
 
       const exitedDefinitions = [
-        'val f = filter(S, (x => iadd(x, 1)))',
+        'val f = filter(S, ((x) => iadd(x, 1)))',
         'val x = false', // From the let definition
         'def l = val x = false { x }',
       ]
@@ -389,7 +389,7 @@ describe('walkModule', () => {
   assume _ = igt(N, 1)
   import M.*
   import A(x = "rainbow") as A1
-  val f = filter(S, (x => iadd(x, 1)))
+  val f = filter(S, ((x) => iadd(x, 1)))
   def l = val x = false { x }
 }`,
       ]
@@ -472,9 +472,9 @@ describe('walkModule', () => {
         }
       }
 
-      const enteredExpressions = ['igt(N, 1)', 'filter(S, (x => iadd(x, 1)))', 'iadd(x, 1)']
+      const enteredExpressions = ['igt(N, 1)', 'filter(S, ((x) => iadd(x, 1)))', 'iadd(x, 1)']
 
-      const exitedExpressions = ['igt(N, 1)', 'iadd(x, 1)', 'filter(S, (x => iadd(x, 1)))']
+      const exitedExpressions = ['igt(N, 1)', 'iadd(x, 1)', 'filter(S, ((x) => iadd(x, 1)))']
 
       const visitor = new TestVisitor()
       walkModule(visitor, quintModule)
@@ -496,7 +496,7 @@ describe('walkModule', () => {
         }
       }
 
-      const enteredExpressions = ['(x => iadd(x, 1))']
+      const enteredExpressions = ['((x) => iadd(x, 1))']
 
       const exitedExpressions = enteredExpressions
 

--- a/quint/test/IRprinting.test.ts
+++ b/quint/test/IRprinting.test.ts
@@ -10,7 +10,7 @@ describe('moduleToString', () => {
   it('pretty prints the module', () => {
     const expectedModule = `module wrapper {
   var S: Set[int]
-  val f = filter(S, (x => iadd(x, 1)))
+  val f = filter(S, ((x) => iadd(x, 1)))
 }`
     assert.deepEqual(moduleToString(quintModule), expectedModule)
   })
@@ -19,13 +19,13 @@ describe('moduleToString', () => {
 describe('definitionToString', () => {
   it('pretty prints op definitions', () => {
     const def = buildDef('val f = S.filter(x => x + 1)')
-    const expectedDef = 'val f = filter(S, (x => iadd(x, 1)))'
+    const expectedDef = 'val f = filter(S, ((x) => iadd(x, 1)))'
     assert.deepEqual(definitionToString(def), expectedDef)
   })
 
   it('pretty prints typed op definitions', () => {
     const def = buildDef('val f: Set[int] = S.filter(x => x + 1)')
-    const expectedDef = 'val f: Set[int] = filter(S, (x => iadd(x, 1)))'
+    const expectedDef = 'val f: Set[int] = filter(S, ((x) => iadd(x, 1)))'
     assert.deepEqual(definitionToString(def), expectedDef)
   })
 
@@ -111,13 +111,13 @@ describe('expressionToString', () => {
 
   it('pretty prints lambda expressions', () => {
     const expr = buildExpression('S.map(x => f(x))')
-    const expectedExpr = 'map(S, (x => f(x)))'
+    const expectedExpr = 'map(S, ((x) => f(x)))'
     assert.deepEqual(expressionToString(expr), expectedExpr)
   })
 
   it('multi argument lambdas retain correct semantics', () => {
     const expr = buildExpression('foo((f, b) => f(b), 1, 2)')
-    const expectedExpr = 'foo((f, b => f(b)), 1, 2)'
+    const expectedExpr = 'foo(((f, b) => f(b)), 1, 2)'
     assert.deepEqual(expressionToString(expr), expectedExpr)
   })
 

--- a/quint/test/effects/inferrer.test.ts
+++ b/quint/test/effects/inferrer.test.ts
@@ -213,7 +213,7 @@ describe('inferEffects', () => {
               "Trying to unify (Read[v3] & Temporal[v4], (Read[v3] & Temporal[v4]) => Read[v5] & Temporal[v6]) => Read[v3, v5] & Temporal[v4, v6] and (Pure, (Read[v2]) => Read[v2] & Update['x']) => e1",
           },
         ],
-        location: 'Trying to infer effect for operator application in map(S, (p => assign(x, p)))',
+        location: 'Trying to infer effect for operator application in map(S, ((p) => assign(x, p)))',
       })
     )
   })

--- a/quint/test/flatenning.test.ts
+++ b/quint/test/flatenning.test.ts
@@ -125,11 +125,11 @@ describe('flatten', () => {
     const expectedDefs = [
       'pure val A1::N: int = 1',
       'var A1::x: int',
-      'pure def A1::f = (A1::a => iadd(A1::a, 1))',
+      'pure def A1::f = ((A1::a) => iadd(A1::a, 1))',
       `action A1::V = assign(A1::x, A1::f(A1::x))`,
       'assume A1::T = igt(A1::N, 0)',
-      'def A1::lam = val A1::b = 1 { (A1::a => iadd(A1::b, A1::a)) }',
-      'def A1::lam2 = val A1::b = 1 { (A1::a => iadd(A1::b, A1::a)) }',
+      'def A1::lam = val A1::b = 1 { ((A1::a) => iadd(A1::b, A1::a)) }',
+      'def A1::lam2 = val A1::b = 1 { ((A1::a) => iadd(A1::b, A1::a)) }',
     ]
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
@@ -140,7 +140,7 @@ describe('flatten', () => {
 
     const defs = ['import A.*']
 
-    const expectedDefs = ['val f = (x => iadd(x, 1))']
+    const expectedDefs = ['val f = ((x) => iadd(x, 1))']
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
   })
@@ -150,7 +150,7 @@ describe('flatten', () => {
 
     const defs = ['import A.*', 'export A.*']
 
-    const expectedDefs = ['val f = (x => iadd(x, 1))']
+    const expectedDefs = ['val f = ((x) => iadd(x, 1))']
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
   })
@@ -160,7 +160,7 @@ describe('flatten', () => {
 
     const defs = ['export A.*']
 
-    const expectedDefs = ['val f = (x => iadd(x, 1))']
+    const expectedDefs = ['val f = ((x) => iadd(x, 1))']
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
   })


### PR DESCRIPTION
Hello :octocat: 

Our grammar and parser require lambda parameters to be wrapped in parenthesis, and the current pretty printing is not including parenthesis around parameters. This PR fixes that

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
