### PR TITLE
Fix CI issue when linting the VSCode plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,6 @@ jobs:
 
   quint-vscode-linting:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./vscode/quint-vscode
     strategy:
       fail-fast: false
     steps:
@@ -41,8 +38,14 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "18"
-      - run: npm install
-      - run: npm run format-check || (echo "Run 'npm run format'" && exit 1)
+      - name: Install quint deps
+        run: cd ./quint && npm install
+      - name: Install yalc
+        run: npm i yalc -g
+      - name: Compile quint vscode plugin
+        run: make local
+      - name: Run formatting for the plugin
+        run: cd ./vscode/quint-vscode && npm run format-check || (echo "Run 'npm run format'" && exit 1)
 
   quint-unit-tests:
     runs-on: ${{ matrix.operating-system }}


### PR DESCRIPTION
Hello :octocat: 

The CI task for linting VSCode plugin files is not currently using the local quint version. This causes problems when the published npm version is not compatible with the unpublished VSCode plugin version, causing errors like [this](https://github.com/informalsystems/quint/actions/runs/6172999525/job/16754376101?pr=1143). I copied the setup from the unit tests task to the linting task to make sure we can run linting in the CI in this scenario.

<!-- Please ensure that your PR includes the following, as needed -->

- [-] Tests added for any new code
- [-] Documentation added for any new functionality
- [-] Entries added to the respective `CHANGELOG.md` for any new functionality
- [-] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
