### PR TITLE
Add constant -> instance dependency to callgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a problem where referencing constants from an instance could cause a crash (#1191)
+
 ### Security
 
 ## v0.14.3 -- 2023-09-19

--- a/quint/src/static/callgraph.ts
+++ b/quint/src/static/callgraph.ts
@@ -190,6 +190,9 @@ export class CallGraphVisitor implements IRVisitor {
     const importedModule = this.context.modulesByName.get(decl.protoName)
     if (importedModule) {
       this.graphAddAll(decl.id, Set([importedModule.id]))
+      decl.overrides.forEach(([_param, expr]) => {
+        this.graphAddAll(expr.id, Set([decl.id]))
+      })
     }
   }
 

--- a/quint/test/static/callgraph.test.ts
+++ b/quint/test/static/callgraph.test.ts
@@ -9,14 +9,7 @@ import {
   parsePhase3importAndNameResolution,
 } from '../../src/parsing/quintParserFrontend'
 import { SourceLookupPath, fileSourceResolver } from '../../src/parsing/sourceResolver'
-import {
-  LookupTable,
-  QuintDeclaration,
-  QuintExport,
-  QuintImport,
-  QuintInstance,
-  QuintModule,
-} from '../../src'
+import { LookupTable, QuintDeclaration, QuintExport, QuintImport, QuintInstance, QuintModule } from '../../src'
 import { CallGraphVisitor, mkCallGraphContext } from '../../src/static/callgraph'
 import { walkModule } from '../../src/ir/IRVisitor'
 


### PR DESCRIPTION
Hello :octocat: 

Fixes #1183.

Our topological sorting does not considering the overrides inside instance statements (i.e. `ConsumerChains = consumerChains`), so the effect checker tries to compute effects for the name `ConsumerChains` before inferring effects from the instance statement. This fix for the toposort makes the declarations be visited in the correct order, and then the effect checker doesn't crash anymore.

This is related to what we do here:
https://github.com/informalsystems/quint/blob/726f85305988263ab08d01e8e30c6487a56dd67c/quint/src/names/collector.ts#L145-L146

That is, the name actually refers to the ID of the expression assigned in the override, and therefore this expression has to depend on the instance statement. This is quite weird, but it works and I don't have other ideas.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
