### PR TITLE
Treat .qnt files as bluespec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+# Track (large) video files via git-lfs
 *.mp4 filter=lfs diff=lfs merge=lfs -text
+
+# Treat .qnt files as bluespec (similar to vim modeline)
+*.qnt linguist-language=Bluespec


### PR DESCRIPTION
Add GH linguist override to treat `.qnt` files as Bluespec in `.gitattributes`.

This should work for all files with `.qnt` extension, similar to a `// -*- mode: Bluespec; -*-` mode line in each file.

For details, see https://github.com/github-linguist/linguist/blob/master/docs/overrides.md