### PR TITLE
Add publishing instruction for the language server npm package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,6 +304,6 @@ executable and the VSCode plugin.
     - Navigate to
       https://marketplace.visualstudio.com/manage/publishers/informal, and click
       the `...` visible when hovering over `Quint` to upload the archive.
-- `cd` into the `server folder` and run `npm publish` for publication of the
-  `@informalsystems/quint-language-server` package (used in Emacs and Neovim
-  integrations).
+- `cd` into the `server` folder and run `npm publish` for publication of the
+  [@informalsystems/quint-language-server](https://www.npmjs.com/package/@informalsystems/quint-language-server)
+  package (used in Emacs and Vim integrations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,3 +304,6 @@ executable and the VSCode plugin.
     - Navigate to
       https://marketplace.visualstudio.com/manage/publishers/informal, and click
       the `...` visible when hovering over `Quint` to upload the archive.
+- `cd` into the `server folder` and run `npm publish` for publication of the
+  `@informalsystems/quint-language-server` package (used in Emacs and Neovim
+  integrations).


### PR DESCRIPTION
Hello :octocat: 

This adds a instruction to "manually" publish the [@informalsystems/quint-language-server](https://www.npmjs.com/package/@informalsystems/quint-language-server) package after publishing the VSCode plugin. We should include this in the script at some point.

P.S. I ran this for `v0.11.0` already, it is all good.
