### PR TITLE
Added a spell for the absolute value

### DIFF
--- a/examples/spells/basicSpells.qnt
+++ b/examples/spells/basicSpells.qnt
@@ -47,6 +47,20 @@ module basicSpells {
     assert(max(-5, -3) == -3),
   }
 
+  /// Compute the absolute value of an integer
+  ///
+  /// - @param __i : an integer whose absolute value we are interested in
+  /// - @returns |__i|, the absolute value of __i
+  pure def abs(__i: int): int = {
+    if (__i < 0) -__i else __i
+  }
+
+  run absTest = all {
+    assert(abs(3) == 3),
+    assert(abs(-3) == 3),
+    assert(abs(0) == 0),
+  }
+
   /// Remove a set element.
   ///
   /// - @param __set a set to remove an element from


### PR DESCRIPTION
This is a simple PR that adds `abs` to basic spells (I found myself needing it a couple of times).
My assumption is that this (since it is not a new functionality) does not need any update to CHANGELOG, let me know if I am wrong about that.
<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
