### PR TITLE
remove the tuple unpacking code

### DIFF
--- a/doc/lang.md
+++ b/doc/lang.md
@@ -804,7 +804,7 @@ The latter form `((x, y)) => e2` is equivalent to:
 )
 ```
 
-As a result, the form `((x_1, ..., x_n)) => e_n` is a syntax sugar for tuple
+As a result, the form `((x_1, ..., x_n)) => e_n` is syntax sugar for tuple
 unpacking, as shown in the above example.
 
 ### Two forms of operator application

--- a/doc/lang.md
+++ b/doc/lang.md
@@ -2,7 +2,7 @@
 
 | Revision | Date       | Author                                                  |
 |:---------|:-----------|:--------------------------------------------------------|
-| 33       | 07.07.2023 | Igor Konnov, Shon Feder, Jure Kukovec, Gabriela Moreira, Thomas Pani |
+| 34       | 09.10.2023 | Igor Konnov, Shon Feder, Jure Kukovec, Gabriela Moreira, Thomas Pani |
 
 This document presents language constructs in the same order as the [summary of
 TLA+](https://lamport.azurewebsites.net/tla/summary.pdf).
@@ -236,7 +236,7 @@ This is intentional: We do not want to mix actions with temporal formulas.
 
 A module definition is introduced like follows:
 
-```
+```bluespec
 // module definition
 module Foo {
   // declarations
@@ -789,6 +789,23 @@ _ => e
 
 Note that lambdas can be only passed as arguments to other operators. They
 cannot be freely assigned to values or returned as a result of an operator.
+
+**Note:** There is a difference between a lambda expression of the form
+`(x, y) => e1` and a lambda expression of the form `((x, y)) => e2`.
+The former is a two-argument lambda operator, whereas the latter is a
+single-argument lambda operator that accepts a pair as its first argument.
+The latter form `((x, y)) => e2` is equivalent to:
+
+```bluespec
+(t =>
+  val x = t._1
+  val y = t._2
+  e2
+)
+```
+
+As a result, the form `((x_1, ..., x_n)) => e_n` is a syntax sugar for tuple
+unpacking, as shown in the above example.
 
 ### Two forms of operator application
 

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -1101,7 +1101,7 @@ export class CompilerVisitor implements IRVisitor {
     // apply the lambda to a single element of the set
     const evaluateElem = function (elem: RuntimeValue): Maybe<[RuntimeValue, RuntimeValue]> {
       // evaluate the predicate against the actual arguments
-      const result = callable.eval([ just(elem) ])
+      const result = callable.eval([just(elem)])
       return result.map(result => [result as RuntimeValue, elem])
     }
     this.applyFun(sourceId, 1, (iterable: Iterable<RuntimeValue>): Maybe<RuntimeValue> => {

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -548,8 +548,7 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('unpacks tuples in map', () => {
-      assertResultAsString('tuples(1.to(3), 4.to(6)).map(((x, y)) => x + y)',
-        'Set(5, 6, 7, 8, 9)')
+      assertResultAsString('tuples(1.to(3), 4.to(6)).map(((x, y)) => x + y)', 'Set(5, 6, 7, 8, 9)')
     })
 
     it('computes map over intervals', () => {
@@ -566,8 +565,7 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('unpacks tuples in filter', () => {
-      assertResultAsString('tuples(1.to(5), 2.to(3)).filter(((x, y)) => x < y)',
-        'Set(Tup(1, 2), Tup(1, 3), Tup(2, 3))')
+      assertResultAsString('tuples(1.to(5), 2.to(3)).filter(((x, y)) => x < y)', 'Set(Tup(1, 2), Tup(1, 3), Tup(2, 3))')
     })
 
     it('computes filter over intervals', () => {

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -507,7 +507,7 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('unpacks tuples in exists', () => {
-      assertResultAsString('tuples(1.to(3), 4.to(6)).exists((x, y) => x + y == 7)', 'true')
+      assertResultAsString('tuples(1.to(3), 4.to(6)).exists(((x, y)) => x + y == 7)', 'true')
     })
 
     it('computes exists over intervals', () => {
@@ -525,7 +525,7 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('unpacks tuples in forall', () => {
-      assertResultAsString('tuples(1.to(3), 4.to(6)).forall((x, y) => x + y <= 9)', 'true')
+      assertResultAsString('tuples(1.to(3), 4.to(6)).forall(((x, y)) => x + y <= 9)', 'true')
     })
 
     it('computes forall over nested sets', () => {
@@ -548,7 +548,8 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('unpacks tuples in map', () => {
-      assertResultAsString('tuples(1.to(3), 4.to(6)).map((x, y) => x + y)', 'Set(5, 6, 7, 8, 9)')
+      assertResultAsString('tuples(1.to(3), 4.to(6)).map(((x, y)) => x + y)',
+        'Set(5, 6, 7, 8, 9)')
     })
 
     it('computes map over intervals', () => {
@@ -565,7 +566,8 @@ describe('compiling specs to runtime values', () => {
     })
 
     it('unpacks tuples in filter', () => {
-      assertResultAsString('tuples(1.to(5), 2.to(3)).filter((x, y) => x < y)', 'Set(Tup(1, 2), Tup(1, 3), Tup(2, 3))')
+      assertResultAsString('tuples(1.to(5), 2.to(3)).filter(((x, y)) => x < y)',
+        'Set(Tup(1, 2), Tup(1, 3), Tup(2, 3))')
     })
 
     it('computes filter over intervals', () => {

--- a/tutorials/.tours/sets.tour
+++ b/tutorials/.tours/sets.tour
@@ -71,19 +71,19 @@
     {
       "title": "Power to the folds!",
       "description": "\nWhen @KryptoCoffeeCat decided to learn a bit more about `fold`, they have found\nthat this operator is quite powerful. For instance, they could write their\nown versions of `exists`, `forall`, `filter`, `map`, and `flatten`.\nDoes it mean that they should use `fold` everywhere now? Better not.\nAlthough folds can express a lot of things, they should be used when really\nrequired. After all, `exists`, `forall`, `filter`, `map`, `flatten`\nare much easier to read.\n        ",
-      "line": 102,
+      "line": 99,
       "file": "lesson4-sets/sets.qnt"
     },
     {
       "title": "Computing cycles with powersets",
       "description": "\nOK, here is a real challenge for @KryptoCoffeeCat! Can they find four pairs\nthat could be swapped in some order, so the sequence of swaps starts with\none coin and ends with the same coin? Degens love swap cycles!\n\nTo do that, they first write `availableUnorderedPairs.powerset()`, which\nblasts `availableUnorderedPairs` into a huge set that contains all combinations\nof pairs. These sets have all possible sizes. @KryptoCoffeeCat filter out the\nsets that are not quadruples. How many quadruples are there? Let's see:\n\n            \n>> echo 'quads.size()' | quint -r ./lesson4-sets/sets.qnt::sets\n\n\n\nPhew. It will take @KryptoCoffeeCat hours to analyze all these pairs by hand.\nHow do we know that some pairs form a cycle? Let's have a look at an example:\n\n| Coin A   | Coin B  |\n| -------- | ------- |\n| JUNO     | ATOM    |\n| ATOM     | OSMO    |\n| OSMO     | EVMOS   |\n| EVMOS    | JUNO    |\n\nThere is an interesting property here. Every coin appears exactly twice in\nthe above set. By browsing [Wikipedia](https://en.wikipedia.org/wiki/Main_Page),\n@KryptoCoffeeCat found that a slightly more general observation was made by\nLeonard Euler about 300 years ago, when he analyzed\n[the bridges of K\u00f6nigsberg](https://en.wikipedia.org/wiki/Seven_Bridges_of_K%C3%B6nigsberg).\nNot bad, @KryptoCoffeeCat!\n\nAfter figuring out the cycles, @KryptoCoffeeCat write the predicate `isCycle`\nand finally the definition `cycles4`. Now they compute all these cycles in a\nsingle click:\n            \n>> echo 'cycles4' | quint -r ./lesson4-sets/sets.qnt::sets\n\n",
-      "line": 122,
+      "line": 119,
       "file": "lesson4-sets/sets.qnt"
     },
     {
       "title": "Conclusions",
       "description": "\n\n@KryptoCoffeeCat has learned a lot in this tutorial.\nBy looking at the\n[Quint cheatsheet](https://github.com/informalsystems/quint/blob/main/doc/quint-cheatsheet.pdf),\nthey have found that this tutorial did not cover two operators on sets.\nCan you find them too?\n\nIf you are writing code in programming languages such as JavaScript, Rust,\nGolang, Java, Python, and similar, sets may be not your everyday data\nstructure (such as arrays and lists), though there is a good chance that you\nhave used sets before. In Quint, it's the opposite. If there is a problem,\nthen sets are most likely there to solve it. If not, you can use maps or lists,\nwhich will be explained in follow up tutorials.\n\n        ",
-      "line": 123,
+      "line": 120,
       "file": "lesson4-sets/sets.qnt"
     }
   ]

--- a/tutorials/lesson4-sets/sets.md
+++ b/tutorials/lesson4-sets/sets.md
@@ -233,7 +233,7 @@ Yes, @KryptoCoffeeCat, this is the way!
 ```
 
 
-After having the moment of revelation, @KryptoCoffeeCat decide to redefine the
+After having the moment of revelation @KryptoCoffeeCat, decide to redefine the
 set `availablePairs`. This time the set should contain sets like
 `Set("ATOM", "JUNO")` instead of pairs like `("ATOM", "JUNO")`.
 @KryptoCoffeeCat does not want to write the whole table again. So they quickly
@@ -529,31 +529,28 @@ echo 'buyableNSwaps(Set("ATOM"), 5)' | quint -r sets.qnt::sets
 
 ```bluespec
 
-  // Higher-order operators do not work in REPL atm:
-  // https://github.com/informalsystems/quint/issues/221
-
   // inSet.exists(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myExists(inSet: Set[a], pred: a => bool): bool =
-  //  inSet.fold(false, (result, elem) => result or pred(elem))
+  val myExists(inSet: Set[a], pred: a => bool): bool =
+    inSet.fold(false, (result, elem) => result or pred(elem))
 
   // inSet.forall(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myForall(inSet: Set[a], pred: a => bool): bool =
-  //  inSet.fold(true, (result, elem) => result and pred(elem))
+  val myForall(inSet: Set[a], pred: a => bool): bool =
+    inSet.fold(true, (result, elem) => result and pred(elem))
 
   // inSet.filter(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
-  //  inSet.fold(Set(),
-  //    (result, elem) =>
-  //      if (pred(elem)) result.union(Set(elem)) else result)
+  val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
+    inSet.fold(Set(),
+      (result, elem) =>
+        if (pred(elem)) result.union(Set(elem)) else result)
 
   // inSet.map(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myMap(inSet: Set[a], mapper: a => b): Set[b] =
-  //  inSet.fold(Set(),
-  //    (result, elem) => result.union(Set(mapper(elem))))
+  val myMap(inSet: Set[a], mapper: a => b): Set[b] =
+    inSet.fold(Set(),
+      (result, elem) => result.union(Set(mapper(elem))))
 
   // flatten(inSet) can be expressed via `fold`, when `inSet` is finite
-  //val myFlatten(inSet: Set[Set[a]]): Set[a] =
-  //  inSet.fold(Set(), (result, elem) => result.union(elem) )
+  val myFlatten(inSet: Set[Set[a]]): Set[a] =
+    inSet.fold(Set(), (result, elem) => result.union(elem) )
 ```
 
 

--- a/tutorials/lesson4-sets/sets.qnt
+++ b/tutorials/lesson4-sets/sets.qnt
@@ -75,31 +75,28 @@ module sets {
     1.to(n).fold(someCoins,
                  (prevCoins, i) => buyableVia1Swap(prevCoins))
 
-  // Higher-order operators do not work in REPL atm:
-  // https://github.com/informalsystems/quint/issues/221
-
   // inSet.exists(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myExists(inSet: Set[a], pred: a => bool): bool =
-  //  inSet.fold(false, (result, elem) => result or pred(elem))
+  val myExists(inSet: Set[a], pred: a => bool): bool =
+    inSet.fold(false, (result, elem) => result or pred(elem))
 
   // inSet.forall(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myForall(inSet: Set[a], pred: a => bool): bool =
-  //  inSet.fold(true, (result, elem) => result and pred(elem))
+  val myForall(inSet: Set[a], pred: a => bool): bool =
+    inSet.fold(true, (result, elem) => result and pred(elem))
 
   // inSet.filter(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
-  //  inSet.fold(Set(),
-  //    (result, elem) =>
-  //      if (pred(elem)) result.union(Set(elem)) else result)
+  val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
+    inSet.fold(Set(),
+      (result, elem) =>
+        if (pred(elem)) result.union(Set(elem)) else result)
 
   // inSet.map(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myMap(inSet: Set[a], mapper: a => b): Set[b] =
-  //  inSet.fold(Set(),
-  //    (result, elem) => result.union(Set(mapper(elem))))
+  val myMap(inSet: Set[a], mapper: a => b): Set[b] =
+    inSet.fold(Set(),
+      (result, elem) => result.union(Set(mapper(elem))))
 
   // flatten(inSet) can be expressed via `fold`, when `inSet` is finite
-  //val myFlatten(inSet: Set[Set[a]]): Set[a] =
-  //  inSet.fold(Set(), (result, elem) => result.union(elem) )
+  val myFlatten(inSet: Set[Set[a]]): Set[a] =
+    inSet.fold(Set(), (result, elem) => result.union(elem) )
 
   // all combinations of unordered pairs that have exactly 4 pairs
   pure val quads =

--- a/tutorials/lesson4-sets/sets.template.qnt
+++ b/tutorials/lesson4-sets/sets.template.qnt
@@ -464,31 +464,28 @@ Now @KryptoCoffeeCat can compute what they can buy via various numbers of swaps:
       </step>
     !*/
 
-  // Higher-order operators do not work in REPL atm:
-  // https://github.com/informalsystems/quint/issues/221
-
   // inSet.exists(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myExists(inSet: Set[a], pred: a => bool): bool =
-  //  inSet.fold(false, (result, elem) => result or pred(elem))
+  val myExists(inSet: Set[a], pred: a => bool): bool =
+    inSet.fold(false, (result, elem) => result or pred(elem))
 
   // inSet.forall(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myForall(inSet: Set[a], pred: a => bool): bool =
-  //  inSet.fold(true, (result, elem) => result and pred(elem))
+  val myForall(inSet: Set[a], pred: a => bool): bool =
+    inSet.fold(true, (result, elem) => result and pred(elem))
 
   // inSet.filter(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
-  //  inSet.fold(Set(),
-  //    (result, elem) =>
-  //      if (pred(elem)) result.union(Set(elem)) else result)
+  val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
+    inSet.fold(Set(),
+      (result, elem) =>
+        if (pred(elem)) result.union(Set(elem)) else result)
 
   // inSet.map(myFun) can be expressed via `fold`, when `inSet` is finite
-  //val myMap(inSet: Set[a], mapper: a => b): Set[b] =
-  //  inSet.fold(Set(),
-  //    (result, elem) => result.union(Set(mapper(elem))))
+  val myMap(inSet: Set[a], mapper: a => b): Set[b] =
+    inSet.fold(Set(),
+      (result, elem) => result.union(Set(mapper(elem))))
 
   // flatten(inSet) can be expressed via `fold`, when `inSet` is finite
-  //val myFlatten(inSet: Set[Set[a]]): Set[a] =
-  //  inSet.fold(Set(), (result, elem) => result.union(elem) )
+  val myFlatten(inSet: Set[Set[a]]): Set[a] =
+    inSet.fold(Set(), (result, elem) => result.union(elem) )
     /*!
       <step>
         <title>Power to the folds!</title>


### PR DESCRIPTION
This is a follow-up to #1202. Since tuples are rewritten by the parser now, there is no need for special treatment in the simulator. This has also unblocked the old code in the tutorial 3.