### PR TITLE
Improve runtime errors in the simulator

### DIFF
--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -20,7 +20,6 @@ import { SourceLookupPath } from './parsing/sourceResolver'
 import { QuintError } from './quintError'
 import { mkErrorMessage } from './cliCommands'
 import { createFinders, formatError } from './errorReporter'
-import { uniqBy } from 'lodash'
 
 /**
  * Various settings that have to be passed to the simulator to run.

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -134,6 +134,7 @@ export function compileAndRun(
 
     let errors = ctx.getRuntimeErrors()
     if (errors.length > 0) {
+      // FIXME(#1052) we shouldn't need to do this if the error id was not some non-sense generated in `compileFromCode`
       const code = new Map([...ctx.compilationState.sourceCode.entries(), [mainPath.normalizedPath, codeWithExtraDefs]])
       const finders = createFinders(code)
       errors = errors.map(error => ({
@@ -143,6 +144,7 @@ export function compileAndRun(
           explanation: error.message,
         }),
       }))
+
       status = 'error'
     }
 


### PR DESCRIPTION
Hello :octocat: 

This is a followup to https://github.com/informalsystems/quint/pull/1340 since I found a (hacky) way to include locations in the reported errors. We should remove this when #1052 is fixed and errors can be reported normally. The reason for this is that it is very hard to find where runtime errors could potentially happen in a big spec, and having the location info makes all the difference.

For this, we compute the locs for the error while we still have access to the `compileFromCode` inputs and outputs, and then manipulate the `QuintError` to include those locs in a hacky way:
1. We remove the (optional) `reference` field, so no locs are included in the final error - since those would be messed up anyaway
2. We then include the locs as text + highlights in the error message, reconstructing a `QuintError` with a pre-formatted message in it's message field.

I added a lot of comments so this is not super shady when we come back to it. The end result (what users see) looks perfectly normal :ninja: 


<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
