### PR TITLE
Add support for sum types in the simulator

### DIFF
--- a/examples/language-features/option.qnt
+++ b/examples/language-features/option.qnt
@@ -1,8 +1,7 @@
 module option {
-  // a demonstration of discriminated unions, specifying an option type.
+  // A demonstration of sum types, specifying an option type.
 
   // An option type for values.
-  // This type declaration is not required. It only defines an alias.
   type Vote_option =
     | None
     | Some(int)

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -622,7 +622,7 @@ export async function verifySpec(prev: TypecheckedStage): Promise<CLIProcedure<V
   }
 
   verifying.table = resolutionResult.table
-  extraDefs.forEach(def => analyzeInc(verifying, verifying.table, def))
+  analyzeInc(verifying, verifying.table, extraDefs)
 
   // Flatten modules, replacing instances, imports and exports with their definitions
   const { flattenedModules, flattenedTable, flattenedAnalysis } = flattenModules(

--- a/quint/src/graphics.ts
+++ b/quint/src/graphics.ts
@@ -101,6 +101,20 @@ export function prettyQuintEx(ex: QuintEx): Doc {
           return nary(text('{'), kvs, text('}'), line())
         }
 
+        case 'variant': {
+          const labelExpr = ex.args[0]
+          assert(labelExpr.kind === 'str', 'malformed variant operator')
+          const label = richtext(chalk.green, labelExpr.value)
+
+          const valueExpr = ex.args[1]
+          const value =
+            valueExpr.kind === 'app' && valueExpr.opcode === 'Rec' && valueExpr.args.length === 0
+              ? [] // A payload with the empty record is shown as a bare label
+              : [text('('), prettyQuintEx(valueExpr), text(')')]
+
+          return group([label, ...value])
+        }
+
         default:
           // instead of throwing, show it in red
           return richtext(chalk.red, `unsupported operator: ${ex.opcode}(...)`)

--- a/quint/src/quintAnalyzer.ts
+++ b/quint/src/quintAnalyzer.ts
@@ -60,7 +60,7 @@ export function analyzeInc(
   declarations: QuintDeclaration[]
 ): AnalysisResult {
   const analyzer = new QuintAnalyzer(lookupTable, analysisOutput)
-  analyzer.analyzeDeclaration(declarations)
+  analyzer.analyzeDeclarations(declarations)
   return analyzer.getResult()
 }
 
@@ -94,11 +94,7 @@ class QuintAnalyzer {
     this.analyzeDeclarations(module.declarations)
   }
 
-  analyzeDeclaration(decl: QuintDeclaration[]): void {
-    this.analyzeDeclarations(decl)
-  }
-
-  private analyzeDeclarations(decls: QuintDeclaration[]): void {
+  analyzeDeclarations(decls: QuintDeclaration[]): void {
     const [typeErrMap, types] = this.typeInferrer.inferTypes(decls)
     const [effectErrMap, effects] = this.effectInferrer.inferEffects(decls)
     const updatesErrMap = this.multipleUpdatesChecker.checkEffects([...effects.values()])

--- a/quint/src/quintAnalyzer.ts
+++ b/quint/src/quintAnalyzer.ts
@@ -57,10 +57,10 @@ export function analyzeModules(lookupTable: LookupTable, quintModules: QuintModu
 export function analyzeInc(
   analysisOutput: AnalysisOutput,
   lookupTable: LookupTable,
-  declaration: QuintDeclaration
+  declarations: QuintDeclaration[]
 ): AnalysisResult {
   const analyzer = new QuintAnalyzer(lookupTable, analysisOutput)
-  analyzer.analyzeDeclaration(declaration)
+  analyzer.analyzeDeclaration(declarations)
   return analyzer.getResult()
 }
 
@@ -94,8 +94,8 @@ class QuintAnalyzer {
     this.analyzeDeclarations(module.declarations)
   }
 
-  analyzeDeclaration(decl: QuintDeclaration): void {
-    this.analyzeDeclarations([decl])
+  analyzeDeclaration(decl: QuintDeclaration[]): void {
+    this.analyzeDeclarations(decl)
   }
 
   private analyzeDeclarations(decls: QuintDeclaration[]): void {

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -582,7 +582,7 @@ function tryEval(out: writer, state: ReplState, newInput: string): boolean {
   }
   if (parseResult.kind === 'declaration') {
     // compile the module and add it to history if everything worked
-    const context = compileDecl(state.compilationState, state.evaluationState, state.rng, parseResult.decl)
+    const context = compileDecl(state.compilationState, state.evaluationState, state.rng, parseResult.decls)
 
     if (
       context.evaluationState.context.size === 0 ||

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -20,7 +20,7 @@ import { FlatModule, QuintDef, QuintEx } from './ir/quintIr'
 import {
   CompilationContext,
   CompilationState,
-  compileDecl,
+  compileDecls,
   compileExpr,
   compileFromCode,
   contextNameLookup,
@@ -582,7 +582,7 @@ function tryEval(out: writer, state: ReplState, newInput: string): boolean {
   }
   if (parseResult.kind === 'declaration') {
     // compile the module and add it to history if everything worked
-    const context = compileDecl(state.compilationState, state.evaluationState, state.rng, parseResult.decls)
+    const context = compileDecls(state.compilationState, state.evaluationState, state.rng, parseResult.decls)
 
     if (
       context.evaluationState.context.size === 0 ||

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -184,7 +184,7 @@ export function compileExpr(
   // Hence, we have to compile it via an auxilliary definition.
   const def: QuintDef = { kind: 'def', qualifier: 'action', name: inputDefName, expr, id: state.idGen.nextId() }
 
-  return compileDecl(state, evaluationState, rng, def)
+  return compileDecl(state, evaluationState, rng, [def])
 }
 
 /**
@@ -195,7 +195,7 @@ export function compileExpr(
  * @param state - The current compilation state
  * @param evaluationState - The current evaluation state
  * @param rng - The random number generator
- * @param decl - The Quint declaration to be compiled
+ * @param decls - The Quint declarations to be compiled
  *
  * @returns A compilation context with the compiled definition or its errors
  */
@@ -203,7 +203,7 @@ export function compileDecl(
   state: CompilationState,
   evaluationState: EvaluationState,
   rng: Rng,
-  decl: QuintDeclaration
+  decls: QuintDeclaration[]
 ): CompilationContext {
   if (state.originalModules.length === 0 || state.modules.length === 0) {
     throw new Error('No modules in state')
@@ -213,7 +213,7 @@ export function compileDecl(
   // ensuring the original object is not modified
   const originalModules = state.originalModules.map(m => {
     if (m.name === state.mainName) {
-      return { ...m, declarations: [...m.declarations, decl] }
+      return { ...m, declarations: [...m.declarations, ...decls] }
     }
     return m
   })
@@ -233,7 +233,7 @@ export function compileDecl(
     return errorContextFromMessage(evaluationState.listener)({ errors, sourceMap: state.sourceMap })
   }
 
-  const [analysisErrors, analysisOutput] = analyzeInc(state.analysisOutput, table, decl)
+  const [analysisErrors, analysisOutput] = analyzeInc(state.analysisOutput, table, decls)
 
   const {
     flattenedModules: flatModules,

--- a/quint/src/runtime/compile.ts
+++ b/quint/src/runtime/compile.ts
@@ -184,7 +184,7 @@ export function compileExpr(
   // Hence, we have to compile it via an auxilliary definition.
   const def: QuintDef = { kind: 'def', qualifier: 'action', name: inputDefName, expr, id: state.idGen.nextId() }
 
-  return compileDecl(state, evaluationState, rng, [def])
+  return compileDecls(state, evaluationState, rng, [def])
 }
 
 /**
@@ -199,7 +199,7 @@ export function compileExpr(
  *
  * @returns A compilation context with the compiled definition or its errors
  */
-export function compileDecl(
+export function compileDecls(
   state: CompilationState,
   evaluationState: EvaluationState,
   rng: Rng,

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -696,6 +696,14 @@ export class CompilerVisitor implements IRVisitor {
           })
           break
 
+        case 'variant':
+          // Construct a variant of a sum type.
+          this.applyFun(app.id, 2, (labelName, value) => just(rv.mkVariant(labelName.toStr(), value)))
+          break
+
+        case 'matchVariant':
+          assert(false, 'TODO: https://github.com/informalsystems/quint/issues/1033')
+
         case 'Set':
           // Construct a set from an array of values.
           this.applyFun(app.id, app.args.length, (...values: RuntimeValue[]) => just(rv.mkSet(values)))
@@ -930,8 +938,6 @@ export class CompilerVisitor implements IRVisitor {
           break
 
         // builtin operators that are not handled by REPL
-        case 'variant': // TODO: https://github.com/informalsystems/quint/issues/1033
-        case 'matchVariant': // TODO: https://github.com/informalsystems/quint/issues/1033
         case 'orKeep':
         case 'mustChange':
         case 'weakFair':

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -38,9 +38,6 @@ import { ErrorCode, QuintError } from '../../quintError'
 import { inputDefName, lastTraceName } from '../compile'
 import { unreachable } from '../../util'
 import { chunk } from 'lodash'
-import { prettyQuintEx } from '../../graphics'
-import { expressionToString } from '../../ir/IRprinting'
-import { newIdGenerator } from '../../idGenerator'
 
 // Internal names in the compiler, which have special treatment.
 // For some reason, if we replace 'q::input' with inputDefName, everything breaks.

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -32,11 +32,15 @@ import { ExecutionListener } from '../trace'
 
 import * as ir from '../../ir/quintIr'
 
-import { RuntimeValue, rv } from './runtimeValue'
+import { RuntimeValue, RuntimeValueLambda, RuntimeValueVariant, rv } from './runtimeValue'
 import { ErrorCode, QuintError } from '../../quintError'
 
 import { inputDefName, lastTraceName } from '../compile'
 import { unreachable } from '../../util'
+import { chunk } from 'lodash'
+import { prettyQuintEx } from '../../graphics'
+import { expressionToString } from '../../ir/IRprinting'
+import { newIdGenerator } from '../../idGenerator'
 
 // Internal names in the compiler, which have special treatment.
 // For some reason, if we replace 'q::input' with inputDefName, everything breaks.
@@ -702,7 +706,34 @@ export class CompilerVisitor implements IRVisitor {
           break
 
         case 'matchVariant':
-          assert(false, 'TODO: https://github.com/informalsystems/quint/issues/1033')
+          this.applyFun(app.id, app.args.length, (variantExpr, ...cases) => {
+            // Type checking ensures that this is a variant expression
+            assert(variantExpr instanceof RuntimeValueVariant, 'invalid value in match expression')
+            const label = variantExpr.label
+            const value = variantExpr.value
+
+            // Find the eliminator marked with the variant's label
+            let result: Maybe<RuntimeValue> | undefined
+            for (const [caseLabel, caseElim] of chunk(cases, 2)) {
+              const caseLabelStr = caseLabel.toStr()
+              if (caseLabelStr === '_') {
+                // The wilcard case ignores the value.
+                // NOTE: This SHOULD be a nullary lambda, but by this point the compiler
+                // has already converted it into a value. Confusing!
+                result = just(caseElim as RuntimeValueLambda)
+              } else if (caseLabelStr === label) {
+                // Type checking ensures the second item of each case is a lambda
+                const eliminator = caseElim as RuntimeValueLambda
+                result = eliminator.eval([just(value)]).map(r => r as RuntimeValue)
+                break
+              }
+            }
+            // Type checking ensures we have cases for every possible variant of a sum type.
+            assert(result, 'non-exhaustive match expression')
+
+            return result
+          })
+          break
 
         case 'Set':
           // Construct a set from an array of values.

--- a/quint/src/runtime/impl/runtimeValue.ts
+++ b/quint/src/runtime/impl/runtimeValue.ts
@@ -825,7 +825,7 @@ class RuntimeValueRecord extends RuntimeValueBase implements RuntimeValue {
   }
 }
 
-class RuntimeValueVariant extends RuntimeValueBase implements RuntimeValue {
+export class RuntimeValueVariant extends RuntimeValueBase implements RuntimeValue {
   label: string
   value: RuntimeValue
 
@@ -1527,7 +1527,7 @@ class RuntimeValueInfSet extends RuntimeValueBase implements RuntimeValue {
  *
  * RuntimeValueLambda cannot be compared with other values.
  */
-class RuntimeValueLambda extends RuntimeValueBase implements RuntimeValue, Callable {
+export class RuntimeValueLambda extends RuntimeValueBase implements RuntimeValue, Callable {
   nparams: number
   callable: Callable
 

--- a/quint/src/runtime/impl/runtimeValue.ts
+++ b/quint/src/runtime/impl/runtimeValue.ts
@@ -138,6 +138,16 @@ export const rv = {
   },
 
   /**
+   * Make a runtime value that represents a variant value of a sum type.
+   *
+   * @param label a string reperenting the variant's label
+   * @param value the value held by the variant
+   * @return a new runtime value that represents the variant
+   */
+  mkVariant: (label: string, value: RuntimeValue): RuntimeValue => {
+    return new RuntimeValueVariant(label, value)
+  },
+  /**
    * Make a runtime value that represents a map.
    *
    * @param value an iterable collection of pairs of runtime values
@@ -582,6 +592,10 @@ abstract class RuntimeValueBase implements RuntimeValue {
     if (this instanceof RuntimeValueRecord && other instanceof RuntimeValueRecord) {
       return this.map.equals(other.map)
     }
+    if (this instanceof RuntimeValueVariant && other instanceof RuntimeValueVariant) {
+      return this.label === other.label && this.value.equals(other.value)
+    }
+
     if (this instanceof RuntimeValueSet && other instanceof RuntimeValueSet) {
       return immutableIs(this.set, other.set)
     }
@@ -811,6 +825,29 @@ class RuntimeValueRecord extends RuntimeValueBase implements RuntimeValue {
   }
 }
 
+class RuntimeValueVariant extends RuntimeValueBase implements RuntimeValue {
+  label: string
+  value: RuntimeValue
+
+  constructor(label: string, value: RuntimeValue) {
+    super(false) // Not a "set-like" value
+    this.label = label
+    this.value = value
+  }
+
+  hashCode() {
+    return hash(this.value) + this.value.hashCode()
+  }
+
+  toQuintEx(gen: IdGenerator): QuintEx {
+    return {
+      id: gen.nextId(),
+      kind: 'app',
+      opcode: 'variant',
+      args: [{ id: gen.nextId(), kind: 'str', value: this.label }, this.value.toQuintEx(gen)],
+    }
+  }
+}
 /**
  * A set of runtime values represented via an immutable Map.
  * This is an internal class.

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -848,6 +848,18 @@ describe('compiling specs to runtime values', () => {
       assertResultAsString('Some(40 + 2)', 'variant("Some", 42)', context)
       assertResultAsString('None', 'variant("None", Rec())', context)
     })
+
+    it('can compile elimination of sum type variants via match', () => {
+      const context = 'type T = Some(int) | None'
+      assertResultAsString('match Some(40 + 2) { Some(x) => x | None => 0 }', '42', context)
+      assertResultAsString('match None { Some(x) => x | None => 0 }', '0', context)
+    })
+
+    it('can compile elimination of sum type variants via match using default', () => {
+      const context = 'type T = Some(int) | None'
+      // We can hit the fallback case
+      assertResultAsString('match None { Some(x) => x | _ => 3 }', '3', context)
+    })
   })
 
   describe('compile over maps', () => {

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -9,7 +9,7 @@ import {
   CompilationContext,
   CompilationState,
   compile,
-  compileDecl,
+  compileDecls,
   compileExpr,
   compileFromCode,
   contextNameLookup,
@@ -1076,7 +1076,7 @@ describe('incremental compilation', () => {
         compilationState.sourceMap
       )
       const defs = parsed.kind === 'declaration' ? parsed.decls : undefined
-      const context = compileDecl(compilationState, evaluationState, dummyRng, defs!)
+      const context = compileDecls(compilationState, evaluationState, dummyRng, defs!)
 
       assert.deepEqual(context.compilationState.analysisOutput.types.get(defs![0].id)?.type, { kind: 'int', id: 3n })
 
@@ -1097,7 +1097,7 @@ describe('incremental compilation', () => {
         compilationState.sourceMap
       )
       const decls = parsed.kind === 'declaration' ? parsed.decls : []
-      const context = compileDecl(compilationState, evaluationState, dummyRng, decls)
+      const context = compileDecls(compilationState, evaluationState, dummyRng, decls)
 
       assert.sameDeepMembers(context.syntaxErrors, [
         {
@@ -1118,7 +1118,7 @@ describe('incremental compilation', () => {
         compilationState.sourceMap
       )
       const decls = parsed.kind === 'declaration' ? parsed.decls : []
-      const context = compileDecl(compilationState, evaluationState, dummyRng, decls)
+      const context = compileDecls(compilationState, evaluationState, dummyRng, decls)
 
       const typeDecl = decls[0]
       assert(typeDecl.kind === 'typedef')
@@ -1137,7 +1137,7 @@ describe('incremental compilation', () => {
         compilationState.sourceMap
       )
       const decls = parsed.kind === 'declaration' ? parsed.decls : []
-      const context = compileDecl(compilationState, evaluationState, dummyRng, decls)
+      const context = compileDecls(compilationState, evaluationState, dummyRng, decls)
 
       assert(decls.find(t => t.kind === 'typedef' && t.name === 'T'))
       // Sum type declarations are expanded to add an

--- a/quint/test/runtime/compile.test.ts
+++ b/quint/test/runtime/compile.test.ts
@@ -4,7 +4,7 @@ import { Either, left, right } from '@sweet-monads/either'
 import { just } from '@sweet-monads/maybe'
 import { expressionToString } from '../../src/ir/IRprinting'
 import { Computable, ComputableKind, fail, kindName } from '../../src/runtime/runtime'
-import { newTraceRecorder, noExecutionListener } from '../../src/runtime/trace'
+import { noExecutionListener } from '../../src/runtime/trace'
 import {
   CompilationContext,
   CompilationState,
@@ -14,7 +14,6 @@ import {
   compileFromCode,
   contextNameLookup,
   inputDefName,
-  newCompilationState,
 } from '../../src/runtime/compile'
 import { RuntimeValue } from '../../src/runtime/impl/runtimeValue'
 import { dedent } from '../textUtils'


### PR DESCRIPTION
Closes #1033

Adds support for sum types to the compiler (and so the simulator):

- Generalizes the REPL so it can compile all the declarations parsed out of its
  input, instead of just the last one (required to enable sum type declarations
  to be entered in the REPL).
- Adds graphics for pretty printing variants.
- Adds evaluation of constructors, requiring a new runtime value to represent
  variants.
- Adds evaluation of match expressions, which eliminate variants.

The history is clean enough that it would probably help to review by commit.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->