### PR TITLE
Fix problem with loading module in the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a problem where definitions were not properly loaded in the REPL when
+  the main module was provided in the CLI argument (#1112)
+
 ### Security
 
 ## v0.13.0 -- 2023-08-03

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -199,6 +199,20 @@ echo "init" | quint -r ../examples/language-features/counters.qnt::counters 2>&1
 >>> 
 ```
 
+### Repl loads a file and a module with -r when the module is not the last one
+
+<!-- !test in repl loads module that is not the last -->
+```
+echo "init" | quint -r ../examples/language-features/imports.qnt::E 2>&1 | tail -n +3
+```
+
+<!-- !test out repl loads module that is not the last -->
+```
+>>> true
+>>> 
+```
+
+
 ### Repl loads a file with .load
 
 <!-- !test in repl loads a file with .load -->

--- a/quint/src/flattening.ts
+++ b/quint/src/flattening.ts
@@ -107,19 +107,19 @@ export function flattenModules(
  * @param sourceMap The source map for all modules involved
  * @param analysisOutput The analysis output for all modules involved
  * @param module The flat module to add the definition to
- * @param def The definition to add
+ * @param decl The definition to add
  *
  * @returns An object containing the flattened module, flattened lookup table
  * and flattened analysis output
  */
-export function addDefToFlatModule(
+export function addDeclarationToFlatModule(
   modules: QuintModule[],
   table: LookupTable,
   idGenerator: IdGenerator,
   sourceMap: Map<bigint, Loc>,
   analysisOutput: AnalysisOutput,
   module: FlatModule,
-  def: QuintDeclaration
+  decl: QuintDeclaration
 ): {
   flattenedModule: FlatModule
   flattenedDefs: QuintDef[]
@@ -130,7 +130,7 @@ export function addDefToFlatModule(
   const flattener = new Flatenner(idGenerator, table, sourceMap, analysisOutput, importedModules, module)
 
   const flattenedDefs = flattener
-    .flattenDef(def)
+    .flattenDef(decl)
     // Inline type aliases in new defs
     .map(d => inlineAliasesInDef(d, table))
   const flattenedModule: FlatModule = { ...module, declarations: [...module.declarations, ...flattenedDefs] }

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -86,6 +86,7 @@ class ReplState {
     const replModule: FlatModule = { name: '__repl__', declarations: simulatorBuiltins(this.compilationState), id: 0n }
     this.compilationState.modules.push(replModule)
     this.compilationState.originalModules.push(replModule)
+    this.compilationState.mainName = '__repl__'
     this.moduleHist += moduleToString(replModule)
   }
 

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -312,11 +312,11 @@ export function compileFromCode(
           const mainNotFoundError: IrErrorMessage[] = main
             ? []
             : [
-              {
-                explanation: `Main module ${mainName} not found`,
-                refs: [],
-              },
-            ]
+                {
+                  explanation: `Main module ${mainName} not found`,
+                  refs: [],
+                },
+              ]
           const defsToCompile = main ? main.declarations : []
           const ctx = compile(compilationState, newEvaluationState(execListener), flattenedTable, rand, defsToCompile)
 

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -26,7 +26,7 @@ import { AnalysisOutput, analyzeInc, analyzeModules } from '../quintAnalyzer'
 import { mkErrorMessage } from '../cliCommands'
 import { IdGenerator, newIdGenerator } from '../idGenerator'
 import { SourceLookupPath } from '../parsing/sourceResolver'
-import { addDefToFlatModule as addDeclataionToFlatModule, flattenModules } from '../flattening'
+import { addDeclarationToFlatModule, flattenModules } from '../flattening'
 import { Rng } from '../rng'
 
 /**
@@ -66,6 +66,8 @@ export interface CompilationState {
   originalModules: QuintModule[]
   // A list of flattened modules.
   modules: FlatModule[]
+  // The name of the main module.
+  mainName?: string
   // The source map for the compiled code.
   sourceMap: Map<bigint, Loc>
   // The output of the Quint analyzer.
@@ -204,18 +206,22 @@ export function compileDecl(
     throw new Error('No modules in state')
   }
 
-  // Define a new module list with the new definition in the last module,
+  // Define a new module list with the new definition in the main module,
   // ensuring the original object is not modified
-  const originalModules = [...state.originalModules]
-  const originalLastModule = originalModules.pop()!
-  originalModules.push({ ...originalLastModule, declarations: [...originalLastModule.declarations, decl] })
+  const originalModules = state.originalModules.map(m => {
+    if (m.name === state.mainName) {
+      return { ...m, declarations: [...m.declarations, decl] }
+    }
+    return m
+  })
 
-  // Same for the flattened module list, but that requires extra care with types
-  const modules: QuintModule[] = [...state.modules]
-  // This is not modules.pop() to ensure flatness
-  const lastModule: FlatModule = state.modules[state.modules.length - 1]
-  modules.pop()
-  modules.push({ ...lastModule, declarations: [...lastModule.declarations, decl] })
+  const mainModule = state.modules.find(m => m.name === state.mainName)!
+  const modules = state.modules.map(m => {
+    if (m.name === state.mainName) {
+      return { ...m, declarations: [...m.declarations, decl] }
+    }
+    return m
+  })
 
   // We need to resolve names for this new definition. Incremental name
   // resolution is not our focus now, so just resolve everything again.
@@ -224,13 +230,14 @@ export function compileDecl(
     .map(({ table }) => {
       const [analysisErrors, analysisOutput] = analyzeInc(state.analysisOutput, table, decl)
 
-      const { flattenedModule, flattenedDefs, flattenedTable, flattenedAnalysis } = addDeclataionToFlatModule(
+      const { flattenedModule, flattenedDefs, flattenedTable, flattenedAnalysis } = addDeclarationToFlatModule(
         modules,
         table,
         state.idGen,
         state.sourceMap,
         analysisOutput,
-        lastModule,
+        // Make a copy of the main module, so that we don't modify the original
+        { ...mainModule, declarations: [...mainModule.declarations] },
         decl
       )
 
@@ -294,6 +301,7 @@ export function compileFromCode(
           const compilationState: CompilationState = {
             originalModules: modules,
             modules: flattenedModules,
+            mainName,
             sourceMap,
             analysisOutput: flattenedAnalysis,
             idGen,
@@ -304,11 +312,11 @@ export function compileFromCode(
           const mainNotFoundError: IrErrorMessage[] = main
             ? []
             : [
-                {
-                  explanation: `Main module ${mainName} not found`,
-                  refs: [],
-                },
-              ]
+              {
+                explanation: `Main module ${mainName} not found`,
+                refs: [],
+              },
+            ]
           const defsToCompile = main ? main.declarations : []
           const ctx = compile(compilationState, newEvaluationState(execListener), flattenedTable, rand, defsToCompile)
 

--- a/quint/test/flatenning.test.ts
+++ b/quint/test/flatenning.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { addDefToFlatModule, flattenModules } from '../src/flattening'
+import { addDeclarationToFlatModule, flattenModules } from '../src/flattening'
 import { newIdGenerator } from '../src/idGenerator'
 import { declarationToString } from '../src/ir/IRprinting'
 import { parse } from '../src/parsing/quintParserFrontend'
@@ -190,7 +190,7 @@ describe('addDefToFlatModule', () => {
 
     const def = module.declarations[module.declarations.length - 1]
     const moduleWithoutDef: FlatModule = { ...module, declarations: [] }
-    const { flattenedModule, flattenedAnalysis } = addDefToFlatModule(
+    const { flattenedModule, flattenedAnalysis } = addDeclarationToFlatModule(
       modules,
       table,
       idGenerator,

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -989,7 +989,7 @@ describe('incremental compilation', () => {
     next: () => 0n,
   }
   /* Adds some quint code to the compilation and evaluation state */
-  function compileModules(text: string): CompilationContext {
+  function compileModules(text: string, mainName: string): CompilationContext {
     const idGen = newIdGenerator()
     const fake_path: SourceLookupPath = { normalizedPath: 'fake_path', toSourceName: () => 'fake_path' }
     const parseResult = parse(idGen, 'fake_location', fake_path, text)
@@ -1013,6 +1013,7 @@ describe('incremental compilation', () => {
       originalModules: modules,
       idGen,
       modules: flattenedModules,
+      mainName,
       sourceMap,
       analysisOutput: flattenedAnalysis,
     }
@@ -1030,7 +1031,7 @@ describe('incremental compilation', () => {
 
   describe('compileExpr', () => {
     it('should compile a Quint expression', () => {
-      const { compilationState, evaluationState } = compileModules('module m { pure val x = 1 }')
+      const { compilationState, evaluationState } = compileModules('module m { pure val x = 1 }', 'm')
 
       const parsed = parseExpressionOrDeclaration(
         'x + 2',
@@ -1049,7 +1050,7 @@ describe('incremental compilation', () => {
 
   describe('compileDef', () => {
     it('should compile a Quint definition', () => {
-      const { compilationState, evaluationState } = compileModules('module m { pure val x = 1 }')
+      const { compilationState, evaluationState } = compileModules('module m { pure val x = 1 }', 'm')
 
       const parsed = parseExpressionOrDeclaration(
         'val y = x + 2',
@@ -1068,7 +1069,8 @@ describe('incremental compilation', () => {
 
     it('non-exported imports are not visible in subsequent importing modules', () => {
       const { compilationState, evaluationState } = compileModules(
-        'module m1 { pure val x1 = 1 }' + 'module m2 { import m1.* pure val x2 = x1 }' + 'module m3 { import m2.* }' // m1 shouldn't be acessible inside m3
+        'module m1 { pure val x1 = 1 }' + 'module m2 { import m1.* pure val x2 = x1 }' + 'module m3 { import m2.* }', // m1 shouldn't be acessible inside m3
+        'm3'
       )
 
       const parsed = parseExpressionOrDeclaration(


### PR DESCRIPTION
Hello :octocat: 

This fixes the issue encountered by Jure during the Quintshop. The problem was: we used to add incremental declarations/expressions to the last module in the list of modules, because the last module was always the `__repl__` module. When we [stopped requiring a `__repl__` module](https://github.com/informalsystems/quint/pull/1039), that became a problem, because not necessarily the last module is the actual main module that was loaded. This PR makes it so the new declarations are always added to the main module.

The reason it works when the file is imported, and not loaded via CLI, is because once no module is specified in the CLI (nor in an annotation inside the file), we introduce a `__repl__` module as the last module, and that is the main one even if you type import statements.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
