### PR TITLE
remove 'repeated'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Deprecated
 ### Removed
+
+- Operator `repeated` (#1026)
+
 ### Fixed
 ### Security
 

--- a/doc/builtin.md
+++ b/doc/builtin.md
@@ -860,33 +860,6 @@ var x: int
 run test = (x' = 1).then(x' = 2).then(x' = 3).then(assert(x == 3))
 ```
 
-## `action repeated: (bool, int) => bool`
-
-**Deprecated**: use `n.reps(A)` instead.
-
-`a.repeated(n)` is the action `a` repeated `n` times.
-
-The semantics of this operator is as follows:
-
-- When `n <= 0`, this operator is equivalent to `unchanged`.
-- When `n = 1`, `a.repeated(n)` is equivalent to `a`.
-- When `n > 1`, `a.repeated(a)`, is equivalent to `a.then(a.repeated(n - 1))`.
-
-Note that the operator `a.repeated(n)` applies `a` exactly `n` times (when `n` is
-non-negative). If you want to repeat `a` from `i` to `j` times, you can combine
-it with `orKeep`:
-
-```
-a.repeated(i).then((a.orKeep(vars)).repeated(j - i))
-```
-
-### Examples
-
-```
-var x: int
-run test = (x' = 0).then((x' = x + 1).repeated(3)).then(assert(x == 3))
-```
-
 ## `action reps: (int, (int) => bool) => bool`
 
 `n.reps(i => A(i))` or `n.reps(A)` the action `A`, `n` times.

--- a/doc/lang.md
+++ b/doc/lang.md
@@ -64,7 +64,6 @@ Table of Contents
       * [Then](#then)
       * [Reps](#reps)
         * [Example](#example)
-      * [Repeated](#repeated)
       * [Fail](#fail)
     * [Temporal operators](#temporal-operators)
       * [Always](#always)
@@ -1796,38 +1795,6 @@ The semantics of this operator is as follows:
 var x: int
 run test = (x' = 0).then(3.reps(_ => x' = x + 1)).then(assert(x == 3))
 ```
-
-*Mode:* Run.
-
-#### Repeated
-
-**Deprecated:** This operator has [usability
-*issues](https://github.com/informalsystems/quint/issues/788).
-Migrate to `reps`, as `repeated` is going [to be
-removed](https://github.com/informalsystems/quint/issues/848).
-
-The operator `repeated` has the following syntax:
-
-```scala
-A.repeated(n)
-repeated(A, n)
-```
-
-The semantics of this operator is as follows:
-
- - When `n <= 0`, this operator is equivalent to `unchanged`.
- - When `n = 1`, `a.repeated(n)` is equivalent to `a`.
- - When `n > 1`, `a.repeated(a)`, is equivalent to `a.then(a.repeated(n - 1))`.
-
-Note that the operator `A.repeated(n)` applies `A` exactly `n` times (when `n` is
-non-negative). If you want to repeat `A` from `i` to `j` times, you can combine
-it with `orKeep` as follows:
-
-```scala
-a.repeated(i).then((a.orKeep(vars)).repeated(j - i))
-```
-
-See the description of [orKeep](#OrKeep) below.
 
 *Mode:* Run.
 

--- a/quint/src/builtin.qnt
+++ b/quint/src/builtin.qnt
@@ -790,32 +790,6 @@ module builtin {
   /// ```
   action then(a, b): (bool, bool) => bool
 
-  /// **Deprecated**: use `n.reps(A)` instead.
-  ///
-  /// `a.repeated(n)` is the action `a` repeated `n` times.
-  ///
-  /// The semantics of this operator is as follows:
-  ///
-  /// - When `n <= 0`, this operator is equivalent to `unchanged`.
-  /// - When `n = 1`, `a.repeated(n)` is equivalent to `a`.
-  /// - When `n > 1`, `a.repeated(a)`, is equivalent to `a.then(a.repeated(n - 1))`.
-  ///
-  /// Note that the operator `a.repeated(n)` applies `a` exactly `n` times (when `n` is
-  /// non-negative). If you want to repeat `a` from `i` to `j` times, you can combine
-  /// it with `orKeep`:
-  ///
-  /// ```
-  /// a.repeated(i).then((a.orKeep(vars)).repeated(j - i))
-  /// ```
-  ///
-  /// ### Examples
-  ///
-  /// ```
-  /// var x: int
-  /// run test = (x' = 0).then((x' = x + 1).repeated(3)).then(assert(x == 3))
-  /// ```
-  action repeated(a, n): (bool, int) => bool
-
   /// `n.reps(i => A(i))` or `n.reps(A)` the action `A`, `n` times.
   /// The iteration number, starting with 0, is passed as an argument of `A`.
   /// As actions are usually not parameterized by the iteration number,

--- a/quint/src/effects/builtinSignatures.ts
+++ b/quint/src/effects/builtinSignatures.ts
@@ -218,7 +218,6 @@ const temporalOperators = [
 const otherOperators = [
   { name: 'assign', effect: parseAndQuantify('(Read[r1], Read[r2]) => Read[r2] & Update[r1]') },
   { name: 'then', effect: parseAndQuantify('(Read[r1] & Update[u], Read[r2] & Update[u]) => Read[r] & Update[u]') },
-  { name: 'repeated', effect: parseAndQuantify('(Read[r] & Update[u], Pure) => Read[r] & Update[u]') },
   { name: 'reps', effect: parseAndQuantify('(Pure, (Read[r1]) => Read[r2] & Update[u]) => Read[r1, r2] & Update[u]') },
   { name: 'fail', effect: propagateComponents(['read', 'update'])(1) },
   { name: 'assert', effect: propagateComponents(['read'])(1) },

--- a/quint/src/names/base.ts
+++ b/quint/src/names/base.ts
@@ -139,7 +139,6 @@ export const builtinNames = [
   'eventually',
   'next',
   'then',
-  'repeated',
   'reps',
   'fail',
   'assert',

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -848,10 +848,6 @@ export class CompilerVisitor implements IRVisitor {
         })
         break
 
-      case 'repeated':
-        this.translateRepeated(app)
-        break
-
       case 'reps':
         this.translateReps(app)
         break

--- a/quint/src/types/builtinSignatures.ts
+++ b/quint/src/types/builtinSignatures.ts
@@ -117,7 +117,6 @@ const otherOperators = [
   { name: 'assign', type: '(a, a) => bool' },
   { name: 'ite', type: '(bool, a, a) => a' },
   { name: 'then', type: '(bool, bool) => bool' },
-  { name: 'repeated', type: '(bool, int) => bool' },
   { name: 'reps', type: '(int, int => bool) => bool' },
   { name: 'fail', type: '(bool) => bool' },
   { name: 'assert', type: '(bool) => bool' },

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -925,16 +925,6 @@ describe('compiling specs to runtime values', () => {
       assertVarAfterCall('n', '12', 'run1', input)
     })
 
-    it('repeated', () => {
-      const input = dedent(
-        `var n: int
-        |run run1 = (n' = 1).then((n' = n + 1).repeated(3))
-        `
-      )
-
-      assertVarAfterCall('n', '4', 'run1', input)
-    })
-
     it('reps', () => {
       const input = dedent(
         `var n: int


### PR DESCRIPTION
Closes #848. A bit of cleanup work. This PR simply removes `repeated`, as was planned in #848.

- [x] Documentation ~added~ removed for any ~new~ removed functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
