### PR TITLE
Serialize big integers in ITF traces as an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
- - Introduce frames on actions in the verbose output. The verbose output has changed! (#1158)
+- Introduce frames on actions in the verbose output. The verbose output has changed! (#1158)
+- The ITF traces always serialize integers as `{ '#bigint': 'num }`  (#1165)
 
 ### Deprecated
 ### Removed

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -635,7 +635,9 @@ rm out-itf-example.itf.json
 ```
 [
   "alice",
-  0
+  {
+    "#bigint": "0"
+  }
 ]
 ```
 
@@ -668,23 +670,33 @@ exit $exit_code
 [
   [
     "alice",
-    0
+    {
+      "#bigint": "0"
+    }
   ],
   [
     "bob",
-    0
+    {
+      "#bigint": "0"
+    }
   ],
   [
     "charlie",
-    0
+    {
+      "#bigint": "0"
+    }
   ],
   [
     "eve",
-    0
+    {
+      "#bigint": "0"
+    }
   ],
   [
     "null",
-    0
+    {
+      "#bigint": "0"
+    }
   ]
 ]
 ```

--- a/quint/test/itf.test.ts
+++ b/quint/test/itf.test.ts
@@ -3,24 +3,24 @@ import { assert } from 'chai'
 import { quintExAreEqual, zip } from './util'
 
 import { buildExpression } from './builders/ir'
-import { ofItf, toItf } from '../src/itf'
+import { ItfTrace, ofItf, toItf } from '../src/itf'
 
 describe('toItf', () => {
   it('converts two states', () => {
     const trace = ['{ x: 2, y: true }', '{ x: 3, y: false }'].map(buildExpression)
 
     const itfTrace = toItf(['x', 'y'], trace)
-    const expected = {
+    const expected: ItfTrace = {
       vars: ['x', 'y'],
       states: [
         {
           '#meta': { index: 0 },
-          x: 2,
+          x: { '#bigint': '2' },
           y: true,
         },
         {
           '#meta': { index: 1 },
-          x: 3,
+          x: { '#bigint': '3' },
           y: false,
         },
       ],
@@ -58,21 +58,21 @@ describe('toItf', () => {
           '#meta': {
             index: 0,
           },
-          a: 2,
+          a: { '#bigint': '2' },
           b: 'hello',
           c: { '#bigint': '1000000000000000000' },
-          d: { '#set': [5, 6] },
-          e: { foo: 3, bar: true },
-          f: { '#tup': [7, 'myStr'] },
+          d: { '#set': [{ '#bigint': '5' }, { '#bigint': '6' }] },
+          e: { foo: { '#bigint': '3' }, bar: true },
+          f: { '#tup': [{ '#bigint': '7' }, 'myStr'] },
           g: {
             '#map': [
-              [1, 'a'],
-              [2, 'b'],
-              [3, 'c'],
+              [{ '#bigint': '1' }, 'a'],
+              [{ '#bigint': '2' }, 'b'],
+              [{ '#bigint': '3' }, 'c'],
             ],
           },
           h: { '#map': [] },
-          i: { '#map': [[1, 'a']] },
+          i: { '#map': [[{ '#bigint': '1' }, 'a']] },
         },
       ],
     }


### PR DESCRIPTION
This PR update the ITF trace format, according to the change made in Apalache, see https://github.com/informalsystems/apalache/pull/2733. As a result, the ITF writer always writes integers in the format `{ '#bigint': 'num' }`. We still parse JS numbers for backwards compatibility.
