### PR TITLE
Avoid `ERR_INVALID_ARG_TYPE` if `APALACHE_DIST` is not set

### DIFF
--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -22,7 +22,7 @@ APALACHE_DIST=/does/not/exist quint verify ../examples/language-features/boolean
 <!-- !test exit 1 -->
 <!-- !test err invalid APALACHE_DIST -->
 ```
-error: Specified APALACHE_DIST /does/not/exist does not exist
+error: Specified APALACHE_DIST /does/not/exist does not exist.
 ```
 
 #### Setting a corrupted `APALACHE_DIST` produces an error
@@ -38,7 +38,7 @@ APALACHE_DIST=_build quint verify ../examples/language-features/booleans.qnt 2> 
 <!-- !test exit 1 -->
 <!-- !test err corrupted APALACHE_DIST -->
 ```
-error: Apalache distribution is corrupted. Cannot find _build/lib/apalache.jar or _build/bin/apalache-mc.
+error: Apalache distribution is corrupted: cannot find _build/lib/apalache.jar. Ensure the APALACHE_DIST environment variable points to the right directory.
 ```
 
 #### Extracting the proto file from a corrupted jar file produces an error

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -143,6 +143,8 @@ function err<A>(explanation: string, errors: ErrorMessage[] = [], traces?: ItfTr
 
 function findApalacheDistribution(): VerifyResult<ApalacheDist> {
   if (!process.env.APALACHE_DIST) {
+    // TODO: fetch release if APALACHE_DIST is not configured
+    // See https://github.com/informalsystems/quint/issues/701
     return err('APALACHE_DIST enviroment variable is not set.')
   }
 

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -161,12 +161,12 @@ function findApalacheDistribution(): VerifyResult<ApalacheDist> {
 
   if (!fs.existsSync(jar)) {
     return err(
-      `Apalache distribution is corrupted: cannot find ${jar}. Ensure the APALACHE_DIST environment variable is set.`
+      `Apalache distribution is corrupted: cannot find ${jar}. Ensure the APALACHE_DIST environment variable points to the right directory.`
     )
   }
   if (!fs.existsSync(exe)) {
     return err(
-      `Apalache distribution is corrupted: cannot find ${exe}. Ensure the APALACHE_DIST environment variable is set.`
+      `Apalache distribution is corrupted: cannot find ${exe}. Ensure the APALACHE_DIST environment variable points to the right directory.`
     )
   }
 

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -142,30 +142,33 @@ function err<A>(explanation: string, errors: ErrorMessage[] = [], traces?: ItfTr
 }
 
 function findApalacheDistribution(): VerifyResult<ApalacheDist> {
-  const configuredDist =
-    process.env.APALACHE_DIST && path.isAbsolute(process.env.APALACHE_DIST)
-      ? process.env.APALACHE_DIST
-      : path.join(process.cwd(), process.env.APALACHE_DIST!)
-
-  // TODO: fetch release if APALACHE_DIST is not configured
-  // See https://github.com/informalsystems/quint/issues/701
-  let distResult: VerifyResult<string> = err(
-    'Unable to find the apalache distribution. Ensure the APALACHE_DIST enviroment variable is set.'
-  )
-
-  if (configuredDist && !fs.existsSync(configuredDist)) {
-    distResult = err(`Specified APALACHE_DIST ${configuredDist} does not exist`)
-  } else if (configuredDist) {
-    distResult = right(configuredDist)
+  if (!process.env.APALACHE_DIST) {
+    return err('APALACHE_DIST enviroment variable is not set.')
   }
 
-  return distResult.chain(dist => {
-    const jar = path.join(dist, 'lib', 'apalache.jar')
-    const exe = path.join(dist, 'bin', 'apalache-mc')
-    return fs.existsSync(jar) && fs.existsSync(exe)
-      ? right({ jar, exe })
-      : err(`Apalache distribution is corrupted. Cannot find ${jar} or ${exe}.`)
-  })
+  const dist = path.isAbsolute(process.env.APALACHE_DIST)
+    ? process.env.APALACHE_DIST
+    : path.join(process.cwd(), process.env.APALACHE_DIST!)
+
+  if (!fs.existsSync(dist)) {
+    return err(`Specified APALACHE_DIST ${dist} does not exist.`)
+  }
+
+  const jar = path.join(dist, 'lib', 'apalache.jar')
+  const exe = path.join(dist, 'bin', 'apalache-mc')
+
+  if (!fs.existsSync(jar)) {
+    return err(
+      `Apalache distribution is corrupted: cannot find ${jar}. Ensure the APALACHE_DIST environment variable is set.`
+    )
+  }
+  if (!fs.existsSync(exe)) {
+    return err(
+      `Apalache distribution is corrupted: cannot find ${exe}. Ensure the APALACHE_DIST environment variable is set.`
+    )
+  }
+
+  return right({ jar, exe })
 }
 
 // See https://grpc.io/docs/languages/node/basics/#example-code-and-setup


### PR DESCRIPTION
Fix an issue where `quint verify` crashes with `ERR_INVALID_ARG_TYPE` when `APALACHE_DIST` is not set.

Closes #905