### PR TITLE
Add functions to fold and map types

### DIFF
--- a/quint/src/ir/base.ts
+++ b/quint/src/ir/base.ts
@@ -1,0 +1,139 @@
+/* ----------------------------------------------------------------------------------
+ * Copyright 2022 Informal Systems
+ * Licensed under the Apache License, Version 2.0.
+ * See LICENSE in the project root for license information.
+ * --------------------------------------------------------------------------------- */
+
+import assert, { fail } from 'assert'
+import { ConcreteRow, QuintType, Row } from './quintTypes'
+
+/**
+ * Core utilities for manipulating the Quint IR
+ *
+ * @author Shon Feder
+ *
+ * @module
+ */
+
+export function foldRow<T>(f: (acc: T, x: Row) => T, init: T, r: Row): T {
+  switch (r.kind) {
+    case 'var':
+    case 'empty':
+      return f(init, r)
+
+    case 'row':
+      const otherAcc = foldRow(f, init, r.other)
+      return f(otherAcc, r)
+  }
+}
+
+export function mapRow(f: (x: Row) => Row, row: Row): Row {
+  const map = (r: Row) => {
+    switch (r.kind) {
+      case 'var':
+      case 'empty':
+        return f(r)
+
+      case 'row':
+        const other = foldRow(f, r.other, r.other)
+        return f({ ...r, other })
+    }
+  }
+
+  return foldRow(map, row, row)
+}
+
+export function rowTypes(row: Row): QuintType[] {
+  const f = (acc: QuintType[], r: Row) => acc.concat(r.kind === 'row' ? r.fields.map(f => f.fieldType) : [])
+  return foldRow(f, [], row)
+}
+
+// TODO
+// This is a "right fold" thru the IR tree, meaning we do a left-biased, breadth-first traversal
+// This will visit the nodes in the same order as the parser takes when it constructs them.
+export function foldType<T>(f: (acc: T, x: QuintType) => T, init: T, q: QuintType): T {
+  switch (q.kind) {
+    case 'bool':
+    case 'int':
+    case 'str':
+    case 'const':
+    case 'var': {
+      return f(init, q)
+    }
+
+    case 'set':
+    case 'list': {
+      const elemAcc = foldType(f, init, q.elem)
+      return f(elemAcc, q)
+    }
+
+    case 'fun': {
+      const argAcc = foldType(f, init, q.arg)
+      const resAcc = foldType(f, argAcc, q.res)
+      return f(resAcc, q)
+    }
+
+    case 'oper': {
+      const argsAcc = q.args.reduce((acc, arg) => foldType(f, acc, arg), init)
+      const resAcc = foldType(f, argsAcc, q.res)
+      return f(resAcc, q)
+    }
+
+    case 'tup':
+    case 'rec':
+    case 'sum': {
+      const rowAcc = rowTypes(q.fields).reduce((acc, arg) => foldType(f, acc, arg), init)
+      return f(rowAcc, q)
+    }
+
+    case 'abs':
+    case 'app':
+      fail('abs and app are not yet finalized or fully supported')
+  }
+}
+
+const mapConcreteRowTypes = (f: (_: QuintType) => QuintType, r: ConcreteRow): ConcreteRow => ({
+  ...r,
+  fields: r.fields.map(field => ({ ...field, fieldType: mapType(f, field.fieldType) })),
+})
+
+export function mapType(f: (_: QuintType) => QuintType, q: QuintType): QuintType {
+  switch (q.kind) {
+    case 'bool':
+    case 'int':
+    case 'str':
+    case 'const':
+    case 'var': {
+      return f(q)
+    }
+
+    case 'set':
+    case 'list': {
+      return f({ ...q, elem: mapType(f, q.elem) })
+    }
+
+    case 'fun': {
+      return f({ ...q, arg: mapType(f, q.arg), res: mapType(f, q.res) })
+    }
+
+    case 'oper': {
+      return f({ ...q, args: q.args.map(a => mapType(f, a)), res: mapType(f, q.res) })
+    }
+
+    case 'tup':
+    case 'rec': {
+      const fields = q.fields.kind === 'row' ? mapConcreteRowTypes(f, q.fields) : q.fields
+      return f({ ...q, fields })
+    }
+
+    case 'sum': {
+      // We know that this map can only take concrete rows to concrete rows,
+      // so we cheat the types here.
+      return f({ ...q, fields: mapConcreteRowTypes(f, q.fields) })
+    }
+
+    case 'abs':
+    case 'app':
+      fail('abs and app are not yet finalized or fully supported')
+  }
+}

--- a/quint/src/ir/base.ts
+++ b/quint/src/ir/base.ts
@@ -48,9 +48,16 @@ export function rowTypes(row: Row): QuintType[] {
   return foldRow(f, [], row)
 }
 
-// TODO
-// This is a "right fold" thru the IR tree, meaning we do a left-biased, breadth-first traversal
-// This will visit the nodes in the same order as the parser takes when it constructs them.
+/** `foldType(f, init, t)` folds the function `f` over the quint type `t` starting
+ * with the initial value `init`
+ *
+ * @param f the function to fold with, where `acc` is the accumulator and `x` the type applied to
+ * @param init the initial value for the accumulator
+ * @param x the quint type over which to apply the fold
+ *
+ * This is a "right fold" thru the IR tree, meaning we do a depth-first, post-order traversal.
+ * This should visit the nodes in the same order as the parser takes when it constructs them.
+ */
 export function foldType<T>(f: (acc: T, x: QuintType) => T, init: T, q: QuintType): T {
   switch (q.kind) {
     case 'bool':
@@ -97,6 +104,9 @@ const mapConcreteRowTypes = (f: (_: QuintType) => QuintType, r: ConcreteRow): Co
   fields: r.fields.map(field => ({ ...field, fieldType: mapType(f, field.fieldType) })),
 })
 
+/** `mapType(f, q)` maps the function `f` over `q`
+ *
+ * This is away of transforming the type and all its sub-expression according to `f` */
 export function mapType(f: (_: QuintType) => QuintType, q: QuintType): QuintType {
   switch (q.kind) {
     case 'bool':

--- a/quint/test/ir/base.test.ts
+++ b/quint/test/ir/base.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'mocha'
+import { assert } from 'chai'
+import { foldType, mapType } from '../../src/ir/base'
+import { parseType } from '../../src/types/parser'
+import { QuintType, typeToString } from '../../src'
+
+const typeOfStr = (s: string) => parseType(s).unwrap()
+
+// A complex, nested type used in all the tests
+const type = typeOfStr('{} => {a: int, b: str, c: List[str], d: (int, Set[List[bool]])}')
+
+describe('foldType', () => {
+  it('can collect an array of all the sub-terms of a type', () => {
+    const f = (acc: QuintType[], q: QuintType) => acc.concat(q)
+    const actual = foldType(f, [], type).map(typeToString)
+    const expected: string[] = [
+      '{}',
+      'int',
+      'str',
+      'str',
+      'List[str]',
+      'int',
+      'bool',
+      'List[bool]',
+      'Set[List[bool]]',
+      '(int, Set[List[bool]])',
+      '{ a: int, b: str, c: List[str], d: (int, Set[List[bool]]) }',
+      '({}) => { a: int, b: str, c: List[str], d: (int, Set[List[bool]]) }',
+    ]
+    assert.deepEqual(actual, expected)
+  })
+
+  it('is a left-biased, depth-first traversal, matching the way IDs are generated during parsing', () => {
+    // We demonstrate this by showing that the IDs of all the sub-terms we collect
+    // are in sequential order
+    const f = (acc: number[], q: QuintType) => acc.concat(Number(q.id!))
+    const actual = foldType(f, [], type)
+    const sortedIDs = [...actual].sort((a, b) => a - b) // JS is cursed https://stackoverflow.com/a/69250874/1187277
+    assert.deepEqual(actual, sortedIDs)
+  })
+})
+
+describe('mapType', () => {
+  it('transforms all sub-terms of a type', () => {
+    const numberOfSubTerms = foldType((acc: QuintType[], q: QuintType) => acc.concat(q), [], type).length
+    const typeWithAllIdsMappedTo0 = mapType((t: QuintType): QuintType => ({ ...t, id: 0n }), type)
+    const allMappedIds = foldType((acc: bigint[], q: QuintType) => acc.concat(q.id!), [], typeWithAllIdsMappedTo0)
+
+    assert.deepEqual(numberOfSubTerms, allMappedIds.length, 'mapType should preserve all IDs')
+    assert.deepEqual(
+      allMappedIds.reduce((a, b) => a + b),
+      0n,
+      'mapType should set all IDs to zero'
+    )
+  })
+})

--- a/quint/test/ir/base.test.ts
+++ b/quint/test/ir/base.test.ts
@@ -6,7 +6,7 @@ import { QuintType, typeToString } from '../../src'
 
 const typeOfStr = (s: string) => parseType(s).unwrap()
 
-// A complex, nested type used in all the tests
+// A complex, nested type used in many of the tests
 const type = typeOfStr('{} => {a: int, b: str, c: List[str], d: (int, Set[List[bool]])}')
 
 describe('foldType', () => {
@@ -52,5 +52,16 @@ describe('mapType', () => {
       0n,
       'mapType should set all IDs to zero'
     )
+  })
+
+  it('can rename type variables', () => {
+    const appendUnderscoreToTypeVariable: (_: QuintType) => QuintType = t =>
+      t.kind === 'var' ? { ...t, name: t.name + '_' } : t
+
+    const originalType = '((a) => b, List[a]) => List[b]'
+    const actualType = typeToString(mapType(appendUnderscoreToTypeVariable, typeOfStr(originalType)))
+    const expectedType = '((a_) => b_, List[a_]) => List[b_]'
+
+    assert.deepEqual(actualType, expectedType)
   })
 })


### PR DESCRIPTION
This adds two functions that allow simpler, functional transformations and
traversals of types, when compared with the visitor-based approach we have been
using.

<!-- Please ensure that your PR includes the following, as needed -->

- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->