### PR TITLE
Install GNU parallel on macOS runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,6 +142,11 @@ jobs:
           make apalache
         env:
           GH_TOKEN: ${{ github.token }}
+      - if: matrix.operating-system == 'macos-latest'
+        # TODO(#1004): Workaround for GNU parallel not being available on macOS
+        # We should find a better way of managing dev dependencies.
+        name: Install GNU parallel
+        run: brew install parallel
       - name: Ensure the examples dashboard is up to date
         run: |
           # Update the examples dashboard


### PR DESCRIPTION
GNU parallel is not available on the macOS CI runner.
Install it through homebrew.

This is more of a workaround, we should find a better way of handling dev dependencies. /cc @shonfeder 

Closes #1004