### PR TITLE
Properly override `checker.tuning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed internal bugs in the effect checker that could cause an incorrect effect
   to be inferred or error to be reported (#1203)
+- Fixed propagation of `checker.tuning` Apalache config file key for `quint
+  verify` (#1216)
 
 ### Security
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -641,6 +641,7 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
       inv: args.invariant ? ['q::inv'] : undefined,
       'temporal-props': args.temporal ? ['q::temporalProps'] : undefined,
       tuning: {
+        ...(loadedConfig.checker?.tuning ?? {}),
         'search.simulation': args.randomTransitions ? 'true' : 'false',
       },
     },


### PR DESCRIPTION
The `checker.tuning` config key was previously fully overridden in code.
Change this to only override the appropriate fields.

- [ ] ~Tests added for any new code~
- [ ] ~Documentation added for any new functionality~
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] ~Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality~

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
