### PR TITLE
Fix line length lints

### DIFF
--- a/quint/src/parsing/ToIrListener.ts
+++ b/quint/src/parsing/ToIrListener.ts
@@ -1000,7 +1000,10 @@ export class ToIrListener implements QuintListener {
     const elimId = this.getId(caseCtx)
     const variantMatch = caseCtx._variantMatch
 
-    // If there is not a variant param, then we have a wildcard case, `_ => foo`, or a hole in the paramater position, `Foo(_) => bar`
+    // If there is not a variant param, then we have one of two things
+    //
+    // - a wildcard case, `_ => foo`
+    // - a hole in the paramater position, `Foo(_) => bar`
     const name = variantMatch && variantMatch._variantParam ? variantMatch._variantParam.text : '_'
     const params = [{ name, id: this.getId(caseCtx) }]
 

--- a/quint/src/types/specialConstraints.ts
+++ b/quint/src/types/specialConstraints.ts
@@ -287,7 +287,7 @@ export function matchConstraints(
             elimExpr
           )}. Only one wildcard can appear and it must be the final case of a match.`
         )
-      : validatedFields.push(right([labelExpr.value, elimType.args[0]])) // The label and associated type of a variant case
+      : validatedFields.push(right([labelExpr.value, elimType.args[0]])) // label and associated type of a variant case
   }
 
   // TODO: Support more expressive and informative type errors.


### PR DESCRIPTION
This was causing noise in PR review changesets due to
linter warnings.

-------

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->