### PR TITLE
Set seed in CI and fix server package name

### DIFF
--- a/examples/solidity/GradualPonzi/gradualPonzi.qnt
+++ b/examples/solidity/GradualPonzi/gradualPonzi.qnt
@@ -232,7 +232,7 @@ module gradualPonziTest {
   //
   // If quint has not reported a violation, try:
   //
-  // $ quint run --invariant=progressInv --main=gradualPonziTest --seed=0x8385bfe3a7497 gradualPonzi.qnt
+  // $ quint run --invariant=progressInv --main=gradualPonziTest --max-steps=50 --seed=0x8272b36d6a57f gradualPonzi.qnt
   //
   // It is quite hard for `quint run` to find a violation to this property.
   // In contrast, `quint verify` finds it in a few seconds.

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -319,17 +319,13 @@ fi
       --invariant=noNegativeInv --main=gradualPonziTest \
       ../examples/solidity/GradualPonzi/gradualPonzi.qnt
 
-### IGNORE on run gradualPonzi::progressInv
+### FAIL on run gradualPonzi::progressInv
 
-This test should fail. We know that from `quint verify`.
-However, `quint run` has hard time finding a counterexample.
-If you see this test failing, you are a lucky winner!
-Add the seed to the command below and change the exit code to 1.
-
-<!-- !test exit 0 -->
+<!-- !test exit 1 -->
 <!-- !test check gradualPonzi - Run progressInv -->
     quint run --invariant=progressInv --main=gradualPonziTest \
       --max-samples=1000 --max-steps=50 \
+      --seed=0x8272b36d6a57f \
       ../examples/solidity/GradualPonzi/gradualPonzi.qnt
 
 ### FAIL on run gradualPonzi::noLeftoversInv

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quint-language-server",
+  "name": "@informalsystems/quint-language-server",
   "description": "Language Server for the Quint specification language",
   "version": "0.8.0",
   "author": "Informal Systems",


### PR DESCRIPTION
Hello :octocat: 

This PR does 2 small things:
1 - Set the seed to produce a counterexample for one of the gradual ponzi invariants, just found by [CI](https://github.com/informalsystems/quint/actions/runs/6087542373/job/16516330316) in my latest merge.
2 - Fix the package name for quint language server, which should include the `@informalsystems/` prefix



<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
