### PR TITLE
Log Apalache distribution-related `verify` messages only at --verbosity >=4

### DIFF
--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,12 +31,10 @@ quint verify ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution...
-Calling Apalache...
+Downloading Apalache distribution... done.
 [ok] No violation found (duration).
 You may increase --max-steps.
 Use --verbosity to produce more (or less) output.
-Calling Apalache...
 [ok] No violation found (duration).
 You may increase --max-steps.
 Use --verbosity to produce more (or less) output.

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,18 +31,13 @@ quint verify ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Couldn't connect to Apalache, checking for latest supported release
-Downloading Apalache distribution from (asseturl)
-Launching Apalache server
+Downloading Apalache distribution...
+Calling Apalache...
 [ok] No violation found (duration).
 You may increase --max-steps.
 Use --verbosity to produce more (or less) output.
-Shutting down Apalache server
-Couldn't connect to Apalache, checking for latest supported release
-Using existing Apalache distribution in (distdir)
-Launching Apalache server
+Calling Apalache...
 [ok] No violation found (duration).
 You may increase --max-steps.
 Use --verbosity to produce more (or less) output.
-Shutting down Apalache server
 ```

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -649,8 +649,8 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
 
   const startMs = Date.now()
 
-  return verify(config).then(res => {
-    const verbosityLevel = !prev.args.out && !prev.args.outItf ? prev.args.verbosity : 0
+  const verbosityLevel = !prev.args.out && !prev.args.outItf ? prev.args.verbosity : 0
+  return verify(config, verbosityLevel).then(res => {
     const elapsedMs = Date.now() - startMs
     return res
       .map(_ => {

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -301,8 +301,9 @@ async function fetchApalache(verbosityLevel: number): Promise<VerifyResult<strin
     return right(apalacheBinary)
   } else {
     fs.mkdirSync(apalacheDistDir(), { recursive: true })
-    console.log(`Downloading Apalache distribution...`)
+    process.stdout.write('Downloading Apalache distribution...')
     const res = await downloadAndUnpackApalache()
+    process.stdout.write(' done.\n')
     return res.map(_ => apalacheBinary)
   }
 
@@ -437,8 +438,5 @@ function debugLog(verbosityLevel: number, msg: string) {
  */
 export async function verify(config: any, verbosityLevel: number): Promise<VerifyResult<void>> {
   const connectionResult = await connect(verbosityLevel)
-  return connectionResult.asyncChain(conn => {
-    console.log('Calling Apalache...')
-    return conn.check(config)
-  })
+  return connectionResult.asyncChain(conn => conn.check(config))
 }

--- a/quint/src/verbosity.ts
+++ b/quint/src/verbosity.ts
@@ -76,4 +76,11 @@ export const verbosity = {
   hasUserOpTracking: (level: number): boolean => {
     return level >= 3
   },
+
+  /**
+   * Shall the tool output debug info.
+   */
+  hasDebugInfo: (level: number): boolean => {
+    return level >= 4
+  },
 }


### PR DESCRIPTION
To avoid cluttering output when invoking `quint verify`, log messages related to obtaining and launching Apalache only at `--verbosity` >=4.

Closes #1121
