### PR TITLE
Add VSCode launch config for the VSCode extension

### DIFF
--- a/vscode/quint-vscode/.vscode/launch.json
+++ b/vscode/quint-vscode/.vscode/launch.json
@@ -1,0 +1,34 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// https://github.com/microsoft/vscode-extension-samples/blob/ead2640188c31d12ad07ed4d3c0d47d5b54a23c8/lsp-web-extension-sample/.vscode/launch.json
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "extensionHost",
+			"request": "launch",
+			"name": "Launch Client",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
+		},
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Attach to Server",
+			"port": 6009,
+			"restart": true,
+			"outFiles": [
+				"${workspaceRoot}/server/out/**/*.js"
+			]
+		}
+	],
+	"compounds": [
+		{
+			"name": "Client + Server",
+			"configurations": [
+				"Launch Client",
+				"Attach to Server"
+			]
+		}
+	]
+}


### PR DESCRIPTION
Add a VSCode launch config for the VSCode extension.

This adds a nice little ⏯️ button in VSCode, that can be used to simultaneously
* launch the VSCode extension in debug mode, and
* attach a second debugger to the LSP server.

Found this very useful for debugging.

![Screenshot 2023-09-05 at 11 13 46](https://github.com/informalsystems/quint/assets/82047/d52ef0cb-6b80-42d4-b151-23872bdaa095)

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
