### PR TITLE
Support imports & module instances in `quint verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ completely implementing every pass.
 | [Records][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | [Discriminated unions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: [244][]        | :x: [539][]        | :x:                | :x:                |
 | [Tuples][]                        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :green_circle:     | :white_check_mark: |
-| [Imports][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :white_check_mark: |
+| [Imports][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Module definitions][]            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [Module instances][]              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| [Module instances][]              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
 | [Multiple files][]                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Constant declarations][]         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | [Variable definitions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/examples/classic/sequential/BinSearch/BinSearch10.qnt
+++ b/examples/classic/sequential/BinSearch/BinSearch10.qnt
@@ -4,7 +4,5 @@ module BinSearch10 {
     INPUT_SEQ=[ 1, 2, 3, 4, 5, 6, 8, 9, 10, 33 ],
     INPUT_KEY=7,
     INT_WIDTH=16
-  ) as I from "./BinSearch"
-
-  export I.*
+  ).* from "./BinSearch"
 }

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -73,6 +73,15 @@ quint verify --init Init --step Next ../examples/language-features/lists.qnt
 quint verify --init Init --step Next ../examples/language-features/maps.qnt
 ```
 
+### Can verify `../examples/classic/sequential/BinSearch/BinSearch10.qnt`
+
+Contains an import + const instantiation.
+
+<!-- !test check can check BinSearch10.qnt -->
+```
+quint verify --init=Init --step=Next --invariant=Postcondition ../examples/classic/sequential/BinSearch/BinSearch10.qnt
+```
+
 ### Default `step` and `init` operators are found
 
 <!-- !test check can find default operator names -->

--- a/quint/src/flattening.ts
+++ b/quint/src/flattening.ts
@@ -47,7 +47,7 @@ interface FlatteningContext {
  *
  * @param modules The modules to flatten
  * @param table The lookup table to for all referred names
- * @param idGenerator The id generator to use for new definitions
+ * @param idGenerator The id generator to use for new definitions; should be the same as used for parsing
  * @param sourceMap The source map for all modules involved
  * @param analysisOutput The analysis output for all modules involved
  *


### PR DESCRIPTION
Flatten modules in `quint verify`, to support imports and const instantiation.

- [x] Tests added for any new code
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entries added to the respective `CHANGELOG.md` for any new functionality~
- [x] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

Closes #936 