### PR TITLE
Incremental compilation

### DIFF
--- a/quint/src/flattening.ts
+++ b/quint/src/flattening.ts
@@ -117,7 +117,12 @@ export function addDefToFlatModule(
   analysisOutput: AnalysisOutput,
   module: FlatModule,
   def: QuintDef
-): { flattenedModule: FlatModule; flattenedTable: LookupTable; flattenedAnalysis: AnalysisOutput } {
+): {
+  flattenedModule: FlatModule
+  flattenedDefs: FlatDef[]
+  flattenedTable: LookupTable
+  flattenedAnalysis: AnalysisOutput
+} {
   const importedModules = new Map(modules.map(m => [m.name, m]))
   const flattener = new Flatenner(idGenerator, table, sourceMap, analysisOutput, importedModules, module)
 
@@ -126,6 +131,7 @@ export function addDefToFlatModule(
 
   return {
     flattenedModule,
+    flattenedDefs,
     flattenedTable: resolveNamesOrThrow(table, sourceMap, flattenedModule),
     flattenedAnalysis: analysisOutput,
   }

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -120,7 +120,9 @@ export function compileAndTest(
           seed = options.rng.getState()
           recorder.onRunCall()
           // reset the trace
-          const traceReg = ctx.values.get(kindName('shadow', lastTraceName)) as Register
+          const traceReg = ctx.compilationState.evaluationState?.context.get(
+            kindName('shadow', lastTraceName)
+          ) as Register
           traceReg.registerValue = just(rv.mkList([]))
           // run the test
           const result = comp.eval()
@@ -209,7 +211,7 @@ export function compileAndTest(
 }
 
 function getComputableForDef(ctx: CompilationContext, def: QuintOpDef): Either<ErrorMessage[], Computable> {
-  const comp = ctx.values.get(kindName('callable', def.id))
+  const comp = ctx.compilationState.evaluationState?.context.get(kindName('callable', def.id))
   if (comp) {
     return right(comp)
   } else {

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -105,7 +105,8 @@ module __run__ {
     return errSimulationResult('error', errors)
   } else {
     // evaluate q::runResult, which triggers the simulator
-    const res: Either<string, Computable> = contextNameLookup(ctx, 'q::runResult', 'callable')
+    const evaluationState = ctx.evaluationState
+    const res: Either<string, Computable> = contextNameLookup(evaluationState.context, 'q::runResult', 'callable')
     if (res.isLeft()) {
       const errors = [{ explanation: res.value, locs: [] }] as ErrorMessage[]
       return errSimulationResult('error', errors)
@@ -127,7 +128,7 @@ module __run__ {
 
     return {
       status: status,
-      vars: ctx.vars,
+      vars: evaluationState.vars.map(v => v.name),
       states: topFrame.args.map(e => e.toQuintEx(idGen)),
       frames: topFrame.subframes,
       errors: ctx.getRuntimeErrors(),

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -40,7 +40,7 @@ function assertResultAsString(input: string, expected: string | undefined) {
 }
 
 function assertInputFromContext(context: CompilationContext, expected: string | undefined) {
-  contextNameLookup(context.evaluationState!.context, 'q::input', 'callable')
+  contextNameLookup(context.evaluationState.context, 'q::input', 'callable')
     .mapLeft(msg => assert(false, `Unexpected error: ${msg}`))
     .mapRight(value => assertComputableAsString(value, expected))
 }
@@ -67,7 +67,7 @@ function evalInContext<T>(input: string, callable: (ctx: CompilationContext) => 
 // Compile a variable definition and check that the compiled value is defined.
 function assertVarExists(kind: ComputableKind, name: string, input: string) {
   const callback = (ctx: CompilationContext) => {
-    return contextNameLookup(ctx.evaluationState!.context, `${name}`, kind)
+    return contextNameLookup(ctx.evaluationState.context, `${name}`, kind)
       .mapRight(_ => true)
       .mapLeft(msg => `Expected a definition for ${name}, found ${msg}, compiled from: ${input}`)
   }
@@ -93,7 +93,7 @@ function evalVarAfterCall(varName: string, callee: string, input: string): Eithe
     if (!key) {
       return left(`${callee} not found`)
     }
-    const run = ctx.evaluationState?.context.get(key)
+    const run = ctx.evaluationState.context.get(key)
     if (!run) {
       return left(`${callee} not found via ${key}`)
     }
@@ -103,7 +103,7 @@ function evalVarAfterCall(varName: string, callee: string, input: string): Eithe
       .map(res => {
         if ((res as RuntimeValue).toBool() === true) {
           // extract the value of the state variable
-          const nextVal = (ctx.evaluationState?.context.get(kindName('nextvar', varName)) ?? fail).eval()
+          const nextVal = (ctx.evaluationState.context.get(kindName('nextvar', varName)) ?? fail).eval()
           // using if-else, as map-or-unwrap confuses the compiler a lot
           if (nextVal.isNone()) {
             return left(`Value of the variable ${varName} is undefined`)


### PR DESCRIPTION
Hello :octocat:

This PR makes actual compilation incremental in the REPL :tada: and therefore closes #933 and #618 

On top of a `compilationState`, the REPL now also stores an (independent) `evaluationState` that stores the relevant state of the `CompilerVisitor` in order to re-instantiate it whenever a new definition or expression is evaluated in the REPL. This new evaluation state keeps track of the vars/nextvars/shadow registers, so I was able to delete some code that used to load and save those into more complicated structures.

The `compile` interface was also updated to stop depending on modules and a main. Instead, it expects a list of definitions, and the responsibility of finding the main module is delegated to its callers. That's because incremental compilation should be on the definition level (that is, allowing us to compile a single definition).

Errors inside `CompilerVisitor` are now stored in a separate class that can be kept in the evaluation state. They used to be stored in the `CompilerVisitor` instance itself, which would cause us to loose track of errors between different compilation steps.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
