### PR TITLE
Remove unused state var in `clockSync3.qnt`

### DIFF
--- a/examples/classic/distributed/ClockSync/clockSync3.qnt
+++ b/examples/classic/distributed/ClockSync/clockSync3.qnt
@@ -46,9 +46,6 @@ module clockSync3Spec {
     /// Hardware clock of a process
     var hc: PROC -> int
 
-    /// Clock adjustment of a process
-    var adj: PROC -> int
-
     /// Messages sent by the processes
     var msgs: MSGS
 
@@ -76,7 +73,6 @@ module clockSync3Spec {
         { nondet hc0 = oneOf(setOfMaps(Procs, Nat))
           hc' = hc0 },
         msgs'  = Set(),
-        adj'   = Procs.mapBy(_ => 0),
         state' = Procs.mapBy(_ => "init"),
         rcvd'  = Procs.mapBy(_ => Set()),
     }


### PR DESCRIPTION
Remove the unused state variable `adj` from `clockSync3.qnt`.
This corresponds to unimplemented functionality in the [TLA+ template](https://github.com/informalsystems/tla-apalache-workshop/blob/main/examples/clock-sync/ClockSync3.tla) where this was translated from.

The variable was declared and initialized, but overlooked in the other actions.

@bugarela Shouldn't the effects checker notice a missing assignment?
It was only flagged in Apalache's transition finder.