### PR TITLE
VSCode Release v0.5.2

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+### Security
+
+## v0.5.2 -- 2023-06-23
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
 
 - Fix pretty-printing bug where types for tuples didn't have parenthesis around them (#969).
 

--- a/vscode/quint-vscode/package-lock.json
+++ b/vscode/quint-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quint-vscode",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-vscode",
-			"version": "0.5.1",
+			"version": "0.5.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "quint-vscode",
 	"displayName": "Quint",
 	"description": "Language support for Quint specifications",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"publisher": "informal",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vscode/quint-vscode/server/package-lock.json
+++ b/vscode/quint-vscode/server/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "quint-lsp-server",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-lsp-server",
-			"version": "0.5.1",
+			"version": "0.5.2",
 			"license": "Apache 2.0",
 			"dependencies": {
-				"@informalsystems/quint": "^0.11.2",
+				"@informalsystems/quint": "^0.11.3",
 				"vscode-languageserver": "^7.0.0",
 				"vscode-languageserver-textdocument": "^1.0.1",
 				"vscode-uri": "^3.0.7"
@@ -477,9 +477,9 @@
 			"dev": true
 		},
 		"node_modules/@informalsystems/quint": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.11.2.tgz",
-			"integrity": "sha512-0YD4a5TgK6C5mhuTfMyU8nKLVpT6zAr+uXbJfELGMXbnaS9e3M1Mx68udRYpy1reWhYNXNdcs2JdQ50sjrMXBQ==",
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.11.3.tgz",
+			"integrity": "sha512-bg/ZufrRtbXTMOkdyDsIJa5mWwG6Lf9FxdbNKJ2mZ3oNHjkYdTtIjHQj3+GlJnG2iotk/Zkv787NjXrs2KuC8A==",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.8.14",
 				"@grpc/proto-loader": "^0.7.7",
@@ -7109,9 +7109,9 @@
 			"dev": true
 		},
 		"@informalsystems/quint": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.11.2.tgz",
-			"integrity": "sha512-0YD4a5TgK6C5mhuTfMyU8nKLVpT6zAr+uXbJfELGMXbnaS9e3M1Mx68udRYpy1reWhYNXNdcs2JdQ50sjrMXBQ==",
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.11.3.tgz",
+			"integrity": "sha512-bg/ZufrRtbXTMOkdyDsIJa5mWwG6Lf9FxdbNKJ2mZ3oNHjkYdTtIjHQj3+GlJnG2iotk/Zkv787NjXrs2KuC8A==",
 			"requires": {
 				"@grpc/grpc-js": "^1.8.14",
 				"@grpc/proto-loader": "^0.7.7",

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "quint-lsp-server",
 	"description": "LSP server for Quint in node.",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"author": "Informal Systems",
 	"license": "Apache 2.0",
 	"engines": {
@@ -12,7 +12,7 @@
 		"url": "https://github.com/informalsystems/quint"
 	},
 	"dependencies": {
-		"@informalsystems/quint": "^0.11.2",
+		"@informalsystems/quint": "^0.11.3",
 		"vscode-languageserver": "^7.0.0",
 		"vscode-languageserver-textdocument": "^1.0.1",
 		"vscode-uri": "^3.0.7"


### PR DESCRIPTION
## v0.5.2 -- 2023-06-23

### Added
### Changed
### Deprecated
### Removed
### Fixed

- Fix pretty-printing bug where types for tuples didn't have parenthesis around them (#969).

### Security

