### PR TITLE
Workaround for state vars from instances in incremental compilation (REPL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fix a problem where state variables from instances didn't work properly in the REPL (#1190)
+
 ### Security
 
 ## v0.14.3 -- 2023-09-19

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -948,3 +948,26 @@ exit $exit_code
 
 error: run failed
 ```
+
+### Repl keeps right track of variables from instances
+
+Incremental evaluation from the REPL interacting with instance flattening leads to state variables having different IDs on separate evaluations. This test ensures this case is well handled during evaluation.
+
+<!-- !test in repl with instance vars -->
+
+```
+cd ../examples/cosmos/tendermint/
+output=$(echo -e "n4_f1::Init\nn4_f1::round" | quint -r TendermintModels.qnt::TendermintModels 2>&1 | tail -n +3)
+exit_code=$?
+cd - > /dev/null
+echo "$output"
+exit $exit_code
+```
+
+<!-- !test out repl with instance vars -->
+
+```
+>>> true
+>>> Map("p1" -> 0, "p2" -> 0, "p3" -> 0)
+>>> 
+```


### PR DESCRIPTION
Hello :octocat: 

Our new flattener process is still not done incrementally (https://github.com/informalsystems/quint/issues/1103). This will likely be a hard problem to solve.

Because of the re-flattening on each REPL evaluation (since it is not incremental), definitions from instances get fresh ids on each evaluation. This includes state variables, and therefore we had a problem (reported by @p-offtermatt on slack) where the values for variables were not persisting between evaluations.

The solution, for now, is to re-map the references to state variables from the old id to the new one. We do this by using the variable name which, after flattening, is guaranteed to be unique.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
