### PR TITLE
Document how to use lmt for writing literate executable specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ editor (currently, VSCode, Emacs and Vim are supported).
    [Apalache][]. Install the [ITF Trace Viewer][] from Visual Studio Code
    Marketplace.
 
+ - Writing [literate executable specifications](./doc/literate.md)
+
+   This is a technique for embedding formal quint formal specifications inside
+   of markdown files.
+
 ## Development
 
 ### Developer docs :guitar:

--- a/doc/literate.md
+++ b/doc/literate.md
@@ -16,6 +16,8 @@ model based testing.
 - An installation of lmt via `go install github.com/driusan/lmt@latest` (or
   following the [lmt instructions to install from source](https://github.com/driusan/lmt#installing-lmt))
 
+If you use nix, you can use [this nix expression](../tutorials/default.nix).
+
 ## Writing a literate spec
 
 A literate quint spec is a markdown file that includes `quint` code blocks that

--- a/doc/literate.md
+++ b/doc/literate.md
@@ -1,0 +1,89 @@
+# Literate Specification
+
+We have developed a workflow for writing literate, executable formal specs using
+the tool [lmt](https://github.com/driusan/lmt). This allows us to embed the
+formal specification of a system within informal, natural language
+specifications, and to extract the formal parts into executable code. This code
+can then be used for testing or verifying the spec, or fed into a toolchain for
+model based testing.
+
+## Prerequisites
+
+- An [installation of go](https://go.dev/doc/install)
+- An [installation of quint](../../quint/README.md)
+- An [installation of make](https://en.wikipedia.org/wiki/Make_(software))
+  (probably already on your system)
+- An installation of lmt via `go install github.com/driusan/lmt@latest` (or
+  following the [lmt instructions to install from source](https://github.com/driusan/lmt#installing-lmt))
+
+## Writing a literate spec
+
+A literate quint spec is a markdown file that includes `quint` code blocks that
+declare a file into which the fragment of the code will be extracted.
+
+Here is an example of a literate spec describing a trivial counter system:
+
+````markdown
+<!-- in myspec.md -->
+# Counter
+
+A counter has a single state variable `n`:
+
+```quint myspec.qnt +=
+module Counter {
+  var n : int
+```
+
+The initial value of `n` is `0`:
+
+```quint myspec.qnt +=
+  action init = n' = 0
+```
+
+At each step, the counter increments the value of `n` by `1`:
+
+```quint myspec.qnt +=
+  action step = n' = n + 1
+}
+```
+
+If you run a counter for 10 steps, the value of `n` at each step will be equal
+to the `i`th step:
+
+```quint myspecTests.qnt +=
+module TestCounter {
+  import Counter.* from "myspec"
+
+  run countTest = {
+    init.then(10.reps(i => all { step, assert(n == i) }))
+  }
+}
+```
+````
+
+Each code block is labeled with three things:
+
+- the language of the code block (`quint`),
+- the file into which the code block will be extracted (e.g. `myspec.qnt`),
+- the operator `+=`, which tells `lmt` to append the content of the code block
+  to the named file.
+
+See the `lmt` documentation for other features supported by that tool.
+
+## Extracting the executable spec and testing it
+
+The following makefile extracts two `.qnt` files from the markdown using
+`lmt`, and then calls `quint` to run the tests:
+
+```Makefile
+.PHONY: test clean
+
+test: myspecTests.qnt myspec.qnt
+	quint test --main TestCounter $<
+
+myspec.qnt myspecTests.qnt &: myspec.md
+	lmt $<
+
+clean:
+	rm myspec.qnt myspecTests.qnt
+```


### PR DESCRIPTION
Closes #449

@konnov reported that lmt was suitable to meet our current needs for supporting
"literate executable specs". This is valuable insofar as it shows how to achieve
the goal of replacing pseudo code snippets with working and tested fragments of
an executable formal specification. However, we had no documentation explaining
how to use the tool for this purpose. Now we do.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [x] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->