### PR TITLE
Update Paxos example

### DIFF
--- a/examples/classic/distributed/Paxos/Paxos.qnt
+++ b/examples/classic/distributed/Paxos/Paxos.qnt
@@ -1,13 +1,4 @@
 // -*- mode: Bluespec; -*-
-// Temp fix for integration tests: mock voting definitions while files are not imported
-module Voting {
-  const Value: Set[int]       // The set of choosable values.
-  const Acceptor: Set[str]    // A set of processes that will choose a value.
-  const Quorum: Set[Set[str]] // The set of "quorums", where a quorum" is a
-
-  def ShowsSafeAt(Q, b, v) = true
-  val Inv = true
-}
 
 module Paxos {
   /***************************************************************************
@@ -244,7 +235,7 @@ module Paxos {
   (***************************************************************************/
 
 
-  import Voting(Value = Value, Acceptor = Acceptor, Quorum = Quorum) as V
+  import Voting(Value = Value, Acceptor = Acceptor, Quorum = Quorum) as V from "./Voting"
 
   // Like theorems? Then you should definitely go straight for TLA+
   // THEOREM Spec => V!Spec

--- a/examples/classic/distributed/Paxos/Paxos.qnt
+++ b/examples/classic/distributed/Paxos/Paxos.qnt
@@ -265,3 +265,11 @@ module Paxos {
      V::Inv,
   }
 }
+
+module Paxos_val2_accept3_quorum2 {
+  import Paxos(
+    Value = Set(0, 1),
+    Acceptor = Set("a1", "a2", "a3"),
+    Quorum = Set(Set("a1", "a2"))
+  ).*
+}


### PR DESCRIPTION
Update `Paxos` example:
* Replace the inline mock `Voting` module with a proper file import
* Add an instance for model checking (same parameters as in Apalache tests)

(This still doesn't pass through Apalache, because the spec uses discriminated unions, which [aren't implemented as of now](#539))