### PR TITLE
Ensure tests are present in the main module for flattening

### DIFF
--- a/quint/src/names/base.ts
+++ b/quint/src/names/base.ts
@@ -69,6 +69,19 @@ export type DefinitionsByModule = Map<string, DefinitionsByName>
 export type LookupTable = Map<bigint, LookupDefinition>
 
 /**
+ * A lazy mapping from module names to the definitions that are available but not used in that module.
+ */
+export type UnusedDefinitions = (moduleName: string) => Set<LookupDefinition>
+
+/**
+ * The result of name resolution, when successful.
+ */
+export type NameResolutionResult = {
+  table: LookupTable
+  unusedDefinitions: UnusedDefinitions
+}
+
+/**
  * Copy the names of a definitions table to a new one, ignoring hidden
  * definitions, and optionally adding a namespace.
  *

--- a/quint/src/parsing/quintParserFrontend.ts
+++ b/quint/src/parsing/quintParserFrontend.ts
@@ -20,7 +20,7 @@ import { QuintListener } from '../generated/QuintListener'
 import { IrErrorMessage, QuintDeclaration, QuintDef, QuintEx, QuintModule, isDef } from '../ir/quintIr'
 import { IdGenerator, newIdGenerator } from '../idGenerator'
 import { ToIrListener } from './ToIrListener'
-import { LookupTable } from '../names/base'
+import { LookupTable, NameResolutionResult, UnusedDefinitions } from '../names/base'
 import { resolveNames } from '../names/resolver'
 import { QuintError, quintErrorToString } from '../quintError'
 import { SourceLookupPath, SourceResolver, fileSourceResolver } from './sourceResolver'
@@ -114,6 +114,7 @@ export interface ParserPhase2 extends ParserPhase1 {}
  */
 export interface ParserPhase3 extends ParserPhase2 {
   table: LookupTable
+  unusedDefinitions: UnusedDefinitions
 }
 
 /**
@@ -297,7 +298,7 @@ export function parsePhase2sourceResolution(
 export function parsePhase3importAndNameResolution(phase2Data: ParserPhase2): ParseResult<ParserPhase3> {
   return resolveNames(phase2Data.modules)
     .mapLeft(errors => errors.map(fromQuintError(phase2Data.sourceMap)))
-    .map(table => ({ ...phase2Data, table }))
+    .map((result: NameResolutionResult) => ({ ...phase2Data, ...result }))
 }
 
 /**

--- a/quint/test/names/resolver.test.ts
+++ b/quint/test/names/resolver.test.ts
@@ -18,13 +18,13 @@ describe('resolveNames', () => {
   function resolveNamesForExprs(exprs: string[]): Either<QuintError[], LookupTable> {
     const module = buildModule(baseDefs, exprs, undefined, zerog)
 
-    return resolveNames([module])
+    return resolveNames([module]).map(r => r.table)
   }
 
   function resolveNamesForDefs(defs: string[]): Either<QuintError[], LookupTable> {
     const module = buildModuleWithDecls(baseDefs.concat(defs), undefined, zerog)
 
-    return resolveNames([module])
+    return resolveNames([module]).map(r => r.table)
   }
 
   describe('operator definitions', () => {


### PR DESCRIPTION
Hello :octocat: 

This fixes #1150. In order to ensure that flattening will not get rid of unused test definitions, we now add an auxiliary definition to reference any unused test definitions, similar to what we are doing with `verify` and `simulate`.

In order to properly find the definitions with all necessary metadata, I added a field to name resolution return value, including any unused definition - since this values don't make it to the lookup table and, otherwise, would be lost after the name resolution stage.


<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
