### PR TITLE
Wrap `bigint`s into string in JSON serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `quint run` produces a friendlier message when it meets a `const` (#1050)
+- JSON output now wraps `bigint` values into a string (#1065)
 
 ### Deprecated
 ### Removed

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -8,10 +8,13 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import JSONbig from 'json-bigint'
+import JSONbig_ from 'json-bigint'
 import { basename, dirname, resolve } from 'path'
 import { cwd } from 'process'
 import chalk from 'chalk'
+
+// serialize `bigint`s as string
+const JSONbig = JSONbig_({ storeAsString: true })
 
 import {
   ErrorMessage,

--- a/quint/test/builders/ir.ts
+++ b/quint/test/builders/ir.ts
@@ -1,8 +1,11 @@
 import { parsePhase1fromText } from '../../src/parsing/quintParserFrontend'
 import { IdGenerator, newIdGenerator } from '../../src/idGenerator'
 import { QuintDef, QuintEx, QuintModule } from '../../src/quintIr'
-import JSONbig from 'json-bigint'
+import JSONbig_ from 'json-bigint'
 import { QuintType } from '../../src/quintTypes'
+
+// serialize `bigint`s as string
+const JSONbig = JSONbig_({ storeAsString: true })
 
 export function buildModuleWithExpressions(expressions: string[]): QuintModule {
   return buildModule([], expressions)

--- a/quint/test/parsing/quintParserFrontend.test.ts
+++ b/quint/test/parsing/quintParserFrontend.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha'
 import { assert } from 'chai'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
-import JSONbig from 'json-bigint'
+import JSONbig_ from 'json-bigint'
 import {
   compactSourceMap,
   parsePhase1fromText,
@@ -15,6 +15,9 @@ import { right } from '@sweet-monads/either'
 import { newIdGenerator } from '../../src/idGenerator'
 import { collectIds } from '../util'
 import { fileSourceResolver } from '../../src/parsing/sourceResolver'
+
+// serialize `bigint`s as string
+const JSONbig = JSONbig_({ storeAsString: true })
 
 // read a Quint file from the test data directory
 function readQuint(name: string): string {


### PR DESCRIPTION
Wrap `bigint`s into a string when serializing to JSON, so that `upickle` on the Apalache side can deserialize it into a Scala `BigInt`.

Closes #1059. Together with https://github.com/informalsystems/apalache/pull/2654, closes #1055