### PR TITLE
Fix ITF not being produced on successful runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Erroneous effect checking failure resulting from invalid occurs check. This
   error prevented some valid specs from being simulated or verified (#1359).
+- Regression on ITF production, where we stopped producing ITF traces on
+  successful runs (#1362)
 
 ### Security
 

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -683,6 +683,25 @@ rm out-itf-example.itf.json
 ]
 ```
 
+### Run without violation outputs ITF
+
+<!-- !test in sucessful run itf -->
+```
+quint run --out-itf=out-itf-example.itf.json --max-steps=5 --seed=123  ../examples/solidity/Coin/coin.qnt
+cat out-itf-example.itf.json | jq '.states[0]."balances"."#map"[0]'
+rm out-itf-example.itf.json
+```
+
+<!-- !test out sucessful run itf -->
+```
+[
+  "alice",
+  {
+    "#bigint": "0"
+  }
+]
+```
+
 ### Test outputs ITF
 
 TODO: output states after fix: https://github.com/informalsystems/quint/issues/288

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -549,6 +549,16 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
 
   const elapsedMs = Date.now() - startMs
 
+  if (prev.args.outItf) {
+    const trace = toItf(result.vars, result.states)
+    if (trace.isRight()) {
+      const jsonObj = addItfHeader(prev.args.input, result.outcome.status, trace.value)
+      writeToJson(prev.args.outItf, jsonObj)
+    } else {
+      return cliErr(`ITF conversion failed: ${trace.value}`, { ...simulator, errors: [] })
+    }
+  }
+
   switch (result.outcome.status) {
     case 'error':
       return cliErr('Runtime error', {
@@ -582,16 +592,6 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
 
         if (verbosity.hasHints(options.verbosity)) {
           console.log(chalk.gray('Use --verbosity=3 to show executions.'))
-        }
-      }
-
-      if (prev.args.outItf) {
-        const trace = toItf(result.vars, result.states)
-        if (trace.isRight()) {
-          const jsonObj = addItfHeader(prev.args.input, result.outcome.status, trace.value)
-          writeToJson(prev.args.outItf, jsonObj)
-        } else {
-          return cliErr(`ITF conversion failed: ${trace.value}`, { ...simulator, errors: [] })
         }
       }
 


### PR DESCRIPTION
Hello :octocat: 

@p-offtermatt just reported a problem on slack where we stopped producing ITF on successful runs - we are currently only producing them in violations. This fixes the problem and adds an integration test for this previously uncovered scenario.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
