### PR TITLE
Hotfix: Handle cases where table entries or types are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
-- Fixed a bug introduced in v0.19.3 here the analyzer would crash if there were
+- Fixed a bug introduced in v0.19.3 where the analyzer would crash if there were
   some specific type errors (#1436)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a bug introduced in v0.19.3 here the analyzer would crash if there were
+  some specific type errors (#1436)
+
 ### Security
 
 ## v0.19.3 -- 2024-05-07

--- a/quint/src/effects/NondetChecker.ts
+++ b/quint/src/effects/NondetChecker.ts
@@ -49,7 +49,13 @@ export class NondetChecker implements IRVisitor {
   enterOpDef(def: QuintOpDef) {
     this.lastDefQualifier = def.qualifier
 
-    if (def.qualifier === 'nondet' && this.table.get(def.id)!.depth === 0) {
+    const entry = this.table.get(def.id)
+    if (!entry) {
+      // A name resolution error should have been reported already
+      return
+    }
+
+    if (def.qualifier === 'nondet' && entry.depth === 0) {
       this.errors.push({
         code: 'QNT206',
         message: `'nondet' can only be used inside actions, not at the top level`,
@@ -93,7 +99,12 @@ export class NondetChecker implements IRVisitor {
     }
 
     // if the opdef is nondet, the return type must be bool
-    const expressionType = this.types.get(expr.expr.id)!
+    const expressionType = this.types.get(expr.expr.id)
+    if (!expressionType) {
+      // A type error should have been reported already
+      return
+    }
+
     if (expressionType.type.kind !== 'bool') {
       this.errors.push({
         code: 'QNT205',

--- a/quint/src/effects/inferrer.ts
+++ b/quint/src/effects/inferrer.ts
@@ -56,8 +56,9 @@ export class EffectInferrer implements IRVisitor {
   }
 
   /**
-   * Infers an effect for every expression in a module based on
-   * the definitions table for that module
+   * Infers an effect for every expression in a module based on the definitions
+   * table for that module. If there are missing effects in the effect map,
+   * there will be at least one error.
    *
    * @param declarations: the list of QuintDeclarations to infer effects for
    *

--- a/quint/src/types/inferrer.ts
+++ b/quint/src/types/inferrer.ts
@@ -30,7 +30,8 @@ export class TypeInferrer extends ConstraintGeneratorVisitor {
   }
 
   /**
-   * Infers a type for each expression in a list of QuintDeclarations
+   * Infers a type for each expression in a list of QuintDeclarations. If there
+   * are missing types in the type map, there will be at least one error.
    *
    * @param declarations: the list of QuintDeclarations to infer types for
    *

--- a/quint/test/effects/NondetChecker.test.ts
+++ b/quint/test/effects/NondetChecker.test.ts
@@ -112,4 +112,21 @@ describe('checkNondets', () => {
       },
     ])
   })
+
+  it('can survive missing types and lookup table entries', () => {
+    const text = `module A {
+      var x: int
+
+      nondet top_level = Set(1,2).oneOf()
+      val non_action = { nondet bar = Set(1,2).oneOf() bar }
+    }`
+
+    const { module } = parseAndTypecheck(text)
+    const table = new Map()
+    const types = new Map()
+
+    const errors = new NondetChecker(table).checkNondets(types, module.declarations)
+
+    assert.sameDeepMembers(errors, [])
+  })
 })


### PR DESCRIPTION
Hello :octocat: 

This is a hotfix for a mistake I made in https://github.com/informalsystems/quint/pull/1431.

I thought I could assume all types were present at that point, but as those checks run in the same phase as the type checker, it can be the case that there are type errors and, therefore, missing types. This was causing the tool and the language server to crash in those scenarios, in their latest versions released after the linked PR.

We strive for accumulating as many errors as we can before giving up analysis and reporting them. So this PR tries to report nondet errors when it can (types and lookup table entries are found), and otherwise just safely skip the check since surely a type error is already in the list of errors to be reported on exit.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
