### PR TITLE
Use same register for variables with the same id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Erroneous effect checking failure resulting from invalid occurs check. This
   error prevented some valid specs from being simulated or verified (#1359).
+- Compilation problem in some scenarios where a module with state variables is
+  imported by different paths with different namespaces (#1363)
 
 ### Security
 

--- a/examples/language-features/imports.qnt
+++ b/examples/language-features/imports.qnt
@@ -64,7 +64,6 @@ module test {
 // Qualified imports and exports
 module E {
   var x: int
-  action init = x' = 1
 
   // Export Math as a qualified name
   // to be accessed by E::Math
@@ -80,15 +79,21 @@ module F {
   export basics as ExportedBasics
 }
 
+module G {
+  import E.*
+  action init = x' = 1
+}
+
 module imports {
   import E
   import F as MyF
+  import G
 
   val test_exported1 = E::Math::pow(2, 2) == 4
   val test_exported2 = MyF::ExportedBasics::double(2) == 4
 
   action init = all {
-    E::init,
+    G::init,
     MyF::init
   }
 

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -205,7 +205,7 @@ echo "init" | quint -r ../examples/language-features/counters.qnt::counters 2>&1
 
 <!-- !test in repl loads module that is not the last -->
 ```
-echo "init" | quint -r ../examples/language-features/imports.qnt::E 2>&1 | tail -n +3
+echo "init" | quint -r ../examples/language-features/imports.qnt::G 2>&1 | tail -n +3
 ```
 
 <!-- !test out repl loads module that is not the last -->

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -365,6 +365,19 @@ export class CompilerVisitor implements IRVisitor {
       return
     }
 
+    // Also, the other way around because of flattening non-instances
+    if (this.context.has(kindName('var', vardef.id))) {
+      const register = this.context.get(kindName('var', vardef.id))!
+      this.context.set(kindName('var', varName), register)
+
+      if (this.context.has(kindName('nextvar', vardef.id))) {
+        const register = this.context.get(kindName('nextvar', vardef.id))!
+        this.context.set(kindName('nextvar', varName), register)
+      }
+
+      return
+    }
+
     // simply introduce two registers:
     //  one for the variable, and
     //  one for its next-state version


### PR DESCRIPTION
Hello :octocat: 

This fixes a problem I found recently when using multiple modules and no instances. Currently, our registers (which store values for state variables) are indexed by both the variable name and variable id. We already had some code ensuring that, if two variables have the same name (but a different id), they'd have the same register - this is important for instances, and flattening ensures that no two different state variables can have the same name.

Now, I'm adding a very similar piece of code to ensure variables with the same id get the same register, even if they have different names. This part is important for imports, since qualified imports can make it so the same variable is referred by different names.

I'm not confident this will work for all combinations of imports and instances, but it definitely covers more ground than what we currently have.

For testing, I just updated the existing `imports.qnt` example to have the complexity needed to hit the problem (fixed by this).

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
