### PR TITLE
Add instantiating module to `LamportMutex`

### DIFF
--- a/examples/.scripts/run-example.sh
+++ b/examples/.scripts/run-example.sh
@@ -27,11 +27,21 @@ get_main () {
   echo "${main}"
 }
 
+get_verify_args () {
+  local file="$1"
+  local args=""
+  if [[ "$file" == "classic/distributed/LamportMutex/LamportMutex.qnt" ]] ; then
+    args="--init=Init --step=Next"
+  fi
+  echo "${args}"
+}
+
 file="$1"
 syntax="$(result "quint parse ${file}")"
 types="$(result "quint typecheck ${file}")"
 main="$(get_main "${file}")"
 tests="$(result "quint test ${main} ${file}")"
-verify="$(result "quint verify --max-steps=5 ${main} ${file}")"
+verify_args="$(get_verify_args "${file}")"
+verify="$(result "quint verify --max-steps=5 ${verify_args} ${main} ${file}")"
 
 echo "| [${file}](./${file}) | ${syntax} | ${types} | ${tests} | ${verify} |"

--- a/examples/.scripts/run-example.sh
+++ b/examples/.scripts/run-example.sh
@@ -18,10 +18,20 @@ result () {
     fi
 }
 
+get_main () {
+  local file="$1"
+  local main=""
+  if [[ "$file" == "classic/distributed/LamportMutex/LamportMutex.qnt" ]] ; then
+    main="--main=LamportMutex_3_10"
+  fi
+  echo "${main}"
+}
+
 file="$1"
 syntax="$(result "quint parse ${file}")"
 types="$(result "quint typecheck ${file}")"
-tests="$(result "quint test ${file}")"
-verify="$(result "quint verify --max-steps=5 ${file}")"
+main="$(get_main "${file}")"
+tests="$(result "quint test ${main} ${file}")"
+verify="$(result "quint verify --max-steps=5 ${main} ${file}")"
 
 echo "| [${file}](./${file}) | ${syntax} | ${types} | ${tests} | ${verify} |"

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ listed without any additional command line arguments.
 |---------|:----------------:|:-------------------:|:-------------------:|:-------------------:|
 | [classic/distributed/ClockSync/clockSync3.qnt](./classic/distributed/ClockSync/clockSync3.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [classic/distributed/ewd840/ewd840.qnt](./classic/distributed/ewd840/ewd840.qnt) | :white_check_mark: | :x: | :x: | :x: |
-| [classic/distributed/LamportMutex/LamportMutex.qnt](./classic/distributed/LamportMutex/LamportMutex.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| [classic/distributed/LamportMutex/LamportMutex.qnt](./classic/distributed/LamportMutex/LamportMutex.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [classic/distributed/Paxos/Paxos.qnt](./classic/distributed/Paxos/Paxos.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [classic/distributed/Paxos/Voting.qnt](./classic/distributed/Paxos/Voting.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [classic/distributed/ReadersWriters/ReadersWriters.qnt](./classic/distributed/ReadersWriters/ReadersWriters.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ listed without any additional command line arguments.
 |---------|:----------------:|:-------------------:|:-------------------:|:-------------------:|
 | [classic/distributed/ClockSync/clockSync3.qnt](./classic/distributed/ClockSync/clockSync3.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [classic/distributed/ewd840/ewd840.qnt](./classic/distributed/ewd840/ewd840.qnt) | :white_check_mark: | :x: | :x: | :x: |
-| [classic/distributed/LamportMutex/LamportMutex.qnt](./classic/distributed/LamportMutex/LamportMutex.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
+| [classic/distributed/LamportMutex/LamportMutex.qnt](./classic/distributed/LamportMutex/LamportMutex.qnt) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
 | [classic/distributed/Paxos/Paxos.qnt](./classic/distributed/Paxos/Paxos.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [classic/distributed/Paxos/Voting.qnt](./classic/distributed/Paxos/Voting.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |
 | [classic/distributed/ReadersWriters/ReadersWriters.qnt](./classic/distributed/ReadersWriters/ReadersWriters.qnt) | :white_check_mark: | :white_check_mark: | :x: | :x: |

--- a/examples/classic/distributed/LamportMutex/LamportMutex.qnt
+++ b/examples/classic/distributed/LamportMutex/LamportMutex.qnt
@@ -175,3 +175,10 @@ module LamportMutex {
   // The main safety property of mutual exclusion.
   val Mutex = crit.forall(p => crit.forall(q => p == q))
 }
+
+module LamportMutex_3_10 {
+  import LamportMutex(
+    N = 3,
+    maxClock = 10
+  ).*
+}


### PR DESCRIPTION
Instantiate parameterized module `LamportMutex` to let it go through `quint test` and `quint verify`.

I chose the same parameters as in Apalache tests: https://github.com/informalsystems/apalache/blob/191bca02b14572e5b13f3dbdc8b490d4d89be50b/test/tla/MC_LamportMutexTyped.tla

This also updates the example runner to consider (hardcoded) `--main`/`--init`/`--step` that differ from the file name. This is a quick fix for now, I will revisit this with a better solution when we have a majority of the examples working.