### PR TITLE
Small improvements/fixes to the examples tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # @file
 # @version 0.1
 
-.PHONY: vscode quint local tutorials docs all apalache examples
+.PHONY: vscode quint local tutorials docs all apalache examples ./examples/README.md
 
 all: vscode
 

--- a/examples/.scripts/run-examples.sh
+++ b/examples/.scripts/run-examples.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 EXAMPLES_DIR="${SCRIPT_DIR}/.."
 cd "$EXAMPLES_DIR"
 
-export APALACHE_DIST=../quint/_build/apalache
+export APALACHE_DIST=${APALACHE_DIST:-../quint/_build/apalache}
 # Start the apalache server
 "$APALACHE_DIST"/bin/apalache-mc server &> /dev/null &
 


### PR DESCRIPTION
Two small improvements/fixes to the examples tooling:
- Make target for `examples/README.md` phony, so that it can be run even when the example sources don't change (e.g., to test Apalache modifications)
- Use `APALACHE_DIST` in `run-examples.sh` if already set, to allow reusing a local Apalache repo