### PR TITLE
PR template comment on CI update checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,3 +4,16 @@
 - [ ] Documentation added for any new functionality
 - [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
 - [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
+
+<!--
+There are also some checks in the CI that enforce updates. This is only a
+heads up in case your checks unexpectedly fail, but you can also run these
+update commands preemptively to avoid any surprises:
+- The formatting in all files is consistent with the project's style.
+   - Run `npm run format` to automatically format all files.
+- The `examples/README.md` file must be updated if any new examples are added or
+  if their ability to go through each stage of the pipeline changes.
+   - Run `make examples` to automatically update this file locally.
+- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
+   - Run `npm run generate` to automatically update these files locally.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,14 +6,12 @@
 - [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality
 
 <!--
-There are also some checks in the CI that enforce updates. This is only a
-heads up in case your checks unexpectedly fail, but you can also run these
-update commands preemptively to avoid any surprises:
+Some common CI checks and how to fix them (if failing):
 - The formatting in all files is consistent with the project's style.
    - Run `npm run format` to automatically format all files.
-- The `examples/README.md` file must be updated if any new examples are added or
-  if their ability to go through each stage of the pipeline changes.
-   - Run `make examples` to automatically update this file locally.
+- The `examples/README.md` file contains all Quint files in `examples/`
+  and correctly lists their ability to go through pipeline stages.
+   - Run `make examples` to automatically regenerate this file locally.
 - The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
    - Run `npm run generate` to automatically update these files locally.
 -->


### PR DESCRIPTION
Hello :octocat: 

@Kukovec raised the problem that CI can unexpectedly fail if the PR author doesn't know about some auto-generated files requiring updates. This adds a comment to the PR template to act as a heads up that it can happen, and also explains how to prevent it or act upon it.

I'm not super confident about the text, so suggestions are welcome!
