### PR TITLE
Fix exporting modules that were imported with a qualifier

### DIFF
--- a/quint/src/names/collector.ts
+++ b/quint/src/names/collector.ts
@@ -154,6 +154,11 @@ export class NameCollector implements IRVisitor {
       return
     }
 
+    if (def.qualifiedName) {
+      const newTable = new Map([...moduleTable.entries()])
+      this.definitionsByModule.set(def.qualifiedName, newTable)
+    }
+
     const qualifier = def.defName ? undefined : def.qualifiedName ?? def.protoName
     const importableDefinitions = copyNames(moduleTable, qualifier, true)
 

--- a/quint/test/names/collector.test.ts
+++ b/quint/test/names/collector.test.ts
@@ -147,6 +147,20 @@ describe('NameCollector', () => {
       assert.deepEqual(definitions.get('T'), { kind: 'type', reference: 0n, typeAnnotation: { kind: 'int', id: 0n } })
     })
 
+    it('exports previously imported qualified definitions', () => {
+      const quintModule = buildModuleWithDefs(['import test_module as T1', 'export T1.*'], undefined, zerog)
+
+      const [errors, definitions] = collect(quintModule)
+
+      assert.isEmpty(errors)
+      assert.deepEqual(definitions.get('a'), { kind: 'def', reference: 0n })
+      assert.deepEqual(definitions.get('T'), {
+        kind: 'type',
+        reference: 0n,
+        typeAnnotation: { kind: 'int', id: 0n },
+      })
+    })
+
     it('exports specific definitions', () => {
       const quintModule = buildModuleWithDefs(['import test_module.*', 'export test_module.a'], undefined, zerog)
 


### PR DESCRIPTION
Hello :octocat: 

This is a simple fix for the scenario:
```
import X as MyX
export MyX.*
```

That is not currently working.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
