### PR TITLE
Ensure entities are flattened in mode checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a bug where sometimes static analysis would flag a mode error where
+  there isn't one (#960)
+
 ### Security
 
 ## v0.11.2 -- 2023-06-15

--- a/examples/cosmos/ics20/denomTrace.qnt
+++ b/examples/cosmos/ics20/denomTrace.qnt
@@ -51,7 +51,7 @@ module denomTrace {
 
   /// `channelNamesUniquePerChain` is true iff channel names are unique by chain
   pure def channelNamesUniquePerChain(topology: ChannelTopology): bool =
-    pure val chainNames = Set("A", "B", "C") // should be topology.keys(), but that's breaking the effect checker somehow (see issue #808)
+    pure val chainNames = topology.keys()
     and {
       // Check the domain for the second level of chains
       chainNames.forall(chain => topology.get(chain).keys() == chainNames),

--- a/quint/src/effects/modeChecker.ts
+++ b/quint/src/effects/modeChecker.ts
@@ -248,7 +248,7 @@ function paramEntitiesByEffect(effect: ArrowEffect): Map<ComponentKind, Entity[]
       case 'concrete': {
         p.components.forEach(c => {
           const existing = entitiesByComponentKind.get(c.kind) || []
-          entitiesByComponentKind.set(c.kind, existing.concat(c.entity))
+          entitiesByComponentKind.set(c.kind, concatEntity(existing, c.entity))
         })
         break
       }
@@ -256,12 +256,12 @@ function paramEntitiesByEffect(effect: ArrowEffect): Map<ComponentKind, Entity[]
         const nested = paramEntitiesByEffect(p)
         nested.forEach((entities, kind) => {
           const existing = entitiesByComponentKind.get(kind) || []
-          entitiesByComponentKind.set(kind, existing.concat(entities))
+          entitiesByComponentKind.set(kind, entities.reduce(concatEntity, existing))
         })
         if (p.result.kind === 'concrete') {
           p.result.components.forEach(c => {
             const existing = entitiesByComponentKind.get(c.kind) || []
-            entitiesByComponentKind.set(c.kind, existing.concat(c.entity))
+            entitiesByComponentKind.set(c.kind, concatEntity(existing, c.entity))
           })
         }
       }
@@ -269,6 +269,16 @@ function paramEntitiesByEffect(effect: ArrowEffect): Map<ComponentKind, Entity[]
   })
 
   return entitiesByComponentKind
+}
+
+function concatEntity(list: Entity[], entity: Entity): Entity[] {
+  switch (entity.kind) {
+    case 'union':
+      return entity.entities.reduce(concatEntity, list)
+    case 'concrete':
+    case 'variable':
+      return list.concat(entity)
+  }
 }
 
 const modeOrder = ['pureval', 'puredef', 'val', 'def', 'nondet', 'action', 'temporal', 'run']

--- a/quint/src/effects/modeChecker.ts
+++ b/quint/src/effects/modeChecker.ts
@@ -226,7 +226,7 @@ function modeForEffect(scheme: EffectScheme): [OpQualifier, string] {
 function addedEntities(paramEntities: Entity[], resultEntity: Entity): Entity[] {
   switch (resultEntity.kind) {
     case 'union':
-      return resultEntity.entities.filter(v => !paramEntities.some(p => isEqual(p, v)))
+      return resultEntity.entities.flatMap(entity => addedEntities(paramEntities, entity))
     case 'concrete': {
       const vars = resultEntity.stateVariables.filter(v => !paramEntities.some(p => isEqual(p, v)))
       if (vars.length === 0) {

--- a/quint/test/effects/modeChecker.test.ts
+++ b/quint/test/effects/modeChecker.test.ts
@@ -238,4 +238,13 @@ describe('checkModes', () => {
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(quintErrorToString)}`)
     assert.deepEqual(suggestions.size, 0)
   })
+
+  it('finds correct equalities between entity unions (#808)', () => {
+    const defs = ['pure def foo(s: Set[int]): bool = { tuples(s, s).forall((a,b) => (a + b).in(s)) }']
+
+    const [errors, suggestions] = checkMockedDefs(defs)
+
+    assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(quintErrorToString)}`)
+    assert.deepEqual(suggestions.size, 0)
+  })
 })


### PR DESCRIPTION
Hello :octocat: 

It's a Friday miracle, I could finally fix #808 :tada: 

I thought unpacking was doing something wrong, then I though arrow effect simplification was doing something wrong... but in the end, it was not even an effect inference issue, but a problem in mode checking!

For mode checking arrow effects, we want to see if there are entities in the result that are not present on the parameters. When mode checking an effect like `(Read[v0, v1] & Temporal[v2, v3]) => Read[v0, v1] & Temporal[v2, v3]`, we were not properly handling unions (i.e. `[v0, v1]`), so we were saying that `v2 != [v2, v3]` and `v3 != [v2, v3]`, therefore `v2` and `v3` were new temporal entities and the overall mode had to be temporal, which of course is wrong.

So I fixed the mode checker to properly recurse over unions and produce a flat list.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
