### PR TITLE
Convenience Spells

### DIFF
--- a/examples/spells/basicSpells.qnt
+++ b/examples/spells/basicSpells.qnt
@@ -75,6 +75,16 @@ module basicSpells {
     assert(Set() == Set().setRemove(3)),
   }
 
+  pure def setAdd(__set: Set[a], __elem: a): Set[a] = {
+    __set.union(Set(__elem))
+  }
+
+  run setAddTest = all{
+    assert(Set(2, 3, 4) == Set(2, 4).setAdd(3)),
+    assert(Set(3) == Set().setAdd(3)),
+    assert(Set(2,4) == Set(2,4).setAdd(4)),
+  }
+
   /// Test whether a key is present in a map
   ///
   /// - @param __map a map to query

--- a/examples/spells/commonSpells.qnt
+++ b/examples/spells/commonSpells.qnt
@@ -19,6 +19,32 @@ module commonSpells {
   }
 
 
+/// Compute the sum of the values in a list.
+   ///
+   /// - @param __list a list of integers
+   /// - @returns the sum of the elements; when the list is empty, the sum is 0.
+  pure def listSum(__list: List[int]): int = {
+    __list.foldl(0, ((__sum, __i) => __sum + __i))
+  }
+
+  run listSumTest = all {
+    assert(listSum([]) == 0),
+    assert(listSum([1,1,1,3]) == 6),
+    assert(listSum([-4, 4, 5]) == 5),
+  }
+
+  pure def listContains(__list: List[a], __elem: a): bool = 
+    __list.foldl(
+      false, 
+      (__acc, __i) => __acc or __i == __elem)
+    
+  run listContainsTest = all {
+    assert(listContains([], 1) == false),
+    assert(listContains([1, 2, 3], 1) == true),
+    assert(listContains([1, 2, 3], 4) == false),
+    assert(listContains([1, 2, 2, 2, 3], 2) == true),
+  }
+
    /// Convert a map into a set of pairs coordinating its keys and values
    ///
    /// - @param __map a map


### PR DESCRIPTION
Adding 3  convenience spells:
 - `setAdd`, to add a single element to a set
 - `listSum`, sum of all elements in a list
 - `listContains`, a boolean saying whether a list contains an element