### PR TITLE
Fix pure defs and vals in tutorial 4

### DIFF
--- a/tutorials/lesson4-sets/sets.md
+++ b/tutorials/lesson4-sets/sets.md
@@ -348,20 +348,20 @@ themselves.
   pure def someCoinsExample = Set("ATOM", "ETH", "USDT")
 
   // which coins can be bought by swapping a coin from `someCoins` once?
-  val buyableVia1Swap(someCoins) =
+  pure def buyableVia1Swap(someCoins) =
     availableUnorderedPairs
       .filter(p => p.intersect(someCoins).size() == 1)
       .flatten()
       .exclude(someCoins)
 
   // which coins can be bought by swapping a coin from `someCoins` exactly twice?
-  val buyableVia2Swaps(someCoins) =
+  pure def buyableVia2Swaps(someCoins) =
     someCoins
       .buyableVia1Swap()
       .buyableVia1Swap()
 
   // which coins can be bought by swapping a coin from `someCoins` twice?
-  val buyableVia1or2Swaps(someCoins) =
+  pure def buyableVia1or2Swaps(someCoins) =
     buyableVia1Swap(someCoins)
       .union(buyableVia2Swaps(someCoins))
 ```
@@ -447,7 +447,7 @@ echo 'buyableVia1or2Swaps(Set("ATOM"))' | quint -r sets.qnt::sets
 ```bluespec
 
   // which coins can we buy via n swaps when starting from `someCoins`
-  val buyableNSwaps(someCoins, n) =
+  pure def buyableNSwaps(someCoins, n) =
     1.to(n).fold(someCoins,
                  (prevCoins, i) => buyableVia1Swap(prevCoins))
 ```
@@ -530,26 +530,26 @@ echo 'buyableNSwaps(Set("ATOM"), 5)' | quint -r sets.qnt::sets
 ```bluespec
 
   // inSet.exists(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myExists(inSet: Set[a], pred: a => bool): bool =
+  pure def myExists(inSet: Set[a], pred: a => bool): bool =
     inSet.fold(false, (result, elem) => result or pred(elem))
 
   // inSet.forall(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myForall(inSet: Set[a], pred: a => bool): bool =
+  pure def myForall(inSet: Set[a], pred: a => bool): bool =
     inSet.fold(true, (result, elem) => result and pred(elem))
 
   // inSet.filter(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
+  pure def myFilter(inSet: Set[a], pred: a => bool): Set[a] =
     inSet.fold(Set(),
       (result, elem) =>
         if (pred(elem)) result.union(Set(elem)) else result)
 
   // inSet.map(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myMap(inSet: Set[a], mapper: a => b): Set[b] =
+  pure def myMap(inSet: Set[a], mapper: a => b): Set[b] =
     inSet.fold(Set(),
       (result, elem) => result.union(Set(mapper(elem))))
 
   // flatten(inSet) can be expressed via `fold`, when `inSet` is finite
-  val myFlatten(inSet: Set[Set[a]]): Set[a] =
+  pure def myFlatten(inSet: Set[Set[a]]): Set[a] =
     inSet.fold(Set(), (result, elem) => result.union(elem) )
 ```
 

--- a/tutorials/lesson4-sets/sets.qnt
+++ b/tutorials/lesson4-sets/sets.qnt
@@ -53,49 +53,49 @@ module sets {
   pure def someCoinsExample = Set("ATOM", "ETH", "USDT")
 
   // which coins can be bought by swapping a coin from `someCoins` once?
-  val buyableVia1Swap(someCoins) =
+  pure def buyableVia1Swap(someCoins) =
     availableUnorderedPairs
       .filter(p => p.intersect(someCoins).size() == 1)
       .flatten()
       .exclude(someCoins)
 
   // which coins can be bought by swapping a coin from `someCoins` exactly twice?
-  val buyableVia2Swaps(someCoins) =
+  pure def buyableVia2Swaps(someCoins) =
     someCoins
       .buyableVia1Swap()
       .buyableVia1Swap()
 
   // which coins can be bought by swapping a coin from `someCoins` twice?
-  val buyableVia1or2Swaps(someCoins) =
+  pure def buyableVia1or2Swaps(someCoins) =
     buyableVia1Swap(someCoins)
       .union(buyableVia2Swaps(someCoins))
 
   // which coins can we buy via n swaps when starting from `someCoins`
-  val buyableNSwaps(someCoins, n) =
+  pure def buyableNSwaps(someCoins, n) =
     1.to(n).fold(someCoins,
                  (prevCoins, i) => buyableVia1Swap(prevCoins))
 
   // inSet.exists(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myExists(inSet: Set[a], pred: a => bool): bool =
+  pure def myExists(inSet: Set[a], pred: a => bool): bool =
     inSet.fold(false, (result, elem) => result or pred(elem))
 
   // inSet.forall(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myForall(inSet: Set[a], pred: a => bool): bool =
+  pure def myForall(inSet: Set[a], pred: a => bool): bool =
     inSet.fold(true, (result, elem) => result and pred(elem))
 
   // inSet.filter(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
+  pure def myFilter(inSet: Set[a], pred: a => bool): Set[a] =
     inSet.fold(Set(),
       (result, elem) =>
         if (pred(elem)) result.union(Set(elem)) else result)
 
   // inSet.map(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myMap(inSet: Set[a], mapper: a => b): Set[b] =
+  pure def myMap(inSet: Set[a], mapper: a => b): Set[b] =
     inSet.fold(Set(),
       (result, elem) => result.union(Set(mapper(elem))))
 
   // flatten(inSet) can be expressed via `fold`, when `inSet` is finite
-  val myFlatten(inSet: Set[Set[a]]): Set[a] =
+  pure def myFlatten(inSet: Set[Set[a]]): Set[a] =
     inSet.fold(Set(), (result, elem) => result.union(elem) )
 
   // all combinations of unordered pairs that have exactly 4 pairs

--- a/tutorials/lesson4-sets/sets.template.qnt
+++ b/tutorials/lesson4-sets/sets.template.qnt
@@ -306,20 +306,20 @@ themselves.
   pure def someCoinsExample = Set("ATOM", "ETH", "USDT")
 
   // which coins can be bought by swapping a coin from `someCoins` once?
-  val buyableVia1Swap(someCoins) =
+  pure def buyableVia1Swap(someCoins) =
     availableUnorderedPairs
       .filter(p => p.intersect(someCoins).size() == 1)
       .flatten()
       .exclude(someCoins)
 
   // which coins can be bought by swapping a coin from `someCoins` exactly twice?
-  val buyableVia2Swaps(someCoins) =
+  pure def buyableVia2Swaps(someCoins) =
     someCoins
       .buyableVia1Swap()
       .buyableVia1Swap()
 
   // which coins can be bought by swapping a coin from `someCoins` twice?
-  val buyableVia1or2Swaps(someCoins) =
+  pure def buyableVia1or2Swaps(someCoins) =
     buyableVia1Swap(someCoins)
       .union(buyableVia2Swaps(someCoins))
     /*!
@@ -395,7 +395,7 @@ Also easy: Just take the set union of what is possible in one or two swaps:
     !*/
 
   // which coins can we buy via n swaps when starting from `someCoins`
-  val buyableNSwaps(someCoins, n) =
+  pure def buyableNSwaps(someCoins, n) =
     1.to(n).fold(someCoins,
                  (prevCoins, i) => buyableVia1Swap(prevCoins))
     /*!
@@ -465,26 +465,26 @@ Now @KryptoCoffeeCat can compute what they can buy via various numbers of swaps:
     !*/
 
   // inSet.exists(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myExists(inSet: Set[a], pred: a => bool): bool =
+  pure def myExists(inSet: Set[a], pred: a => bool): bool =
     inSet.fold(false, (result, elem) => result or pred(elem))
 
   // inSet.forall(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myForall(inSet: Set[a], pred: a => bool): bool =
+  pure def myForall(inSet: Set[a], pred: a => bool): bool =
     inSet.fold(true, (result, elem) => result and pred(elem))
 
   // inSet.filter(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myFilter(inSet: Set[a], pred: a => bool): Set[a] =
+  pure def myFilter(inSet: Set[a], pred: a => bool): Set[a] =
     inSet.fold(Set(),
       (result, elem) =>
         if (pred(elem)) result.union(Set(elem)) else result)
 
   // inSet.map(myFun) can be expressed via `fold`, when `inSet` is finite
-  val myMap(inSet: Set[a], mapper: a => b): Set[b] =
+  pure def myMap(inSet: Set[a], mapper: a => b): Set[b] =
     inSet.fold(Set(),
       (result, elem) => result.union(Set(mapper(elem))))
 
   // flatten(inSet) can be expressed via `fold`, when `inSet` is finite
-  val myFlatten(inSet: Set[Set[a]]): Set[a] =
+  pure def myFlatten(inSet: Set[Set[a]]): Set[a] =
     inSet.fold(Set(), (result, elem) => result.union(elem) )
     /*!
       <step>


### PR DESCRIPTION
Closes #1157. In tutorial 4, `pure def` and `pure val` are used where they should be used.