### PR TITLE
wrap formatError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug where `export` for a qualified import would not work (#1030)
 - Fix a problem where name resolution would fail to flag name errors for
   non-exported names in incremetal evaluation in REPL (#1031)
+- Do not fail on a bug in error formatting (#1063)
 
 ### Security
 

--- a/quint/src/errorReporter.ts
+++ b/quint/src/errorReporter.ts
@@ -67,8 +67,8 @@ export function formatError(
   } catch (error: any) {
     // If it happens that an error occurs during the error reconstruction,
     // print that we could not construct a good explanation, instead of throwing.
-    console.error('\nSomething unexpected happened during error reconstruction. Report a bug.\n')
-    console.error('Please include this in the bug report: {')
+    console.error('\nSomething unexpected happened during error reconstruction. Please report a bug.\n')
+    console.error('Include this in the bug report: {')
     console.trace(error.message)
     console.error('} // end of the bug report\n')
 

--- a/quint/src/errorReporter.ts
+++ b/quint/src/errorReporter.ts
@@ -39,29 +39,42 @@ export function formatError(
     return `error: ${message.explanation}`
   }
 
-  return message.locs.reduce((output, loc) => {
-    // If lineOffset is a number, print the source location.
-    // If lineOfsset is undefined, omit the source location (e.g., in REPL).
-    const locString = lineOffset.isJust()
-      ? `${loc.source}:${loc.start.line + lineOffset.value}:${loc.start.col + 1} - `
-      : ''
-    output += `${locString}error: ${message.explanation}\n`
+  try {
+    // try to extract the location of the error
+    return message.locs.reduce((output, loc) => {
+      // If lineOffset is a number, print the source location.
+      // If lineOfsset is undefined, omit the source location (e.g., in REPL).
+      const locString = lineOffset.isJust()
+        ? `${loc.source}:${loc.start.line + lineOffset.value}:${loc.start.col + 1} - `
+        : ''
+      output += `${locString}error: ${message.explanation}\n`
 
-    const endLine = loc.end ? loc.end.line : loc.start.line
-    const endCol = loc.end ? loc.end.col : loc.start.col
-    for (let i = loc.start.line; i <= endLine; i++) {
-      // finder's indexes start at 1
-      const lineStartIndex = finder.toIndex(i + 1, 1)
-      const line = text.slice(lineStartIndex).split('\n')[0]
+      const endLine = loc.end ? loc.end.line : loc.start.line
+      const endCol = loc.end ? loc.end.col : loc.start.col
+      for (let i = loc.start.line; i <= endLine; i++) {
+        // finder's indexes start at 1
+        const lineStartIndex = finder.toIndex(i + 1, 1)
+        const line = text.slice(lineStartIndex).split('\n')[0]
 
-      const lineStartCol = i === loc.start.line ? loc.start.col : 0
-      const lineEndCol = i === endLine ? endCol : line.length - 1
+        const lineStartCol = i === loc.start.line ? loc.start.col : 0
+        const lineEndCol = i === endLine ? endCol : line.length - 1
 
-      const lineIndex = lineOffset.map(offs => offs + i)
-      output += formatLine(lineIndex, lineStartCol, lineEndCol, line)
-    }
-    return output
-  }, '')
+        const lineIndex = lineOffset.map(offs => offs + i)
+        output += formatLine(lineIndex, lineStartCol, lineEndCol, line)
+      }
+      return output
+    }, '')
+  } catch (error: any) {
+    // If it happens that an error occurs during the error reconstruction,
+    // print that we could not construct a good explanation, instead of throwing.
+    console.error('\nSomething unexpected happened during error reconstruction. Report a bug.\n')
+    console.error('Please include this in the bug report: {')
+    console.trace(error.message)
+    console.error('} // end of the bug report\n')
+
+    // return the bare bones error message
+    return `error: ${message.explanation}`
+  }
 }
 
 function formatLine(lineIndex: Maybe<number>, startCol: number, endCol: number, line: string): string {


### PR DESCRIPTION
Closes #1061. It happened several times that the error formatter was throwing a new exception, instead of explaining the error. In the long run, we should carefully proof-read `formatError`. This PR wraps `formatError` code in try/catch, so `quint test` does not simply crash in error formatting, but print the stack trace and continues.

I believe that this should be the tool behavior for the non-critical logic.

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
