### PR TITLE
Output the execution stack on undefined values in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- `quint repl` produces an evaluation trace on errors too (#1056)
+
 ### Changed
 
 - `quint run` produces a friendlier message when it meets a `const` (#1050)

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -279,6 +279,7 @@ exit $exit_code
 
 
   Use --verbosity=3 to show executions.
+      HOME/failingTestCounters.qnt
 ```
 
 ### test counters produces no execution

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -421,7 +421,8 @@ export async function runTests(prev: TypecheckedStage): Promise<CLIProcedure<Tes
     }
 
     if (failed.length > 0 && verbosity.hasHints(options.verbosity) && !verbosity.hasActionTracking(options.verbosity)) {
-      out(chalk.gray('\n  Use --verbosity=3 to show executions.'))
+      out(chalk.gray(`\n  Use --verbosity=3 to show executions.`))
+      out(chalk.gray(`  Further debug with: quint --verbosity=3 ${prev.args.input}`))
     }
   }
 

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -724,19 +724,19 @@ function evalExpr(state: ReplState, out: writer): Either<string, QuintEx> {
     })
     .join()
 
-    if (verbosity.hasUserOpTracking(state.verbosity)) {
-      const trace = state.recorder.getBestTrace()
-      if (trace.subframes.length > 0) {
+  if (verbosity.hasUserOpTracking(state.verbosity)) {
+    const trace = state.recorder.getBestTrace()
+    if (trace.subframes.length > 0) {
+      out('\n')
+      trace.subframes.forEach((f, i) => {
+        out(`[Frame ${i}]\n`)
+        printExecutionFrameRec({ width: columns, out }, f, [])
         out('\n')
-        trace.subframes.forEach((f, i) => {
-          out(`[Frame ${i}]\n`)
-          printExecutionFrameRec({ width: columns, out }, f, [])
-          out('\n')
-        })
-      }
+      })
     }
+  }
 
-    return result
+  return result
 }
 
 function getMainModuleAnnotation(moduleHist: string): string | undefined {

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -699,7 +699,7 @@ function countBraces(str: string): [number, number, number] {
 function evalExpr(state: ReplState, out: writer): Either<string, QuintEx> {
   const computable = contextNameLookup(state.evaluationState.context, 'q::input', 'callable')
   const columns = terminalWidth()
-  return computable
+  const result = computable
     .mapRight(comp => {
       return comp
         .eval()
@@ -707,18 +707,6 @@ function evalExpr(state: ReplState, out: writer): Either<string, QuintEx> {
           const ex = value.toQuintEx(state.compilationState.idGen)
           out(format(columns, 0, prettyQuintEx(ex)))
           out('\n')
-
-          if (verbosity.hasUserOpTracking(state.verbosity)) {
-            const trace = state.recorder.getBestTrace()
-            if (trace.subframes.length > 0) {
-              out('\n')
-              trace.subframes.forEach((f, i) => {
-                out(`[Frame ${i}]\n`)
-                printExecutionFrameRec({ width: columns, out }, f, [])
-                out('\n')
-              })
-            }
-          }
 
           if (ex.kind === 'bool' && ex.value) {
             // A Boolean expression may be an action or a run.
@@ -735,6 +723,20 @@ function evalExpr(state: ReplState, out: writer): Either<string, QuintEx> {
         .unwrap()
     })
     .join()
+
+    if (verbosity.hasUserOpTracking(state.verbosity)) {
+      const trace = state.recorder.getBestTrace()
+      if (trace.subframes.length > 0) {
+        out('\n')
+        trace.subframes.forEach((f, i) => {
+          out(`[Frame ${i}]\n`)
+          printExecutionFrameRec({ width: columns, out }, f, [])
+          out('\n')
+        })
+      }
+    }
+
+    return result
 }
 
 function getMainModuleAnnotation(moduleHist: string): string | undefined {

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -277,7 +277,6 @@ describe('repl ok', () => {
     await assertRepl(input, output)
   })
 
-
   it('caching nullary definitions', async () => {
     const input = dedent(
       `var x: int

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -249,6 +249,35 @@ describe('repl ok', () => {
     await assertRepl(input, output)
   })
 
+  it('change verbosity and show execution on failure', async () => {
+    const input = dedent(
+      `pure def div(x, y) = x / y
+      |.verbosity=4
+      |div(2, 0)
+      |`
+    )
+    const output = dedent(
+      `>>> pure def div(x, y) = x / y
+      |
+      |>>> .verbosity=4
+      |.verbosity=4
+      |>>> div(2, 0)
+      |
+      |[Frame 0]
+      |q::input() => none
+      |└─ div(2, 0) => none
+      |
+      |runtime error: error: Division by zero
+      |div(2, 0)
+      |                     ^^^^^
+      |
+      |<undefined value>
+      |>>> `
+    )
+    await assertRepl(input, output)
+  })
+
+
   it('caching nullary definitions', async () => {
     const input = dedent(
       `var x: int


### PR DESCRIPTION
This is a quality of life improvement in REPL. I've noticed that I would usually like to see an execution trace when a test is failing in REPL, when setting `.verbosity` to 3-4. This is what this PR does.

- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
