### PR TITLE
Fix problems reporting errors between multiple files

### DIFF
--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -972,3 +972,24 @@ exit $exit_code
 >>> Map("p1" -> 0, "p2" -> 0, "p3" -> 0)
 >>> 
 ```
+
+### Errors are reported in the right file
+
+File `ImportFileWithError.qnt` has no error, but it imports a module from file `FileWithError.qnt` that has a type error. The type should be reported only in `FileWithError.qnt`.
+
+<!-- !test in error for file -->
+```
+quint typecheck ./testFixture/typechecking/ImportFileWithError.qnt 2>&1 | sed 's#.*quint/\(testFixture\)#HOME/\1#g'
+```
+
+<!-- !test out error for file -->
+```
+HOME/testFixture/typechecking/FileWithError.qnt:2:3 - error: [QNT000] Couldn't unify bool and int
+Trying to unify bool and int
+
+2:   val a: int = true
+     ^^^^^^^^^^^^^^^^^
+
+error: typechecking failed
+```
+

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -46,7 +46,7 @@ import { verify } from './quintVerifier'
 import { flattenModules } from './flattening/fullFlattener'
 import { analyzeInc, analyzeModules } from './quintAnalyzer'
 import { ExecutionFrame } from './runtime/trace'
-import { flow } from 'lodash'
+import { flow, isEqual, uniqWith } from 'lodash'
 
 export type stage = 'loading' | 'parsing' | 'typechecking' | 'testing' | 'running' | 'documentation'
 
@@ -72,7 +72,7 @@ interface OutputStage {
   documentation?: Map<string, Map<string, DocumentationEntry>>
   errors?: ErrorMessage[]
   warnings?: any[] // TODO it doesn't look like this is being used for anything. Should we remove it?
-  sourceCode?: string // Should not printed, only used in formatting errors
+  sourceCode?: Map<string, string> // Should not printed, only used in formatting errors
 }
 
 // Extract just the parts of a ProcedureStage that we use for the output
@@ -118,7 +118,7 @@ interface ProcedureStage extends OutputStage {
 interface LoadedStage extends ProcedureStage {
   // Path to the source file
   path: string
-  sourceCode: string
+  sourceCode: Map<string, string>
 }
 
 interface ParsedStage extends LoadedStage {
@@ -161,7 +161,7 @@ interface DocumentationStage extends LoadedStage {
 // A procedure stage which is guaranteed to have `errors` and `sourceCode`
 interface ErrorData extends ProcedureStage {
   errors: ErrorMessage[]
-  sourceCode: string
+  sourceCode: Map<string, string>
 }
 
 type ErrResult = { msg: string; stage: ErrorData }
@@ -185,14 +185,18 @@ export async function load(args: any): Promise<CLIProcedure<LoadedStage>> {
         ...stage,
         args,
         path,
-        sourceCode,
+        sourceCode: new Map([[path, sourceCode]]),
         warnings: [],
       })
     } catch (err: unknown) {
-      return cliErr(`file ${args.input} could not be opened due to ${err}`, { ...stage, errors: [], sourceCode: '' })
+      return cliErr(`file ${args.input} could not be opened due to ${err}`, {
+        ...stage,
+        errors: [],
+        sourceCode: new Map(),
+      })
     }
   } else {
-    return cliErr(`file ${args.input} does not exist`, { ...stage, errors: [], sourceCode: '' })
+    return cliErr(`file ${args.input} does not exist`, { ...stage, errors: [], sourceCode: new Map() })
   }
 }
 
@@ -203,12 +207,13 @@ export async function load(args: any): Promise<CLIProcedure<LoadedStage>> {
  */
 export async function parse(loaded: LoadedStage): Promise<CLIProcedure<ParsedStage>> {
   const { args, sourceCode, path } = loaded
+  const text = sourceCode.get(path)!
   const parsing = { ...loaded, stage: 'parsing' as stage }
   const idGen = newIdGenerator()
   return flow([
-    () => parsePhase1fromText(idGen, sourceCode, path),
+    () => parsePhase1fromText(idGen, text, path),
     phase1Data => {
-      const resolver = fileSourceResolver()
+      const resolver = fileSourceResolver(sourceCode)
       const mainPath = resolver.lookupPath(dirname(path), basename(path))
       return parsePhase2sourceResolution(idGen, resolver, mainPath, phase1Data)
     },
@@ -379,6 +384,7 @@ export async function runTests(prev: TypecheckedStage): Promise<CLIProcedure<Tes
     sourceMap: testing.sourceMap,
     analysisOutput: flattenedAnalysis,
     idGen: testing.idGen,
+    sourceCode: testing.sourceCode,
   }
   const testOut = compileAndTest(compilationState, mainName, flattenedTable, options)
 
@@ -423,10 +429,10 @@ export async function runTests(prev: TypecheckedStage): Promise<CLIProcedure<Tes
     // output errors, if there are any
     if (verbosity.hasTestDetails(verbosityLevel) && namedErrors.length > 0) {
       const code = prev.sourceCode!
-      const finder = lineColumn(code)
+      const finders = createFinders(code)
       out('')
       namedErrors.forEach(([name, err, testResult], index) => {
-        const details = formatError(code, finder, err)
+        const details = formatError(code, finders, err)
         // output the header
         out(`  ${index + 1}) ${name}:`)
         const lines = details.split('\n')
@@ -508,11 +514,12 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
   }
   const startMs = Date.now()
 
-  const mainPath = fileSourceResolver().lookupPath(dirname(prev.args.input), basename(prev.args.input))
+  const mainText = prev.sourceCode.get(prev.path)!
+  const mainPath = fileSourceResolver(prev.sourceCode).lookupPath(dirname(prev.args.input), basename(prev.args.input))
   const mainId = prev.modules.find(m => m.name === mainName)!.id
   const mainStart = prev.sourceMap.get(mainId)!.start.index
   const mainEnd = prev.sourceMap.get(mainId)!.end!.index
-  const result = compileAndRun(newIdGenerator(), prev.sourceCode, mainStart, mainEnd, mainName, mainPath, options)
+  const result = compileAndRun(newIdGenerator(), mainText, mainStart, mainEnd, mainName, mainPath, options)
 
   if (result.status === 'error') {
     const newErrors = result.errors.map(mkErrorMessage(prev.sourceMap))
@@ -582,14 +589,14 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
       loadedConfig = JSON.parse(readFileSync(args.apalacheConfig, 'utf-8'))
     }
   } catch (err: any) {
-    return cliErr(`failed to read Apalache config: ${err.message}`, { ...verifying, errors: [], sourceCode: '' })
+    return cliErr(`failed to read Apalache config: ${err.message}`, { ...verifying, errors: [], sourceCode: new Map() })
   }
 
   const mainArg = prev.args.main
   const mainName = mainArg ? mainArg : basename(prev.args.input, '.qnt')
   const main = verifying.modules.find(m => m.name === mainName)
   if (!main) {
-    return cliErr(`module ${mainName} does not exist`, { ...verifying, errors: [], sourceCode: '' })
+    return cliErr(`module ${mainName} does not exist`, { ...verifying, errors: [], sourceCode: new Map() })
   }
 
   // Wrap init, step, invariant and temporal properties in other definitions,
@@ -705,8 +712,9 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
  */
 export async function docs(loaded: LoadedStage): Promise<CLIProcedure<DocumentationStage>> {
   const { sourceCode, path } = loaded
+  const text = sourceCode.get(path)!
   const parsing = { ...loaded, stage: 'documentation' as stage }
-  const phase1Data = parsePhase1fromText(newIdGenerator(), sourceCode, path)
+  const phase1Data = parsePhase1fromText(newIdGenerator(), text, path)
   const allEntries: [string, Map<string, DocumentationEntry>][] = phase1Data.modules.map(module => {
     const documentationEntries = produceDocs(module)
     const title = `# Documentation for ${module.name}\n\n`
@@ -744,8 +752,8 @@ export function outputResult(result: CLIProcedure<ProcedureStage>) {
       if (args.out) {
         writeToJson(args.out, outputData)
       } else {
-        const finder = lineColumn(sourceCode!)
-        errors.forEach(err => console.error(formatError(sourceCode, finder, err)))
+        const finders = createFinders(sourceCode!)
+        uniqWith(errors, isEqual).forEach(err => console.error(formatError(sourceCode, finders, err)))
         console.error(`error: ${msg}`)
       }
       process.exit(1)
@@ -831,4 +839,8 @@ function isMatchingTest(match: string | undefined, name: string) {
   } else {
     return name.endsWith('Test')
   }
+}
+
+export function createFinders(sourceCode: Map<string, string>): Map<string, any> {
+  return new Map([...sourceCode.entries()].map(([path, code]) => [path, lineColumn(code)]))
 }

--- a/quint/src/errorReporter.ts
+++ b/quint/src/errorReporter.ts
@@ -15,6 +15,7 @@
  */
 
 import { Maybe, just } from '@sweet-monads/maybe'
+import JSONbig from 'json-bigint'
 
 import { ErrorMessage } from './ErrorMessage'
 
@@ -30,8 +31,8 @@ import { ErrorMessage } from './ErrorMessage'
  * @returns a formatted string with error information
  * */
 export function formatError(
-  text: string,
-  finder: any,
+  code: Map<string, string>,
+  finders: Map<string, any>,
   message: ErrorMessage,
   lineOffset: Maybe<number> = just(1)
 ): string {
@@ -42,6 +43,8 @@ export function formatError(
   try {
     // try to extract the location of the error
     return message.locs.reduce((output, loc) => {
+      const text = code.get(loc.source)!
+      const finder = finders.get(loc.source)!
       // If lineOffset is a number, print the source location.
       // If lineOfsset is undefined, omit the source location (e.g., in REPL).
       const locString = lineOffset.isJust()
@@ -70,6 +73,7 @@ export function formatError(
     console.error('\nSomething unexpected happened during error reconstruction. Please report a bug.\n')
     console.error('Include this in the bug report: {')
     console.trace(error.message)
+    console.log('Trying to format', JSONbig.stringify(message.locs))
     console.error('} // end of the bug report\n')
 
     // return the bare bones error message

--- a/quint/src/parsing/quintParserFrontend.ts
+++ b/quint/src/parsing/quintParserFrontend.ts
@@ -289,12 +289,13 @@ export function parse(
   idGen: IdGenerator,
   sourceLocation: string,
   mainPath: SourceLookupPath,
-  code: string
+  code: string,
+  sourceCode: Map<string, string> = new Map()
 ): ParseResult<ParserPhase4> {
   return flow([
     () => parsePhase1fromText(idGen, code, sourceLocation),
     phase1Data => {
-      const resolver = fileSourceResolver()
+      const resolver = fileSourceResolver(sourceCode)
       return parsePhase2sourceResolution(idGen, resolver, mainPath, phase1Data)
     },
     parsePhase3importAndNameResolution,

--- a/quint/src/parsing/sourceResolver.ts
+++ b/quint/src/parsing/sourceResolver.ts
@@ -81,7 +81,10 @@ export interface SourceResolver {
  * @returns A filesystem resolver. For each path, it returns
  *          either `left(errorMessage)`, or `right(fileContents)`.
  */
-export const fileSourceResolver = (replacer: (path: string) => string = path => path): SourceResolver => {
+export function fileSourceResolver(
+  sourceCode: Map<string, string> = new Map(),
+  replacer: (path: string) => string = path => path
+): SourceResolver {
   return {
     lookupPath: (basepath: string, importPath: string) => {
       return {
@@ -94,7 +97,9 @@ export const fileSourceResolver = (replacer: (path: string) => string = path => 
 
     load: (lookupPath: SourceLookupPath): Either<string, string> => {
       try {
-        return right(lf(readFileSync(lookupPath.normalizedPath, 'utf8')))
+        const code = lf(readFileSync(lookupPath.normalizedPath, 'utf8'))
+        sourceCode.set(lookupPath.normalizedPath, code)
+        return right(code)
       } catch (err: any) {
         return left(err.message)
       }

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -11,7 +11,6 @@
 import * as readline from 'readline'
 import { Readable, Writable } from 'stream'
 import { readFileSync, writeFileSync } from 'fs'
-import lineColumn from 'line-column'
 import { Maybe, just, none } from '@sweet-monads/maybe'
 import { Either, left, right } from '@sweet-monads/either'
 import chalk from 'chalk'
@@ -42,8 +41,9 @@ import { cwd } from 'process'
 import { newIdGenerator } from './idGenerator'
 import { moduleToString } from './ir/IRprinting'
 import { EvaluationState, newEvaluationState } from './runtime/impl/compilerImpl'
-import { mkErrorMessage } from './cliCommands'
+import { createFinders, mkErrorMessage } from './cliCommands'
 import { QuintError } from './quintError'
+import { ErrorMessage } from './ErrorMessage'
 
 // tunable settings
 export const settings = {
@@ -490,7 +490,8 @@ function simulatorBuiltins(st: CompilationState): QuintDef[] {
 
 function tryEvalModule(out: writer, state: ReplState, mainName: string): boolean {
   const modulesText = state.moduleHist
-  const mainPath = fileSourceResolver().lookupPath(cwd(), 'repl.ts')
+  const mainPath = fileSourceResolver(state.compilationState.sourceCode).lookupPath(cwd(), 'repl.ts')
+  state.compilationState.sourceCode.set(mainPath.toSourceName(), modulesText)
 
   const context = compileFromCode(
     newIdGenerator(),
@@ -505,7 +506,9 @@ function tryEvalModule(out: writer, state: ReplState, mainName: string): boolean
     context.compileErrors.length > 0 ||
     context.syntaxErrors.length > 0
   ) {
-    printErrors(out, state, context)
+    const tempState = state.clone()
+    tempState.compilationState = context.compilationState
+    printErrors(out, tempState, context)
     return false
   }
 
@@ -625,10 +628,21 @@ function printErrorMessages(
   const modulesText = state.moduleHist + inputText
   const messages = errors.map(mkErrorMessage(state.compilationState.sourceMap))
   // display the error messages and highlight the error places
+  // FIXME: moudulesText can come from multiple files, but `compileFromCode` ignores that.
+  // We use a fallback here to '<modules>'
+  const sourceCode = new Map([
+    ['<input>', inputText],
+    ['<modules>', modulesText],
+    ...state.compilationState.sourceCode.entries(),
+  ])
+  const finders = createFinders(sourceCode)
+
   messages.forEach(e => {
-    const text = e.locs[0]?.source === '<input>' ? inputText : modulesText
-    const finder = lineColumn(text)
-    const msg = formatError(text, finder, e, none())
+    const error: ErrorMessage = {
+      ...e,
+      locs: e.locs.map(loc => ({ ...loc, source: finders.has(loc.source) ? loc.source : '<modules>' })),
+    }
+    const msg = formatError(sourceCode, finders, error, none())
     out(color(`${kind}: ${msg}\n`))
   })
 }

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -59,6 +59,8 @@ export interface CompilationContext {
 export interface CompilationState {
   // The ID generator used during compilation.
   idGen: IdGenerator
+  // File content loaded for each source, used to report errors
+  sourceCode: Map<string, string>
   // A list of modules as they are constructed, without flattening. This is
   // needed to derive correct name resolution during incremental compilation in
   // a flattened context.
@@ -77,6 +79,7 @@ export interface CompilationState {
 export function newCompilationState(): CompilationState {
   return {
     idGen: newIdGenerator(),
+    sourceCode: new Map(),
     originalModules: [],
     modules: [],
     sourceMap: new Map(),
@@ -276,7 +279,9 @@ export function compileFromCode(
   rand: (bound: bigint) => bigint
 ): CompilationContext {
   // parse the module text
-  const { modules, table, sourceMap, errors } = parse(idGen, '<module_input>', mainPath, code)
+  // FIXME: We should build a proper sourceCode map from the files we previously loaded
+  const sourceCode: Map<string, string> = new Map()
+  const { modules, table, sourceMap, errors } = parse(idGen, mainPath.toSourceName(), mainPath, code, sourceCode)
   // On errors, we'll produce the computational context up to this point
   const [analysisErrors, analysisOutput] = analyzeModules(table, modules)
 
@@ -294,6 +299,7 @@ export function compileFromCode(
     sourceMap,
     analysisOutput: flattenedAnalysis,
     idGen,
+    sourceCode,
   }
 
   const main = flattenedModules.find(m => m.name === mainName)

--- a/quint/test/cli.test.ts
+++ b/quint/test/cli.test.ts
@@ -13,7 +13,7 @@ module exModule {
 const loaded = {
   args: {},
   path: 'mocked/path',
-  sourceCode: exModule,
+  sourceCode: new Map([['mocked/path', exModule]]),
   stage: 'loading' as stage,
   warnings: [],
 }

--- a/quint/test/errorReporter.test.ts
+++ b/quint/test/errorReporter.test.ts
@@ -8,8 +8,8 @@ describe('errorReporter', () => {
   const text = `module test {
   def op = "value"
 }`
-
-  const finder = lineColumn(text)
+  const sourceCode: Map<string, string> = new Map([['file', text]])
+  const finder: Map<string, any> = new Map([['file', lineColumn(text)]])
 
   it('highlights the middle line', () => {
     const message: ErrorMessage = {
@@ -27,7 +27,7 @@ describe('errorReporter', () => {
 2:   def op = "value"
        ^^^^`
 
-    const error = formatError(text, finder, message).trim()
+    const error = formatError(sourceCode, finder, message).trim()
     assert.equal(error, expectedError)
   })
 
@@ -49,7 +49,7 @@ describe('errorReporter', () => {
 2:   def op = "value"
    ^^^^^^^^`
 
-    const error = formatError(text, finder, message).trim()
+    const error = formatError(sourceCode, finder, message).trim()
     assert.equal(error, expectedError)
   })
 
@@ -68,7 +68,7 @@ describe('errorReporter', () => {
 2:   def op = "value"
        ^`
 
-    const error = formatError(text, finder, message).trim()
+    const error = formatError(sourceCode, finder, message).trim()
     assert.equal(error, expectedError)
   })
 
@@ -88,7 +88,7 @@ describe('errorReporter', () => {
 2:   def op = "value"
        ^^^^`
 
-    const error = formatError(text, finder, message).trim()
+    const error = formatError(sourceCode, finder, message).trim()
     assert.equal(error, expectedError)
   })
 
@@ -100,7 +100,7 @@ describe('errorReporter', () => {
 
     const expectedError = 'error: error explanation'
 
-    const error = formatError(text, finder, message).trim()
+    const error = formatError(sourceCode, finder, message).trim()
     assert.equal(error, expectedError)
   })
 })

--- a/quint/test/parsing/quintParserFrontend.test.ts
+++ b/quint/test/parsing/quintParserFrontend.test.ts
@@ -40,7 +40,7 @@ function parseAndCompare(artifact: string): void {
   // read the input from the data directory and parse it
   const gen = newIdGenerator()
   const basepath = resolve(__dirname, '../../testFixture')
-  const resolver = fileSourceResolver((path: string) => {
+  const resolver = fileSourceResolver(new Map(), (path: string) => {
     // replace the absolute path with a generic mocked path,
     // so the same fixtures work accross different setups
     return path.replace(basepath, 'mocked_path/testFixture')

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -985,8 +985,9 @@ describe('incremental compilation', () => {
   /* Adds some quint code to the compilation and evaluation state */
   function compileModules(text: string, mainName: string): CompilationContext {
     const idGen = newIdGenerator()
+    const sourceCode: Map<string, string> = new Map()
     const fake_path: SourceLookupPath = { normalizedPath: 'fake_path', toSourceName: () => 'fake_path' }
-    const { modules, table, sourceMap, errors } = parse(idGen, 'fake_location', fake_path, text)
+    const { modules, table, sourceMap, errors } = parse(idGen, 'fake_path', fake_path, text, sourceCode)
     assert.isEmpty(errors)
 
     const [analysisErrors, analysisOutput] = analyzeModules(table, modules)
@@ -1007,6 +1008,7 @@ describe('incremental compilation', () => {
       mainName,
       sourceMap,
       analysisOutput: flattenedAnalysis,
+      sourceCode,
     }
 
     const moduleToCompile = flattenedModules[flattenedModules.length - 1]

--- a/quint/testFixture/typechecking/FileWithError.qnt
+++ b/quint/testFixture/typechecking/FileWithError.qnt
@@ -1,0 +1,3 @@
+module WithError {
+  val a: int = true
+}

--- a/quint/testFixture/typechecking/ImportFileWithError.qnt
+++ b/quint/testFixture/typechecking/ImportFileWithError.qnt
@@ -1,0 +1,4 @@
+module Test {
+  import WithError.* from "./FileWithError"
+  val b = a
+}

--- a/quint/tsconfig.json
+++ b/quint/tsconfig.json
@@ -1,16 +1,16 @@
 {
-	"compilerOptions": {
-		"target": "es2021",
-		"lib": ["ES2021"],
-		"module": "commonjs",
-		"moduleResolution": "node",
-    "esModuleInterop": true,
-    "declaration": true,
-		"sourceMap": true,
-		"strict": true,
-    "noImplicitAny": true,
-		"outDir": "dist"
-	},
-	"include": ["src", "test"],
-	"exclude": ["node_modules", ".vscode-test"]
+    "compilerOptions": {
+        "target": "es2021",
+        "lib": ["ES2021"],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "declaration": true,
+        "sourceMap": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "outDir": "dist"
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", ".vscode-test"]
 }

--- a/vscode/quint-vscode/server/src/reporting.ts
+++ b/vscode/quint-vscode/server/src/reporting.ts
@@ -25,17 +25,21 @@ import { compact } from 'lodash'
  *
  * @returns a list of diagnostics with the proper error messages and locations
  */
-export function diagnosticsFromErrors(errors: QuintError[], sourceMap: SourceMap): Diagnostic[] {
-  const diagnostics = errors.map(error => {
+export function diagnosticsFromErrors(errors: QuintError[], sourceMap: SourceMap): Map<string, Diagnostic[]> {
+  const diagnostics = new Map()
+
+  errors.forEach(error => {
     const loc = sourceMap.get(error.reference!)!
     if (!loc) {
       console.log(`loc for ${error} not found in source map`)
     } else {
-      return assembleDiagnostic(error, loc)
+      const diagnostic = assembleDiagnostic(error, loc)
+      const previous = diagnostics.get(loc.source) ?? []
+      diagnostics.set(loc.source, [ ...previous, diagnostic])
     }
   })
 
-  return compact(diagnostics)
+  return diagnostics
 }
 
 /**

--- a/vscode/quint-vscode/server/test/reporting.test.ts
+++ b/vscode/quint-vscode/server/test/reporting.test.ts
@@ -21,7 +21,7 @@ describe('diagnosticsFromErrorMap', () => {
   it('assembles diagnosticts from error maps', () => {
     const diagnostics = diagnosticsFromErrors(errors, sourceMap)
 
-    assert.sameDeepMembers(diagnostics, [
+    assert.sameDeepMembers(diagnostics.get('mocked_path')!, [
       {
         message: 'Message',
         range: {


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
