### PR TITLE
fix the order of identifiers and numbers in vscode highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Operator `repeated` (#1026)
 
 ### Fixed
-
-- VSCode plugin: Highlighting of identifiers that contain numbers (#1028)
-
 ### Security
 
 ## v0.12.0 -- 2023-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Operator `repeated` (#1026)
 
 ### Fixed
+
+- VSCode plugin: Highlighting of identifiers that contain numbers (#1028)
+
 ### Security
 
 ## v0.12.0 -- 2023-07-06

--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- VSCode plugin: Highlighting of identifiers that contain numbers (#1028)
+
 ### Security
 
 ## v0.6.0 -- 2023-07-06

--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -18,9 +18,6 @@
 			"include": "#constants"
 		},
 		{
-			"include": "#numbers"
-		},
-		{
 			"include": "#operators"
 		},
 		{
@@ -28,6 +25,9 @@
 		},
 		{
 			"include": "#strings"
+		},
+		{
+			"include": "#numbers"
 		}
 	],
 	"repository": {


### PR DESCRIPTION
Closes #524. Fixes highlighting of identifiers that contains numbers, e.g., `Foo123`.

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality