### PR TITLE
Fix release notes for releases workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         # See https://github.com/softprops/action-gh-release#-external-release-notes
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ github.workspace }}/release-notes.txt
+          body_path: ${{ github.workspace }}/release-notes.txt
       - name: Publish
         # See https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
         run: npm publish


### PR DESCRIPTION
Fixes #883

We were using the wrong field of this action, and as a result the
release notes were being included as an attachment rather than in the
body of the release.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [-] Tests added for any new code
- [-] Documentation added for any new functionality
- [-] Entries added to the respective `CHANGELOG.md` for any new functionality
- [-] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality