### PR TITLE
[LSP] Wrap parsing and analysis in `try...catch` block

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- The language server should no longer crash when there is a crash on quint
+  functions (#1205)
+
 ### Security
 
 ## v0.9.1 -- 2023-10-02


### PR DESCRIPTION
Hello :octocat: 

This is a simple fix for the hanging on VSCode where it gave up on restarting the language server after 5 times. Even in unpredictable scenarios where we throw errors, this shouldn't happen.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
