### PR TITLE
Remove erroneous occurs check from "effect entity" unfication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Erroneous effect checking failure resulting from invalid occurs check. This
+  error prevented some valid specs from being simulated or verified (#1359).
+
 ### Security
 
 ## v0.18.2 -- 2024-01-26

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -255,12 +255,12 @@ export function mkErrorMessage(sourceMap: SourceMap): (_: QuintError) => ErrorMe
  */
 export async function typecheck(parsed: ParsedStage): Promise<CLIProcedure<TypecheckedStage>> {
   const { table, modules, sourceMap } = parsed
-  const typechecking = { ...parsed, stage: 'typechecking' as stage }
 
   const [errorMap, result] = analyzeModules(table, modules)
 
+  const typechecking = { ...parsed, ...result, stage: 'typechecking' as stage }
   if (errorMap.length === 0) {
-    return right({ ...typechecking, ...result })
+    return right(typechecking)
   } else {
     const errors = errorMap.map(mkErrorMessage(sourceMap))
     return cliErr('typechecking failed', { ...typechecking, errors })

--- a/quint/src/effects/base.ts
+++ b/quint/src/effects/base.ts
@@ -81,11 +81,11 @@ export interface StateVariable {
  * entity variable or a combination of other entities.
  */
 export type Entity =
-  /* A list of state variables */
+  /* A set of state variables, represented as a list */
   | { kind: 'concrete'; stateVariables: StateVariable[] }
-  /* A variable representing some entity */
+  /* A variable representing some set of entities */
   | { kind: 'variable'; name: string; reference?: bigint }
-  /* A combination of entities */
+  /* The union of sets of entities, represented as a list */
   | { kind: 'union'; entities: Entity[] }
 
 /*
@@ -177,23 +177,35 @@ function bindEffect(name: string, effect: Effect): Either<string, Substitutions>
   }
 }
 
-function bindEntity(name: string, entity: Entity): Either<string, Substitutions> {
+function bindEntity(name: string, entity: Entity): Substitutions {
   switch (entity.kind) {
     case 'concrete':
     case 'variable':
-      return right([{ kind: 'entity', name, value: entity }])
+      return [{ kind: 'entity', name, value: entity }]
     case 'union':
       if (entityNames(entity).includes(name)) {
         // An entity variable (which always stands for a set of state variables)
-        // unifies with the union of entities that may include  include itself,
-        // iff the variables unify.
+        // unifies with the union of n sets of entities that may include itself,
+        // iff it unifies with each set.
         //
         // I.e.:
         //
         //   (v1 =.= v1 ∪ ... ∪ vn) <=> (v1 =.= ... =.= vn)
-        return right(entity.entities.map(e => ({ kind: 'entity', name, value: e })))
+        //
+        // We call this function recursively because, in the general case,
+        // occurrences of `v1` may be nested, as in:
+        //
+        //    v1 =.= v1 ∪ (v2 ∪ (v3 ∪ v1)) ∪ v4
+        //
+        // In practice, we are flattening unions before we call this function,
+        // but solving the general case ensures we preserve correct behavior
+        // even if this function is used on its own, without incurring any
+        // notable overhead when `entities` is already flat.
+        return entity.entities.flatMap(e => bindEntity(name, e))
       } else {
-        return right([{ kind: 'entity', name, value: entity }])
+        // Otherwise, the variable may be bound to the union of the entities
+        // without qualification.
+        return [{ kind: 'entity', name, value: entity }]
       }
   }
 }
@@ -334,9 +346,9 @@ export function unifyEntities(va: Entity, vb: Entity): Either<ErrorTree, Substit
   } else if (v1.kind === 'variable' && v2.kind === 'variable' && v1.name === v2.name) {
     return right([])
   } else if (v1.kind === 'variable') {
-    return bindEntity(v1.name, v2).mapLeft(msg => buildErrorLeaf(location, msg))
+    return right(bindEntity(v1.name, v2))
   } else if (v2.kind === 'variable') {
-    return bindEntity(v2.name, v1).mapLeft(msg => buildErrorLeaf(location, msg))
+    return right(bindEntity(v2.name, v1))
   } else if (isEqual(v1, v2)) {
     return right([])
   } else if (v1.kind === 'union' && v2.kind === 'concrete') {

--- a/quint/src/effects/inferrer.ts
+++ b/quint/src/effects/inferrer.ts
@@ -37,7 +37,7 @@ import { Error, ErrorTree, buildErrorLeaf, buildErrorTree, errorTreeToString } f
 import { getSignatures, standardPropagation } from './builtinSignatures'
 import { FreshVarGenerator } from '../FreshVarGenerator'
 import { effectToString } from './printing'
-import { zip } from 'lodash'
+import { zip } from '../util'
 import { addNamespaces } from './namespaces'
 
 export type EffectInferenceResult = [Map<bigint, ErrorTree>, Map<bigint, EffectScheme>]
@@ -185,11 +185,6 @@ export class EffectInferrer implements IRVisitor {
                 effects,
                 expr.args.map(a => a.id)
               ).forEach(([effect, id]) => {
-                if (!effect || !id) {
-                  // Impossible: effects and expr.args are the same length
-                  throw new Error(`Expected ${expr.args.length} effects, but got ${effects.length}`)
-                }
-
                 const r = applySubstitution(s, effect).map(toScheme)
                 this.addToResults(id, r)
               })

--- a/quint/test/effects/base.test.ts
+++ b/quint/test/effects/base.test.ts
@@ -383,7 +383,7 @@ describe('unify', () => {
       // We should be able to form a valid substitution iff v1 =.= v2, since
       // this then simplifies to
       //
-      //   v1 =.= v1
+      //   v1 =.= v1 =.= v2
       //
       // NOTE: This test was inverted after an incorrect occurs check was
       // causing erroneous effect checking failures, as reported in

--- a/quint/test/effects/inferrer.test.ts
+++ b/quint/test/effects/inferrer.test.ts
@@ -207,6 +207,19 @@ describe('inferEffects', () => {
     assert.deepEqual(effectForDef(defs, effects, 'CoolAction'), expectedEffect)
   })
 
+  it('avoids invalid cyclical binding error (regression on #1356)', () => {
+    const defs = [
+      `pure def foo(s: int, g: int => int): int = {
+        val r = if (true) s else g(s)
+        g(r)
+      }`,
+    ]
+
+    const [errors, _] = inferEffectsForDefs(defs)
+
+    assert.isEmpty(errors, `Should find no errors, found: ${[...errors.values()].map(errorTreeToString)}`)
+  })
+
   it('returns error when operator signature is not unifiable with args', () => {
     const defs = [`def a = S.map(p => x' = p)`]
 


### PR DESCRIPTION
Closes #1356

The originating issues was caused by fairly subtle error in our unification algorithm for the effect checker, which was making an invalid occurs check. This error was hard to spot, because (I think) we are not used to thinking of unification sets! I think we usually think of unification in terms of the "geometric structure" of the syntactic terms being unified. E.g., when unifying lists, `[A, B] =.= [C, D]` iff `A =.= C, B =.= D`, and `A =.= [1, 2, A]` should fail an occurs check because it would require unifying `A` with a term that includes itself as a sub-term. However, the extensional nature of sets invalidates the "evident" geometric intuition that guides us in the previous examples. `A =.= B ∪ C ∪ A` is true iff `B =.= C =.= A`.

This is also explained in a bit more detail in comments added with this change set.

The PR also includes a regression test and some simplification of the effect inference code, introduced during the debugging process.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
