### PR TITLE
Cache results of `scopesForId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- One internal cache was added to the name resolution step, improving
+  performance for large specs (#1001)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/quint/src/names/definitionsByName.ts
+++ b/quint/src/names/definitionsByName.ts
@@ -125,24 +125,26 @@ export function addTypeToTable(def: TypeDefinition, table: DefinitionsByName) {
 /**
  * Lookup a name in the value definitions in a definitions table
  *
- * @param table the definitions table to be scanned
- * @param scopeTree the scope tree for the module where the name occurs
- * @param name the name of the definition to be found
- * @param scope the expression id where the name occurs
+ * @param table - The definitions table to be scanned.
+ * @param scopeTree - The scope tree for the module where the name occurs.
+ * @param name - The name of the definition to be found.
+ * @param scope - The expression id where the name occurs.
+ * @param cache - A map of cached scope ids.
  *
- * @returns the value definition, if found under the scope. Otherwise, undefined
+ * @returns The value definition, if found under the scope. Otherwise, undefined.
  */
 export function lookupValue(
   table: DefinitionsByName,
   scopeTree: ScopeTree,
   name: string,
-  scope: bigint
+  scope: bigint,
+  cache: Map<bigint, bigint[]>
 ): ValueDefinition | undefined {
   if (!table.valueDefinitions.has(name)) {
     return undefined
   }
 
-  return filterScope(table.valueDefinitions.get(name)!, scopesForId(scopeTree, scope))[0]
+  return filterScope(table.valueDefinitions.get(name)!, scopesForId(scopeTree, scope, cache))[0]
 }
 
 /**

--- a/quint/src/names/definitionsScanner.ts
+++ b/quint/src/names/definitionsScanner.ts
@@ -54,11 +54,12 @@ export type DefinitionsConflictResult = Either<Conflict[], void>
  */
 export function scanConflicts(table: DefinitionsByName, tree: ScopeTree): DefinitionsConflictResult {
   const conflicts: Conflict[] = []
+  const cache: Map<bigint, bigint[]> = new Map()
   table.valueDefinitions.forEach((defs, identifier) => {
     // Value definition conflicts depend on scope
     const conflictingDefinitions = defs.filter(def =>
       defs.some(d => {
-        return !isEqual(d, def) && canConflict(tree, d, def)
+        return !isEqual(d, def) && canConflict(d, def, tree, cache)
       })
     )
 
@@ -89,11 +90,11 @@ export function scanConflicts(table: DefinitionsByName, tree: ScopeTree): Defini
   }
 }
 
-function canConflict(tree: ScopeTree, d1: ValueDefinition, d2: ValueDefinition): Boolean {
+function canConflict(d1: ValueDefinition, d2: ValueDefinition, tree: ScopeTree, cache: Map<bigint, bigint[]>): Boolean {
   return (
     !d1.scope ||
     !d2.scope ||
-    scopesForId(tree, d1.scope).includes(d2.scope) ||
-    scopesForId(tree, d2.scope).includes(d1.scope)
+    scopesForId(tree, d1.scope, cache).includes(d2.scope) ||
+    scopesForId(tree, d2.scope, cache).includes(d1.scope)
   )
 }

--- a/quint/src/names/nameResolver.ts
+++ b/quint/src/names/nameResolver.ts
@@ -73,6 +73,7 @@ class NameResolverVisitor implements IRVisitor {
   table: LookupTable = new Map()
 
   private scopeTree: ScopeTree
+  private cache: Map<bigint, bigint[]> = new Map()
   private definitionsByName: DefinitionsByName
   private lastDefName: string = ''
 
@@ -124,7 +125,7 @@ class NameResolverVisitor implements IRVisitor {
 
   // Check that there is a value definition for `name` under scope `id`
   private checkScopedName(name: string, id: bigint) {
-    const def = lookupValue(this.definitionsByName, this.scopeTree, name, id)
+    const def = lookupValue(this.definitionsByName, this.scopeTree, name, id, this.cache)
     if (!def) {
       this.recordError('value', name, id)
       return

--- a/quint/src/names/scoping.ts
+++ b/quint/src/names/scoping.ts
@@ -28,21 +28,26 @@ export interface ScopeTree {
 }
 
 /**
- * Recursively search for a node in the scope tree and return a list with
- * all of its parents until the root of the tree
+ * Recursively search for a node in the scope tree and return a list with all of
+ * its parents until the root of the tree
  *
- * @param treeNode the tree to search from
- * @param id the id to be searched
+ * @param treeNode - The tree to search from.
+ * @param id - The id to be searched.
+ * @param cache - An optional cache to store previously computed results.
  *
- * @returns a list of ids, including the given id, for scopes this id belongs to,
- *          ordered from the node itself to the module root
+ * @returns A list of ids, including the given id, for scopes this id belongs
+ *          to, ordered from the node itself to the module root.
  */
-export function scopesForId(treeNode: ScopeTree, id: bigint): bigint[] {
+export function scopesForId(treeNode: ScopeTree, id: bigint, cache?: Map<bigint, bigint[]>): bigint[] {
   if (treeNode.value === id) {
     return [treeNode.value]
   }
 
-  return treeNode.children.flatMap(child => {
+  if (cache && cache.has(id)) {
+    return cache.get(id)!
+  }
+
+  const result = treeNode.children.flatMap(child => {
     const childScopes = scopesForId(child, id)
     // if it's under some of the node's children scope, then it is under the node's scope
     if (childScopes.length > 0) {
@@ -51,6 +56,12 @@ export function scopesForId(treeNode: ScopeTree, id: bigint): bigint[] {
 
     return []
   })
+
+  if (cache) {
+    cache.set(id, result)
+  }
+
+  return result
 }
 
 /**


### PR DESCRIPTION
Hello :octocat: 

Towards #994 

This is a small addition that improves performance significantly. The problem here is a bit more structural in the name resolution step, which also doesn't have a good interface to enable incremental resolution at the moment.

I will address the structural problems (probably next week), but I decided to propose this small change right now as I had already implemented it and the performance improvement can be useful for our users (specially Manu, whose spec was taking ~60s to load and now takes ~25s).

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [X] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
