### PR TITLE
Upgrade Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: npm install
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - name: Install quint deps
@@ -57,8 +57,8 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: npm install
@@ -73,8 +73,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: npm install
@@ -92,8 +92,8 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: cd ./quint && npm ci
@@ -139,8 +139,8 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: cd ./quint && npm ci
@@ -176,8 +176,8 @@ jobs:
   quint-antlr-grammar:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: cd ./quint && npm install
@@ -190,8 +190,8 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - name: Install quint deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
         working-directory: ./quint
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "17"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Bumps Github actions `actions/checkout@v2` and `actions/setup-node@v2` to `v4` and `v3`, respectively.

Resolves the following deprecatation warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
