### PR TITLE
introduce type fences in runtime values

### DIFF
--- a/quint/src/runtime/impl/runtimeValue.ts
+++ b/quint/src/runtime/impl/runtimeValue.ts
@@ -488,19 +488,23 @@ abstract class RuntimeValueBase implements RuntimeValue {
   }
 
   toSet(): Set<RuntimeValue> {
-    // the default transformation to a set is done via iteration
-    let set = Set.of<RuntimeValue>()
-    for (const e of this) {
-      set = set.add(e.normalForm())
+    if (this.isSetLike) {
+      // the default transformation to a set is done via iteration
+      let set = Set.of<RuntimeValue>()
+      for (const e of this) {
+        set = set.add(e.normalForm())
+      }
+      return set
+    } else {
+      throw new Error('Expected a set-like value')
     }
-    return set
   }
 
   toList(): List<RuntimeValue> {
     if (this instanceof RuntimeValueTupleOrList) {
       return this.list
     } else {
-      return List()
+      throw new Error('Expected a list value')
     }
   }
 
@@ -508,7 +512,7 @@ abstract class RuntimeValueBase implements RuntimeValue {
     if (this instanceof RuntimeValueRecord) {
       return this.map
     } else {
-      return OrderedMap()
+      throw new Error('Expected a record value')
     }
   }
 
@@ -516,7 +520,7 @@ abstract class RuntimeValueBase implements RuntimeValue {
     if (this instanceof RuntimeValueMap) {
       return this.map
     } else {
-      return Map()
+      throw new Error('Expected a map value')
     }
   }
 
@@ -524,7 +528,7 @@ abstract class RuntimeValueBase implements RuntimeValue {
     if (this instanceof RuntimeValueBool) {
       return (this as RuntimeValueBool).value
     } else {
-      return false
+      throw new Error('Expected a Boolean value')
     }
   }
 
@@ -532,7 +536,7 @@ abstract class RuntimeValueBase implements RuntimeValue {
     if (this instanceof RuntimeValueInt) {
       return (this as RuntimeValueInt).value
     } else {
-      return 0n
+      throw new Error('Expected an integer value')
     }
   }
 
@@ -540,7 +544,7 @@ abstract class RuntimeValueBase implements RuntimeValue {
     if (this instanceof RuntimeValueStr) {
       return (this as RuntimeValueStr).value
     } else {
-      return ''
+      throw new Error('Expected a string value')
     }
   }
 

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -148,7 +148,11 @@ describe('repl ok', () => {
       |^^^^^^^^^
       |
       |
-      |1
+      |runtime error: error: [QNT501] Expected an integer value
+      |1 + false
+      |^^^^^^^^^
+      |
+      |<undefined value>
       |>>> `
     )
     await assertRepl(input, output)


### PR DESCRIPTION
Following [this discussion](https://github.com/informalsystems/quint/pull/1304#discussion_r1425177604), here are defensive checks in runtime values, so we don't have to test for exact type in the compiler code. Interestingly, one of the tests has triggered an exception, since REPL passes through type-incorrect expressions. (We should disable that at some point).

- [x] Tests added for any new code
