### PR TITLE
Add mapRemoveAll to basic spells

### DIFF
--- a/examples/spells/basicSpells.qnt
+++ b/examples/spells/basicSpells.qnt
@@ -123,4 +123,21 @@ module basicSpells {
     assert(Map(3 -> 4, 7 -> 8) == Map(3 -> 4, 5 -> 6, 7 -> 8).mapRemove(5)),
     assert(Map() == Map().mapRemove(3)),
   }
+
+  /// Removes a set of map entry.
+  ///
+  /// - @param __map a map to remove an entry from
+  /// - @param __keys a set of keys to remove from the map
+  /// - @returns a new map that contains all entries of __map
+  ///          that do not have a key in __keys
+  pure def mapRemoveAll(__map: a -> b, __keys: Set[a]): a -> b = {
+      __map.keys().exclude(__keys).mapBy(__k => __map.get(__k))
+  }
+
+  run mapRemoveAllTest =
+      val m = Map(3 -> 4, 5 -> 6, 7 -> 8)
+      all {
+          assert(m.mapRemoveAll(Set(5, 7)) == Map(3 -> 4)),
+          assert(m.mapRemoveAll(Set(5, 99999)) == Map(3 -> 4, 7 -> 8)),
+      }
 }


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

This PR adds a mapRemoveAll spell. Could alternatively be called mapExclude to match the terminology for sets.
I chose to put it as a basic spell, not a rare spell, since in my opinion, it should be right next to mapRemove.
The spell itself is very straightforward and works just like mapRemove.

- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
