### PR TITLE
Print pretty messages in `quint verify`

### DIFF
--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -22,9 +22,11 @@ again.
 <!-- !test in server not running -->
 ```
 quint verify ../examples/language-features/booleans.qnt | \
-  sed 's!https://.*!(asseturl)!'
+  sed 's!https://.*!(asseturl)!' | \
+  sed -e 's/([0-9]*ms)/(duration)/'
 quint verify ../examples/language-features/booleans.qnt | \
-  sed 's!\(Using existing Apalache distribution in \).*!\1(distdir)!'
+  sed 's!\(Using existing Apalache distribution in \).*!\1(distdir)!' | \
+  sed -e 's/([0-9]*ms)/(duration)/'
 ```
 
 <!-- !test out server not running -->
@@ -32,9 +34,15 @@ quint verify ../examples/language-features/booleans.qnt | \
 Couldn't connect to Apalache, checking for latest supported release
 Downloading Apalache distribution from (asseturl)
 Launching Apalache server
+[ok] No violation found (duration).
+You may increase --max-steps.
+Use --verbosity to produce more (or less) output.
 Shutting down Apalache server
 Couldn't connect to Apalache, checking for latest supported release
 Using existing Apalache distribution in (distdir)
 Launching Apalache server
+[ok] No violation found (duration).
+You may increase --max-steps.
+Use --verbosity to produce more (or less) output.
 Shutting down Apalache server
 ```

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -77,7 +77,10 @@ quint verify --invariant inv,inv2 ../examples/verification/defaultOpNames.qnt
 
 <!-- !test in prints a trace on invariant violation -->
 ```
-quint verify --invariant inv ./testFixture/apalache/violateOnFive.qnt
+output=$(quint verify --invariant inv ./testFixture/apalache/violateOnFive.qnt)
+exit_code=$?
+echo "$output" | sed -e 's/([0-9]*ms)/(duration)/'
+exit $exit_code
 ```
 
 <!-- !test exit 1 -->
@@ -100,6 +103,7 @@ An example execution:
 
 [State 4] { n: 5 }
 
+[violation] Found an issue (duration).
 ```
 
 ### Variant violations write ITF to file when `--out-itf` is specified
@@ -126,7 +130,10 @@ error: found a counterexample
 
 <!-- !test in reports deadlock -->
 ```
-quint verify ./testFixture/apalache/deadlock.qnt
+output=$(quint verify ./testFixture/apalache/deadlock.qnt)
+exit_code=$?
+echo "$output" | sed -e 's/([0-9]*ms)/(duration)/'
+exit $exit_code
 ```
 
 <!-- !test exit 1 -->
@@ -149,4 +156,5 @@ An example execution:
 
 [State 4] { n: 5 }
 
+[violation] Found an issue (duration).
 ```

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -864,11 +864,6 @@ exit $exit_code
 <!-- !test exit 1 -->
 <!-- !test out run uninitialized -->
 ```
-An example execution:
-
-[failure] Found an issue (duration).
-Use --seed=0x0 to reproduce.
-Use --verbosity=3 to show executions.
 <module_input>:2:3 - error: QNT500: Uninitialized const N. Use: import <moduleName>(N=<value>).*
 2:   const N: int
      ^^^^^^^^^^^^
@@ -877,5 +872,5 @@ Use --verbosity=3 to show executions.
 5:   action init = { x' = N }
                           ^
 
-error: Runtime error
+error: run failed
 ```

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -238,7 +238,12 @@ const verifyCmd = {
       .option('apalache-config', {
         desc: 'Filename of the additional Apalache configuration (in the HOCON format, a superset of JSON)',
         type: 'string',
-      }),
+      })
+      .option('verbosity', {
+        desc: 'control how much output is produced (0 to 5)',
+        type: 'number',
+      })
+      .default('verbosity', verbosity.defaultLevel),
   // Timeouts are postponed for:
   // https://github.com/informalsystems/quint/issues/633
   //

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -589,7 +589,8 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
   return verify(config).then(res => {
     const verbosityLevel = !prev.args.out && !prev.args.outItf ? prev.args.verbosity : 0
     const elapsedMs = Date.now() - startMs
-    return res.map(_ => {
+    return res
+      .map(_ => {
         if (verbosity.hasResults(verbosityLevel)) {
           console.log(chalk.green('[ok]') + ' No violation found ' + chalk.gray(`(${elapsedMs}ms).`))
           if (verbosity.hasHints(verbosityLevel)) {
@@ -597,7 +598,7 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
             console.log(chalk.gray('Use --verbosity to produce more (or less) output.'))
           }
         }
-        return ({ ...verifying, status: 'ok', errors: [] } as VerifiedStage)
+        return { ...verifying, status: 'ok', errors: [] } as VerifiedStage
       })
       .mapLeft(err => {
         const trace: QuintEx[] | undefined = err.traces ? ofItf(err.traces[0]) : undefined
@@ -619,7 +620,7 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
           stage: { ...verifying, status, errors: err.errors, trace },
         }
       })
-    })
+  })
 }
 
 /**

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -587,7 +587,7 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
   const startMs = Date.now()
 
   return verify(config).then(res => {
-    const verbosityLevel = prev.args.out || prev.args.outItf ? 0 : 2
+    const verbosityLevel = !prev.args.out && !prev.args.outItf ? prev.args.verbosity : 0
     const elapsedMs = Date.now() - startMs
     return res.map(_ => {
         if (verbosity.hasResults(verbosityLevel)) {

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -583,15 +583,32 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
       inv: args.invariant,
     },
   }
-  return verify(config).then(res =>
-    res
-      .map(_ => ({ ...verifying, status: 'ok', errors: [] } as VerifiedStage))
+
+  const startMs = Date.now()
+
+  return verify(config).then(res => {
+    const verbosityLevel = prev.args.out || prev.args.outItf ? 0 : 2
+    const elapsedMs = Date.now() - startMs
+    return res.map(_ => {
+        if (verbosity.hasResults(verbosityLevel)) {
+          console.log(chalk.green('[ok]') + ' No violation found ' + chalk.gray(`(${elapsedMs}ms).`))
+          if (verbosity.hasHints(verbosityLevel)) {
+            console.log(chalk.gray('You may increase --max-steps.'))
+            console.log(chalk.gray('Use --verbosity to produce more (or less) output.'))
+          }
+        }
+        return ({ ...verifying, status: 'ok', errors: [] } as VerifiedStage)
+      })
       .mapLeft(err => {
         const trace: QuintEx[] | undefined = err.traces ? ofItf(err.traces[0]) : undefined
+        const status = trace !== undefined ? 'violation' : 'failure'
         if (trace !== undefined) {
           // Always print the conterexample, unless the output is being directed to one of the outfiles
-          const verbosityLevel = prev.args.out || prev.args.outItf ? 0 : 2
           maybePrintCounterExample(verbosityLevel, trace)
+
+          if (verbosity.hasResults(verbosityLevel)) {
+            console.log(chalk.red(`[${status}]`) + ' Found an issue ' + chalk.gray(`(${elapsedMs}ms).`))
+          }
 
           if (prev.args.outItf) {
             writeToJson(prev.args.outItf, err.traces)
@@ -599,10 +616,10 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
         }
         return {
           msg: err.explanation,
-          stage: { ...verifying, status: 'failure', errors: err.errors, trace },
+          stage: { ...verifying, status, errors: err.errors, trace },
         }
       })
-  )
+    })
 }
 
 /**

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -48,7 +48,7 @@ export interface SimulatorResult {
 
 function errSimulationResult(status: SimulatorResultStatus, errors: ErrorMessage[]): SimulatorResult {
   return {
-    status: 'failure',
+    status,
     vars: [],
     states: [],
     frames: [],


### PR DESCRIPTION
Addresses (1) of #1121:

Print pretty messages in `quint verify`, similar to `quint run`

- [x] Tests added for any new code
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entries added to the respective `CHANGELOG.md` for any new functionality~
- [ ] ~Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality~

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
