### PR TITLE
Fix serialization of Sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed a dependency causing deprecation errors messages to be emitted.
   (#1380)
 - Fixed a type checker bug causing too general types to be inferred (#1409).
+- Fixes serialization of Sets in JSON outputs (#1410).
 
 ### Security
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -901,7 +901,7 @@ function addItfHeader(source: string, status: string, traceInJson: any): any {
 
 // Preprocess troublesome types so they are represented in JSON.
 //
-// We need it particularly because, by default, serialization of Map
+// We need it particularly because, by default, serialization of Map and Set
 // objects just produces an empty object
 // (see https://stackoverflow.com/questions/46634449/json-stringify-of-object-of-map-return-empty)
 //
@@ -910,6 +910,9 @@ function replacer(_key: String, value: any): any {
   if (value instanceof Map) {
     // Represent Maps as JSON objects
     return Object.fromEntries(value)
+  } else if (value instanceof Set) {
+    // Represent Sets as JSON arrays
+    return Array.from(value)
   } else {
     return value
   }


### PR DESCRIPTION
Hello :octocat: 

This ensures that Sets are properly serialized in the JSON output. Needed for a follow-up PR I'll open in Apalache, where we start using the information about quantified variables in type schemes, which are represented as Sets. Related to #1398.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
