### PR TITLE
Add --random-transitions to run Apalache symbolic simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- Added `--random-transitions` flag for `verify`, enabling symbolic simulation
+  through Apalache (#1188)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/doc/quint.md
+++ b/doc/quint.md
@@ -277,6 +277,8 @@ Options:
   --invariant        the invariants to check, separated by a comma      [string]
   --temporal         the temporal properties to check, separated by a comma
                                                                         [string]
+  --random-transitions  choose transitions at random (= use symbolic simulation)
+                                                      [boolean] [default: false]
   --apalache-config  Filename of the additional Apalache configuration (in the
                      HOCON format, a superset of JSON)                  [string]
   --verbosity        control how much output is produced (0 to 5)

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -240,6 +240,11 @@ const verifyCmd = {
         type: 'string',
         coerce: (s: string) => s.split(','),
       })
+      .option('random-transitions', {
+        desc: 'choose transitions at random (= use symbolic simulation)',
+        type: 'boolean',
+        default: false,
+      })
       .option('apalache-config', {
         desc: 'Filename of the additional Apalache configuration (in the HOCON format, a superset of JSON)',
         type: 'string',

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -644,6 +644,9 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
       next: 'q::step',
       inv: args.invariant ? ['q::inv'] : undefined,
       'temporal-props': args.temporal ? ['q::temporalProps'] : undefined,
+      tuning: {
+        'search.simulation': args.randomTransitions ? 'true' : 'false',
+      },
     },
   }
 


### PR DESCRIPTION
Add a `--random-transitions` flag to `verify`, to run Apalache symbolic simulator instead of BMC.

Closes #1185 

- [ ] ~Tests added for any new code~
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] ~Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality~

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
