### PR TITLE
Pin antlr4ts version

### DIFF
--- a/quint/package-lock.json
+++ b/quint/package-lock.json
@@ -16,7 +16,7 @@
         "@sweet-monads/maybe": "~3.2.0",
         "@types/line-column": "^1.0.0",
         "@types/seedrandom": "^3.0.4",
-        "antlr4ts": "^0.5.0-alpha.4",
+        "antlr4ts": "0.5.0-alpha.4",
         "chalk": "^4.1.2",
         "eol": "^0.9.1",
         "immutable": "^4.3.0",

--- a/quint/package.json
+++ b/quint/package.json
@@ -55,7 +55,7 @@
     "@sweet-monads/maybe": "~3.2.0",
     "@types/line-column": "^1.0.0",
     "@types/seedrandom": "^3.0.4",
-    "antlr4ts": "^0.5.0-alpha.4",
+    "antlr4ts": "0.5.0-alpha.4",
     "chalk": "^4.1.2",
     "eol": "^0.9.1",
     "immutable": "^4.3.0",


### PR DESCRIPTION
Hello :octocat: 

@rnbguy pointed out that version `0.5.0-dev` of `antlr4ts` is incompatible with quint, and might be matched by our current package specification (according to our understanding of [SemVer item 11.4](https://semver.org/#spec-item-11)). Therefore, I'm pinning this dependency to be safe. 

Update: I used the tool `semver` to check if it really matches, and it does:
```sh
$ semver -r '^0.5.0-alpha.4' '0.5.0-dev'
0.5.0-dev
```