### PR TITLE
fix: reset trace recorder at beginning of each test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Produce proper error messages on invalid module name (#1260)
+- Fix JSON output when running multiple tests (#1264)
 
 ### Security
 

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -1038,3 +1038,20 @@ quint test --main=invalid ./testFixture/_1050diffName.qnt
 error: [QNT405] Main module invalid not found
 error: Tests failed
 ```
+
+### Multiple tests output different json
+
+See [#1264](https://github.com/informalsystems/quint/pull/1264).
+
+<!-- !test in multiple jsons -->
+```
+quint test --output {}.itf.json ./testFixture/_1051manyTests.qnt >/dev/null
+cat firstTest.itf.json secondTest.itf.json | jq -c .states
+rm firstTest.itf.json secondTest.itf.json
+```
+
+<!-- !test out multiple jsons -->
+```
+[{"#meta":{"index":0},"x":{"#bigint":"0"}},{"#meta":{"index":1},"x":{"#bigint":"1"}}]
+[{"#meta":{"index":0},"x":{"#bigint":"0"}},{"#meta":{"index":1},"x":{"#bigint":"2"}}]
+```

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -116,6 +116,7 @@ export function compileAndTest(
   return mergeInMany(
     testDefs.map((def, index) => {
       return getComputableForDef(ctx, def).map(comp => {
+        recorder.clear();
         const name = def.name
         // save the initial seed
         let seed = options.rng.getState()

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -116,7 +116,7 @@ export function compileAndTest(
   return mergeInMany(
     testDefs.map((def, index) => {
       return getComputableForDef(ctx, def).map(comp => {
-        recorder.clear();
+        recorder.clear()
         const name = def.name
         // save the initial seed
         let seed = options.rng.getState()

--- a/quint/testFixture/_1051manyTests.qnt
+++ b/quint/testFixture/_1051manyTests.qnt
@@ -1,0 +1,7 @@
+module manyTests {
+  var x: int
+  action init = x' = 0
+
+  run firstTest = init.then(x' = 1).then(all { assert(x == 1), x' = x })
+  run secondTest = init.then(x' = 2).then(all { assert(x == 2), x' = x })
+}


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

Closes #1263

Taking the example from the issue,

```bluespec
module manyTests {
  var x: int
  action init = x' = 0

  run firstTest = init.then(x' = 1).then(all { assert(x == 1), x' = x })
  run secondTest = init.then(x' = 2).then(all { assert(x == 2), x' = x })
}
```

After compiling `quint` with the change from this PR, the saved traces correspond to each test case.

```sh
$ quint test --output {}.itf.json manyTests.qnt
  manyTests
    ok firstTest passed 1 test(s)
    ok secondTest passed 1 test(s)

  2 passing (9ms)
$ cat *.itf.json | jq -c .states
[{"#meta":{"index":0},"x":{"#bigint":"0"}},{"#meta":{"index":1},"x":{"#bigint":"1"}}]
[{"#meta":{"index":0},"x":{"#bigint":"0"}},{"#meta":{"index":1},"x":{"#bigint":"2"}}]
```

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
