### PR TITLE
Fixes for `--apalache-config`

### DIFF
--- a/doc/quint.md
+++ b/doc/quint.md
@@ -279,8 +279,8 @@ Options:
                                                                         [string]
   --random-transitions  choose transitions at random (= use symbolic simulation)
                                                       [boolean] [default: false]
-  --apalache-config  Filename of the additional Apalache configuration (in the
-                     HOCON format, a superset of JSON)                  [string]
+  --apalache-config     path to an additional Apalache configuration file (in
+                        JSON)                                           [string]
   --verbosity        control how much output is produced (0 to 5)
                                                            [number] [default: 2]
 ```

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -246,7 +246,7 @@ const verifyCmd = {
         default: false,
       })
       .option('apalache-config', {
-        desc: 'Filename of the additional Apalache configuration (in the HOCON format, a superset of JSON)',
+        desc: 'path to an additional Apalache configuration file (in JSON)',
         type: 'string',
       })
       .option('verbosity', {

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -570,8 +570,14 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
 export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<VerifiedStage>> {
   const verifying = { ...prev, stage: 'verifying' as stage }
   const args = verifying.args
-  // TODO error handing for file reads and deserde
-  const loadedConfig = args.apalacheConfig ? JSON.parse(readFileSync(args.apalacheConfig, 'utf-8')) : {}
+  let loadedConfig: any = {}
+  try {
+    if (args.apalacheConfig) {
+      loadedConfig = JSON.parse(readFileSync(args.apalacheConfig, 'utf-8'))
+    }
+  } catch (err: any) {
+    return cliErr(`failed to read Apalache config: ${err.message}`, { ...verifying, errors: [], sourceCode: '' })
+  }
 
   const mainArg = prev.args.main
   const mainName = mainArg ? mainArg : basename(prev.args.input, '.qnt')


### PR DESCRIPTION
Two fixes for `--apalache-config`:
* usage message erroneously mentioned HOCON as supported, when we only parse JSON from Quint
* wrap reading + parsing the config file in a try/catch block

Fixes #1215

- [ ] ~Tests added for any new code~
- [ ] ~Documentation added for any new functionality~
- [ ] ~Entries added to the respective `CHANGELOG.md` for any new functionality~
- [ ] ~Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality~