### PR TITLE
Update examples table

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ listed without any additional command line arguments.
 
 | Example | Syntax (`parse`) | Types (`typecheck`) | Unit tests (`test`) | Apalache (`verify`) |
 |---------|:----------------:|:-------------------:|:-------------------:|:-------------------:|
-| [classic/distributed/ClockSync/clockSync3.qnt](./classic/distributed/ClockSync/clockSync3.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| [classic/distributed/ClockSync/clockSync3.qnt](./classic/distributed/ClockSync/clockSync3.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [classic/distributed/ewd840/ewd840.qnt](./classic/distributed/ewd840/ewd840.qnt) | :white_check_mark: | :x: | :x: | :x: |
 | [classic/distributed/LamportMutex/LamportMutex.qnt](./classic/distributed/LamportMutex/LamportMutex.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [classic/distributed/Paxos/Paxos.qnt](./classic/distributed/Paxos/Paxos.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |


### PR DESCRIPTION
Update the examples table to reflect recent updates in Apalache.

The changes in Apalache [v0.40.5](https://github.com/informalsystems/apalache/pull/2624) and [v0.40.6](https://github.com/informalsystems/apalache/pull/2630) in combination enable `clockSync3`.

I'm opening the PR for review now; CI will pass when https://github.com/informalsystems/apalache/pull/2630 is merged and the release is published.