### PR TITLE
VSCode Release v0.10.0

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.10.0 -- 2023-11-08
+
+### Added
+### Changed
 
 - Error reporting was changed to show more errors at a time, instead of having a lot of phases (#1220)
 

--- a/vscode/quint-vscode/package-lock.json
+++ b/vscode/quint-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quint-vscode",
-	"version": "0.9.1",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-vscode",
-			"version": "0.9.1",
+			"version": "0.10.0",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "quint-vscode",
 	"displayName": "Quint",
 	"description": "Language support for Quint specifications",
-	"version": "0.9.1",
+	"version": "0.10.0",
 	"publisher": "informal",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vscode/quint-vscode/server/package-lock.json
+++ b/vscode/quint-vscode/server/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@informalsystems/quint-language-server",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint-language-server",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache 2.0",
       "dependencies": {
-        "@informalsystems/quint": "^0.14.4",
+        "@informalsystems/quint": "^0.15.0",
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-uri": "^3.0.7"
@@ -476,9 +476,9 @@
       "dev": true
     },
     "node_modules/@informalsystems/quint": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.14.4.tgz",
-      "integrity": "sha512-RzoQ5BgJ++DneD0jmkEsWNlE39MCSw/HnaZxAWeNfGy0QkpNZ1AYhSwrBf3BPa9UBWJCF5aIvJPsNKkAT64TYg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.15.0.tgz",
+      "integrity": "sha512-TT+4avsaJRrQYSAU8ijGM7MklUaXnQKAehHQZ95PeLhYuBTFIY7MBEF6/0DoSZNMT3G9mm7t8z2PkidebxeZuw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.8.14",
         "@grpc/proto-loader": "^0.7.7",
@@ -7207,9 +7207,9 @@
       "dev": true
     },
     "@informalsystems/quint": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.14.4.tgz",
-      "integrity": "sha512-RzoQ5BgJ++DneD0jmkEsWNlE39MCSw/HnaZxAWeNfGy0QkpNZ1AYhSwrBf3BPa9UBWJCF5aIvJPsNKkAT64TYg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.15.0.tgz",
+      "integrity": "sha512-TT+4avsaJRrQYSAU8ijGM7MklUaXnQKAehHQZ95PeLhYuBTFIY7MBEF6/0DoSZNMT3G9mm7t8z2PkidebxeZuw==",
       "requires": {
         "@grpc/grpc-js": "^1.8.14",
         "@grpc/proto-loader": "^0.7.7",

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@informalsystems/quint-language-server",
   "description": "Language Server for the Quint specification language",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": "Informal Systems",
   "contributors": [
     {
@@ -43,7 +43,7 @@
     "test/**/*.ts"
   ],
   "dependencies": {
-    "@informalsystems/quint": "^0.14.4",
+    "@informalsystems/quint": "^0.15.0",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-uri": "^3.0.7"


### PR DESCRIPTION
## v0.10.0 -- 2023-11-08

### Added
### Changed

- Error reporting was changed to show more errors at a time, instead of having a lot of phases (#1220)

### Deprecated
### Removed
### Fixed

- The language server should no longer crash when there is a crash on quint
  functions (#1205)
- Fixed a problem where errors in one file were being reported in other files
  related to it (#1224).

### Security

