### PR TITLE
Inline type aliases in the type map

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ completely implementing every pass.
 | [Multiple files][]                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Constant declarations][]         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | [Variable definitions][]          | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [Assumptions][]                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :green_circle:     | :x: [235][]        | :white_check_mark: | :x:                |
+| [Assumptions][]                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: [235][]        | :white_check_mark: | :x:                |
 | [Lambdas][]                       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Multiline disjunctions][]        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [Multiline conjunctions][]        | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/examples/.scripts/README-text.md
+++ b/examples/.scripts/README-text.md
@@ -26,7 +26,7 @@ yet. To set your expectations right, check the dashboard below first.
    writing easier. We collect them here. One day some of them will become the
    standard library. If you think you have invented a nice spell that would
    help others, [contribute your spell](./spells/contribute-your-spell.md).
- 
+
  - [language-features](./language-features). These are examples that
    demonstrate some language features in isolation. They are mostly used for
    testing the tool.

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ yet. To set your expectations right, check the dashboard below first.
    writing easier. We collect them here. One day some of them will become the
    standard library. If you think you have invented a nice spell that would
    help others, [contribute your spell](./spells/contribute-your-spell.md).
- 
+
  - [language-features](./language-features). These are examples that
    demonstrate some language features in isolation. They are mostly used for
    testing the tool.
@@ -73,7 +73,7 @@ listed without any additional command line arguments.
 | [puzzles/prisoners/prisoners.qnt](./puzzles/prisoners/prisoners.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [puzzles/river/river.qnt](./puzzles/river/river.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [puzzles/tictactoe/tictactoe.qnt](./puzzles/tictactoe/tictactoe.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
-| [solidity/Coin/coin.qnt](./solidity/Coin/coin.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| [solidity/Coin/coin.qnt](./solidity/Coin/coin.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [solidity/ERC20/erc20.qnt](./solidity/ERC20/erc20.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [solidity/GradualPonzi/gradualPonzi.qnt](./solidity/GradualPonzi/gradualPonzi.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [solidity/icse23-fig7/lottery.qnt](./solidity/icse23-fig7/lottery.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |

--- a/quint/src/flattening.ts
+++ b/quint/src/flattening.ts
@@ -33,7 +33,7 @@ import { QuintType, Row } from './quintTypes'
 import { Loc, parsePhase3importAndNameResolution } from './parsing/quintParserFrontend'
 import { compact, uniqBy } from 'lodash'
 import { AnalysisOutput } from './quintAnalyzer'
-import { inlineAliasesInDef, inlineTypeAliases } from './types/aliasInliner'
+import { inlineAliasesInDef, inlineAnalysisOutput, inlineTypeAliases } from './types/aliasInliner'
 
 /**
  * Flatten an array of modules, replacing instances, imports and exports with
@@ -58,7 +58,7 @@ export function flattenModules(
   // This is not a problem atm, but might be in the future.
 
   // Inline type aliases
-  const inlined = inlineTypeAliases(modules, table)
+  const inlined = inlineTypeAliases(modules, table, analysisOutput)
   // Create a map of imported modules, to be used when flattening
   // instances/imports/exports. This is updated as the modules are flattened.
   const importedModules = new Map(inlined.modules.map(m => [m.name, m]))
@@ -94,7 +94,7 @@ export function flattenModules(
         flattenedAnalysis: flattenedAnalysis,
       }
     },
-    { flattenedModules: [] as FlatModule[], flattenedTable: inlined.table, flattenedAnalysis: analysisOutput }
+    { flattenedModules: [] as FlatModule[], flattenedTable: inlined.table, flattenedAnalysis: inlined.analysisOutput }
   )
 }
 
@@ -142,7 +142,7 @@ export function addDefToFlatModule(
     flattenedModule,
     flattenedDefs,
     flattenedTable: resolveNamesOrThrow(table, sourceMap, flattenedModule),
-    flattenedAnalysis: analysisOutput,
+    flattenedAnalysis: inlineAnalysisOutput(analysisOutput, table),
   }
 }
 

--- a/quint/src/types/aliasInliner.ts
+++ b/quint/src/types/aliasInliner.ts
@@ -19,6 +19,15 @@ import { AnalysisOutput } from '../quintAnalyzer'
 import { QuintDef, QuintModule } from '../quintIr'
 import { QuintType } from '../quintTypes'
 
+/**
+ * Inlines all type aliases in a set of QuintModules, LookupTable and AnalysisOutput.
+ *
+ * @param modules - The array of QuintModules to transform.
+ * @param table - The LookupTable containing the type aliases to be resolved.
+ * @param analysisOutput - The AnalysisOutput to transform.
+ *
+ * @returns An object containing the transformed QuintModules, LookupTable and AnalysisOutput.
+ */
 export function inlineTypeAliases(
   modules: QuintModule[],
   table: LookupTable,
@@ -43,6 +52,14 @@ export function inlineTypeAliases(
   }
 }
 
+/**
+ * Inlines all type aliases in the AnalysisOutput using the provided LookupTable.
+ *
+ * @param analysisOutput - The AnalysisOutput to transform.
+ * @param table - The LookupTable containing the type aliases to be resolved.
+ *
+ * @returns The transformed AnalysisOutput with all type aliases replaced with their resolved types.
+ */
 export function inlineAnalysisOutput(analysisOutput: AnalysisOutput, table: LookupTable): AnalysisOutput {
   const typesWithInlinedAliases = new Map(
     [...analysisOutput.types.entries()].map(([id, typeScheme]) => {

--- a/quint/src/types/constraintGenerator.ts
+++ b/quint/src/types/constraintGenerator.ts
@@ -15,6 +15,7 @@
 import { IRVisitor } from '../IRVisitor'
 import {
   QuintApp,
+  QuintAssume,
   QuintBool,
   QuintConst,
   QuintDef,
@@ -242,6 +243,17 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
       if (e.typeAnnotation) {
         this.constraints.push({ kind: 'eq', types: [t.type, e.typeAnnotation], sourceId: e.id })
       }
+    })
+  }
+
+  exitAssume(e: QuintAssume) {
+    if (this.errors.size !== 0) {
+      return
+    }
+
+    this.fetchResult(e.assumption.id).map(t => {
+      this.addToResults(e.id, right(this.quantify(t.type)))
+      this.constraints.push({ kind: 'eq', types: [t.type, { kind: 'bool' }], sourceId: e.id })
     })
   }
 

--- a/quint/test/flatenning.test.ts
+++ b/quint/test/flatenning.test.ts
@@ -5,8 +5,7 @@ import { newIdGenerator } from '../src/idGenerator'
 import { definitionToString } from '../src/IRprinting'
 import { collectIds } from './util'
 import { parse } from '../src/parsing/quintParserFrontend'
-import { toScheme } from '../src/types/base'
-import { FlatModule } from '../src'
+import { FlatModule, analyzeModules } from '../src'
 import { SourceLookupPath } from '../src/parsing/sourceResolver'
 
 describe('flattenModules', () => {
@@ -23,14 +22,16 @@ describe('flattenModules', () => {
     const { modules, table, sourceMap } = parseResult.unwrap()
     const [moduleA, _module] = modules
 
-    const originalIds = [...sourceMap.keys()]
-    const typesMap = new Map(originalIds.map(i => [i, toScheme({ kind: 'int' })]))
+    const [analysisErrors, analysisOutput] = analyzeModules(table, modules)
+    assert.isEmpty(analysisErrors)
 
-    const { flattenedModules, flattenedAnalysis } = flattenModules(modules, table, idGenerator, sourceMap, {
-      types: typesMap,
-      effects: new Map(),
-      modes: new Map(),
-    })
+    const { flattenedModules, flattenedAnalysis } = flattenModules(
+      modules,
+      table,
+      idGenerator,
+      sourceMap,
+      analysisOutput
+    )
     const [_, flattenedModule] = flattenedModules
 
     it('has all expected defs', () => {
@@ -56,7 +57,14 @@ describe('flattenModules', () => {
     it('adds new entries to the types map', () => {
       assert.includeDeepMembers(
         [...flattenedAnalysis.types.keys()],
-        flattenedModule.defs.map(def => def.id)
+        flattenedModule.defs.filter(def => def.kind !== 'typedef').map(def => def.id)
+      )
+    })
+
+    it('has no aliases in the types map', () => {
+      assert.notIncludeMembers(
+        [...flattenedAnalysis.types.values()].map(t => t.type.kind),
+        ['const']
       )
     })
   }
@@ -170,9 +178,9 @@ describe('flattenModules', () => {
   describe('inlines aliases', () => {
     const baseDefs = ['type MY_ALIAS = int', 'const N: MY_ALIAS']
 
-    const defs = ['import A(N = 1) as A1']
+    const defs = ['import A(N = 1) as A1', 'var t: A1::MY_ALIAS']
 
-    const expectedDefs = ['type A1::MY_ALIAS = int', 'pure val A1::N: int = 1']
+    const expectedDefs = ['type A1::MY_ALIAS = int', 'pure val A1::N: int = 1', 'var t: int']
 
     assertFlatennedDefs(baseDefs, defs, expectedDefs)
   })
@@ -199,8 +207,8 @@ describe('addDefToFlatModule', () => {
     const { modules, table, sourceMap } = parseResult.unwrap()
     const [moduleA, module] = modules
 
-    const originalIds = [...sourceMap.keys()]
-    const typesMap = new Map(originalIds.map(i => [i, toScheme({ kind: 'int' })]))
+    const [analysisErrors, analysisOutput] = analyzeModules(table, modules)
+    assert.isEmpty(analysisErrors)
 
     const def = module.defs[module.defs.length - 1]
     const moduleWithoutDef: FlatModule = { ...module, defs: [] }
@@ -209,7 +217,7 @@ describe('addDefToFlatModule', () => {
       table,
       idGenerator,
       sourceMap,
-      { types: typesMap, effects: new Map(), modes: new Map() },
+      analysisOutput,
       moduleWithoutDef,
       def
     )
@@ -237,7 +245,14 @@ describe('addDefToFlatModule', () => {
     it('adds new entries to the types map', () => {
       assert.includeDeepMembers(
         [...flattenedAnalysis.types.keys()],
-        flattenedModule.defs.map(def => def.id)
+        flattenedModule.defs.filter(def => def.kind !== 'typedef').map(def => def.id)
+      )
+    })
+
+    it('has no aliases in the types map', () => {
+      assert.notIncludeMembers(
+        [...flattenedAnalysis.types.values()].map(t => t.type.kind),
+        ['const']
       )
     })
   }
@@ -281,9 +296,9 @@ describe('addDefToFlatModule', () => {
   describe('type aliases', () => {
     const currentModuleDefs = ['type MY_ALIAS = int']
 
-    const defToAdd = 'const N: MY_ALIAS'
+    const defToAdd = 'var N: MY_ALIAS'
 
-    const expectedDefs = ['const N: int']
+    const expectedDefs = ['var N: int']
 
     assertAddedDefs([], currentModuleDefs, defToAdd, expectedDefs)
   })

--- a/quint/test/types/aliasInliner.test.ts
+++ b/quint/test/types/aliasInliner.test.ts
@@ -7,9 +7,9 @@ import { inlineTypeAliases } from '../../src/types/aliasInliner'
 import { QuintModule } from '../../src/quintIr'
 import { LookupTable } from '../../src/names/lookupTable'
 import { moduleToString } from '../../src/IRprinting'
-import { analyzeModules } from '../../src/quintAnalyzer'
+import { AnalysisOutput, analyzeModules } from '../../src/quintAnalyzer'
 
-function inlineModule(text: string): { modules: QuintModule[]; table: LookupTable } {
+function inlineModule(text: string): { modules: QuintModule[]; table: LookupTable; analysisOutput: AnalysisOutput } {
   const idGen = newIdGenerator()
   const fake_path: SourceLookupPath = { normalizedPath: 'fake_path', toSourceName: () => 'fake_path' }
   const parseResult = parse(idGen, 'fake_location', fake_path, text)
@@ -32,7 +32,7 @@ describe('inlineAliases', () => {
       val a = x
     }`
 
-    const { modules, table } = inlineModule(quintModule)
+    const { modules, table, analysisOutput } = inlineModule(quintModule)
 
     const expectedModule = dedent(`module A {
                                   |  type MY_ALIAS = int
@@ -42,6 +42,7 @@ describe('inlineAliases', () => {
 
     assert.deepEqual(moduleToString(modules[0]), expectedModule)
     assert.deepEqual(table.get(5n)?.typeAnnotation?.kind, 'int')
+    assert.deepEqual(analysisOutput.types.get(4n)?.type.kind, 'int')
   })
 
   it('should handle nested aliases', () => {

--- a/quint/test/types/aliasInliner.test.ts
+++ b/quint/test/types/aliasInliner.test.ts
@@ -7,6 +7,7 @@ import { inlineTypeAliases } from '../../src/types/aliasInliner'
 import { QuintModule } from '../../src/quintIr'
 import { LookupTable } from '../../src/names/lookupTable'
 import { moduleToString } from '../../src/IRprinting'
+import { analyzeModules } from '../../src/quintAnalyzer'
 
 function inlineModule(text: string): { modules: QuintModule[]; table: LookupTable } {
   const idGen = newIdGenerator()
@@ -17,7 +18,10 @@ function inlineModule(text: string): { modules: QuintModule[]; table: LookupTabl
   }
   const { modules, table } = parseResult.unwrap()
 
-  return inlineTypeAliases(modules, table)
+  const [analysisErrors, analysisOutput] = analyzeModules(table, modules)
+  assert.isEmpty(analysisErrors)
+
+  return inlineTypeAliases(modules, table, analysisOutput)
 }
 
 describe('inlineAliases', () => {


### PR DESCRIPTION
Hello :octocat: 

This is part two of two and closes #976.

This PR introduces inlining of type aliases in type maps, so when we try to get the inferred type for a definition/expression, the type will not contain any aliases (unless the alias is an uninterpreted type).

I had to change a bit our test framework for flattening in order to test this, and while doing that, I stumbled upon a problem where we weren't adding types for `assume` expressions to the type map. That was easy enough to fix.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [-] Documentation added for any new functionality
- [-] Entries added to the respective `CHANGELOG.md` for any new functionality
- [X] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
