### PR TITLE
Better (more) icons in VSCode outline

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- Better icons in VSCode outline view (#1024).
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/vscode/quint-vscode/server/src/documentSymbols.ts
+++ b/vscode/quint-vscode/server/src/documentSymbols.ts
@@ -13,6 +13,19 @@ export function getDocumentSymbols(modules: QuintModule[], sourceMap: Map<bigint
 function symbolKind(def: QuintOpDef | QuintConst | QuintVar): SymbolKind {
   switch (def.kind) {
     case 'def':
+      switch (def.qualifier) {
+        case 'def':
+          return SymbolKind.Method
+        case 'puredef':
+          return SymbolKind.Function
+        case 'val':
+        case 'pureval':
+          return SymbolKind.Field
+        case 'action':
+          return SymbolKind.Event
+        case 'run':
+          return SymbolKind.Property
+      }
       return SymbolKind.Function
     case 'const':
       return SymbolKind.Constant


### PR DESCRIPTION
Assign more granular VSCode `SymbolKind`s to `QuintOpDef`s in LSP.

This results in nicer icons in the VSCode outline view:
I particularly like having separate icons for actions and runs, to find them quickly 🤓 

<img width="250" alt="Screenshot 2023-07-07 at 11 11 58" src="https://github.com/informalsystems/quint/assets/82047/4f4de52b-3329-47e4-a651-91590697fb70">