### PR TITLE
Fix type quantification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where sometimes static analysis would flag a mode error where
   there isn't one (#960)
-
-- Fixed the behavior of `slice` for the case `l.slice(length(l), length(l))` (#971)
+- Fixed the behavior of `slice` for the case `l.slice(length(l), length(l))`
+  (#971)
+- Fixed a bug where definitions with nested definitions could have their
+  inferred type be too general.
 
 ### Security
 

--- a/quint/src/effects/inferrer.ts
+++ b/quint/src/effects/inferrer.ts
@@ -304,7 +304,7 @@ export class EffectInferrer implements IRVisitor {
 
         const nonFreeNames = effect.params.reduce(
           (names, p) => {
-            const { effectVariables: effectVariables, entityVariables: entityVariables } = effectNames(p)
+            const { effectVariables, entityVariables } = effectNames(p)
             return {
               effectVariables: new Set([...names.effectVariables, ...effectVariables]),
               entityVariables: new Set([...names.entityVariables, ...entityVariables]),

--- a/quint/src/types/constraintGenerator.ts
+++ b/quint/src/types/constraintGenerator.ts
@@ -27,6 +27,7 @@ import {
   QuintOpDef,
   QuintStr,
   QuintVar,
+  isAnnotatedDef,
 } from '../quintIr'
 import { QuintType, typeNames } from '../quintTypes'
 import { expressionToString, rowToString, typeToString } from '../IRprinting'
@@ -69,6 +70,11 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
   // Track location descriptions for error tree traces
   private location: string = ''
 
+  // the current depth of operator definitions: top-level defs are depth 0
+  private definitionDepth: number = 0
+
+  private freeNames: { typeVariables: Set<string>; rowVariables: Set<string> }[] = []
+
   getResult(): [Map<bigint, ErrorTree>, Map<bigint, TypeScheme>] {
     return [this.errors, this.types]
   }
@@ -77,9 +83,22 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
     this.location = `Generating constraints for ${expressionToString(e)}`
   }
 
-  exitDef(_def: QuintDef) {
+  enterDef(_def: QuintDef) {
+    this.definitionDepth++
+  }
+
+  exitDef(def: QuintDef) {
+    this.definitionDepth--
     if (this.constraints.length > 0) {
-      this.solveConstraints()
+      this.solveConstraints().map(subs => {
+        if (!isAnnotatedDef(def)) {
+          return
+        }
+
+        checkAnnotationGenerality(subs, def.typeAnnotation).mapLeft(err =>
+          this.errors.set(def.typeAnnotation?.id ?? def.id, err)
+        )
+      })
     }
   }
 
@@ -168,10 +187,18 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
   }
 
   enterLambda(expr: QuintLambda) {
+    const lastParamNames = this.currentFreeNames()
+    const paramNames = {
+      typeVariables: new Set(lastParamNames.typeVariables),
+      rowVariables: new Set(lastParamNames.rowVariables),
+    }
     expr.params.forEach(p => {
       const varName = p.name === '_' ? this.freshVarGenerator.freshVar('t') : `t_${p.name}_${p.id}`
+      paramNames.typeVariables.add(varName)
       this.addToResults(p.id, right(toScheme({ kind: 'var', name: varName })))
     })
+
+    this.freeNames.push(paramNames)
   }
 
   //    Γ ∪ {p0: t0, ..., pn: tn} ⊢ e: (te, c)    t0, ..., tn are fresh
@@ -186,7 +213,8 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
       return paramTypes
         .map((ts): TypeScheme => {
           const newType: QuintType = { kind: 'oper', args: ts, res: resultType.type }
-          return { ...typeNames(newType), type: newType }
+
+          return toScheme(newType)
         })
         .mapLeft(e => {
           throw new Error(`This should be impossible: Lambda variables not found: ${e.map(errorTreeToString)}`)
@@ -194,6 +222,7 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
     })
 
     this.addToResults(e.id, result)
+    this.freeNames.pop()
   }
 
   //   Γ ⊢ e1: (t1, c1)  s = solve(c1)     s(Γ ∪ {n: t1}) ⊢ e2: (t2, c2)
@@ -215,16 +244,10 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
     }
 
     this.fetchResult(e.expr.id).map(t => {
-      this.addToResults(e.id, right({ ...typeNames(t.type), type: t.type }))
+      this.addToResults(e.id, right(this.quantify(t.type)))
       if (e.typeAnnotation) {
         this.constraints.push({ kind: 'eq', types: [t.type, e.typeAnnotation], sourceId: e.id })
       }
-
-      this.solveConstraints().chain(subs =>
-        checkAnnotationGenerality(subs, e.typeAnnotation).mapLeft(err =>
-          this.errors.set(e.typeAnnotation?.id ?? e.id, err)
-        )
-      )
     })
   }
 
@@ -260,8 +283,11 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
         // https://github.com/informalsystems/quint/issues/690
         this.types = new Map<bigint, TypeScheme>(
           [...this.types.entries()].map(([id, te]) => {
+            // console.log(substitutionsToString(subs))
+            // console.log(typeSchemeToString(te))
+            // console.log(typeToString(te.type))
             const newType = applySubstitution(this.table, subs, te.type)
-            const scheme: TypeScheme = { ...typeNames(newType), type: newType }
+            const scheme: TypeScheme = this.quantify(newType)
             return [id, scheme]
           })
         )
@@ -309,6 +335,28 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
 
     const subs = compose(this.table, typeSubs, rowSubs)
     return applySubstitution(this.table, subs, t.type)
+  }
+
+  private currentFreeNames(): { typeVariables: Set<string>; rowVariables: Set<string> } {
+    return (
+      this.freeNames[this.freeNames.length - 1] ?? {
+        typeVariables: new Set(),
+        rowVariables: new Set(),
+      }
+    )
+  }
+
+  private quantify(type: QuintType): TypeScheme {
+    const freeNames = this.currentFreeNames()
+    const nonFreeNames = {
+      typeVariables: new Set<string>(
+        [...typeNames(type).typeVariables].filter(name => !freeNames.typeVariables.has(name))
+      ),
+      rowVariables: new Set<string>(
+        [...typeNames(type).rowVariables].filter(name => !freeNames.rowVariables.has(name))
+      ),
+    }
+    return { ...nonFreeNames, type }
   }
 }
 

--- a/quint/test/types/inferrer.test.ts
+++ b/quint/test/types/inferrer.test.ts
@@ -155,6 +155,16 @@ describe('inferTypes', () => {
     ])
   })
 
+  it('keeps track of free variables in nested scopes (#966)', () => {
+    const quintModule = buildModuleWithDefs(['def f(a) = a == "x"', 'def g(b) = val nested = (1,2) { f(b) }'])
+
+    const [errors, types] = inferTypesForModule(quintModule)
+    assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
+
+    const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
+    assert.sameDeepMembers(stringTypes, [[14n, '(str) => bool']])
+  })
+
   it('considers annotations', () => {
     const quintModule = buildModuleWithDefs(['def e(p): (int) => int = p'])
 

--- a/quint/test/types/inferrer.test.ts
+++ b/quint/test/types/inferrer.test.ts
@@ -162,7 +162,7 @@ describe('inferTypes', () => {
     assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
 
     const stringTypes = Array.from(types.entries()).map(([id, type]) => [id, typeSchemeToString(type)])
-    assert.sameDeepMembers(stringTypes, [[14n, '(str) => bool']])
+    assert.includeDeepMembers(stringTypes, [[14n, '(str) => bool']])
   })
 
   it('considers annotations', () => {


### PR DESCRIPTION
Hello :octocat: 

This fixes #966 by improving how quantification is done in the type checker. We now keep a stack of free type names and use the set of free names in the current lambda scope to decide which variables to quantify.

In a follow-up, I'll check if we need to do the same for effects.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
