### PR TITLE
Add command `generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- Add the operator `generate` to mirror `Apalache!Gen`.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/examples/language-features/generate.qnt
+++ b/examples/language-features/generate.qnt
@@ -1,0 +1,20 @@
+// demonstrating the use of 'generate'
+module gen {
+  var S: Set[int]
+  var T: Set[{ x: int, y: bool }]
+
+  action init = {
+    nondet iS = generate(10)
+    nondet iT = generate(20)
+    all {
+      S' = iS,
+      T' = iT,
+    }
+  }
+
+  action step =
+    all {
+      S' = S,
+      T' = T,
+    }
+}

--- a/examples/language-features/generate.qnt
+++ b/examples/language-features/generate.qnt
@@ -4,8 +4,8 @@ module gen {
   var T: Set[{ x: int, y: bool }]
 
   action init = {
-    nondet iS = generate(10, Set(Set(0)))
-    nondet iT = generate(20, Set(Set({ x: 0, y: false })))
+    nondet iS = generate(10, Set(0))
+    nondet iT = generate(20, Set({ x: 0, y: false }))
     all {
       S' = iS,
       T' = iT,

--- a/examples/language-features/generate.qnt
+++ b/examples/language-features/generate.qnt
@@ -4,8 +4,8 @@ module gen {
   var T: Set[{ x: int, y: bool }]
 
   action init = {
-    nondet iS = generate(10)
-    nondet iT = generate(20)
+    nondet iS = generate(0, 10)
+    nondet iT = generate({ x: 0, y: false }, 20)
     all {
       S' = iS,
       T' = iT,

--- a/examples/language-features/generate.qnt
+++ b/examples/language-features/generate.qnt
@@ -4,8 +4,8 @@ module gen {
   var T: Set[{ x: int, y: bool }]
 
   action init = {
-    nondet iS = generate(0, 10)
-    nondet iT = generate({ x: 0, y: false }, 20)
+    nondet iS = generate(10, Set(Set(0)))
+    nondet iT = generate(20, Set(Set({ x: 0, y: false })))
     all {
       S' = iS,
       T' = iT,

--- a/quint/cli-tests.md
+++ b/quint/cli-tests.md
@@ -184,6 +184,11 @@ This example was pointing to Paxos. Now it does not typecheck.
 <!-- !test check coin - Types & Effects-->
     quint typecheck ../examples/solidity/Coin/coin.qnt
 
+### OK on typecheck generate
+
+<!-- !test check generate - Types & Effects -->
+    quint typecheck ../examples/language-features/generate.qnt
+
 ### OK on test SimpleAuction.qnt
 
 <!-- !test check SimpleAuction - Syntax/Types & Effects/Unit tests -->

--- a/quint/src/effects/NondetChecker.ts
+++ b/quint/src/effects/NondetChecker.ts
@@ -92,7 +92,7 @@ export class NondetChecker implements IRVisitor {
     if (body.kind !== 'app' || (body.opcode !== 'oneOf' && body.opcode !== 'generate')) {
       this.errors.push({
         code: 'QNT204',
-        message: `'oneOf' or 'generate' must be the outermost expression in a nondet definition`,
+        message: `'oneOf' and 'generate' must be the outermost expressions in a nondet definition`,
         reference: body.id,
         data: {},
       })

--- a/quint/src/effects/NondetChecker.ts
+++ b/quint/src/effects/NondetChecker.ts
@@ -5,8 +5,8 @@
  * --------------------------------------------------------------------------------- */
 
 /**
- * Checking for the misuse of 'nondet' and 'oneOf'. Necessary to ensure they are
- * compatible with the exists operator from TLA+.
+ * Checking for the misuse of 'nondet', 'oneOf', and 'generate'.
+ * Necessary to ensure they are compatible with the exists operator from TLA+.
  *
  * @author Gabriela Moreira
  *
@@ -32,7 +32,7 @@ export class NondetChecker implements IRVisitor {
   }
 
   /**
-   * Checks declarations for misuse of 'nondet' and 'oneOf'.
+   * Checks declarations for misuse of 'nondet', 'oneOf', and 'generate'.
    *
    * @param types - the types of the declarations
    * @param declarations - the declarations to check
@@ -66,7 +66,7 @@ export class NondetChecker implements IRVisitor {
   }
 
   enterApp(app: QuintApp) {
-    if (app.opcode !== 'oneOf') {
+    if (app.opcode !== 'oneOf' && app.opcode !== 'generate') {
       // nothing to check
       return
     }
@@ -74,7 +74,7 @@ export class NondetChecker implements IRVisitor {
     if (this.lastDefQualifier !== 'nondet') {
       this.errors.push({
         code: 'QNT203',
-        message: `'oneOf' must be used inside a nondet definition`,
+        message: `'${app.opcode}' must be used inside a nondet definition`,
         reference: app.id,
         data: {},
       })
@@ -89,10 +89,10 @@ export class NondetChecker implements IRVisitor {
 
     // body of nondet must be an application of oneOf
     const body = expr.opdef.expr
-    if (body.kind !== 'app' || body.opcode !== 'oneOf') {
+    if (body.kind !== 'app' || (body.opcode !== 'oneOf' && body.opcode !== 'generate')) {
       this.errors.push({
         code: 'QNT204',
-        message: `'oneOf' must be the outermost expression in a nondet definition`,
+        message: `'oneOf' or 'generate' must be the outermost expression in a nondet definition`,
         reference: body.id,
         data: {},
       })

--- a/quint/src/effects/builtinSignatures.ts
+++ b/quint/src/effects/builtinSignatures.ts
@@ -202,7 +202,7 @@ export const integerOperators = [
   { name: 'ilte', effect: standardPropagation(2) },
   { name: 'igte', effect: standardPropagation(2) },
   { name: 'to', effect: standardPropagation(2) },
-  { name: 'generate', effect: standardPropagation(1) },
+  { name: 'generate', effect: standardPropagation(2) },
 ]
 
 const temporalOperators = [

--- a/quint/src/effects/builtinSignatures.ts
+++ b/quint/src/effects/builtinSignatures.ts
@@ -202,6 +202,7 @@ export const integerOperators = [
   { name: 'ilte', effect: standardPropagation(2) },
   { name: 'igte', effect: standardPropagation(2) },
   { name: 'to', effect: standardPropagation(2) },
+  { name: 'generate', effect: standardPropagation(1) },
 ]
 
 const temporalOperators = [

--- a/quint/src/ir/quintIr.ts
+++ b/quint/src/ir/quintIr.ts
@@ -156,6 +156,7 @@ export const builtinOpCodes = [
   'foldl',
   'foldr',
   'forall',
+  'generate',
   'get',
   'head',
   'iadd',

--- a/quint/src/names/base.ts
+++ b/quint/src/names/base.ts
@@ -174,6 +174,7 @@ export const builtinNames = [
   'allLists',
   'allListsUpTo',
   'chooseSome',
+  'generate',
   'oneOf',
   'isFinite',
   'size',

--- a/quint/src/quintError.ts
+++ b/quint/src/quintError.ts
@@ -115,6 +115,8 @@ export type ErrorCode =
   | 'QNT513'
   /* QNT514: Cardinality is infinite */
   | 'QNT514'
+  /* QNT515: 'generate' is not supported by the simulator */
+  | 'QNT515'
 
 /* Additional data for a Quint error */
 export interface QuintErrorData {

--- a/quint/src/runtime/impl/compilerImpl.ts
+++ b/quint/src/runtime/impl/compilerImpl.ts
@@ -813,6 +813,9 @@ export class CompilerVisitor implements IRVisitor {
           this.applyOneOf(app.id)
           break
 
+        case 'generate':
+          return left({ code: 'QNT515', message: "Operator 'generate' is not supported by the random simulator" })
+
         case 'exists':
           this.mapLambdaThenReduce(app.id, set => rv.mkBool(set.find(([result, _]) => result.toBool()) !== undefined))
           break

--- a/quint/src/types/builtinSignatures.ts
+++ b/quint/src/types/builtinSignatures.ts
@@ -106,7 +106,7 @@ const integerOperators = [
   { name: 'igte', type: '(int, int) => bool' },
   { name: 'to', type: '(int, int) => Set[int]' },
   { name: 'iuminus', type: '(int) => int' },
-  { name: 'generate', type: '(a, int) => Set[a]' },
+  { name: 'generate', type: '(int, Set[a]) => a' },
 ]
 const temporalOperators = [
   { name: 'always', type: '(bool) => bool' },

--- a/quint/src/types/builtinSignatures.ts
+++ b/quint/src/types/builtinSignatures.ts
@@ -106,7 +106,7 @@ const integerOperators = [
   { name: 'igte', type: '(int, int) => bool' },
   { name: 'to', type: '(int, int) => Set[int]' },
   { name: 'iuminus', type: '(int) => int' },
-  { name: 'generate', type: '(int, Set[a]) => a' },
+  { name: 'generate', type: '(int, a) => a' },
 ]
 const temporalOperators = [
   { name: 'always', type: '(bool) => bool' },

--- a/quint/src/types/builtinSignatures.ts
+++ b/quint/src/types/builtinSignatures.ts
@@ -106,7 +106,7 @@ const integerOperators = [
   { name: 'igte', type: '(int, int) => bool' },
   { name: 'to', type: '(int, int) => Set[int]' },
   { name: 'iuminus', type: '(int) => int' },
-  { name: 'generate', type: '(int) => Set[a]' },
+  { name: 'generate', type: '(a, int) => Set[a]' },
 ]
 const temporalOperators = [
   { name: 'always', type: '(bool) => bool' },

--- a/quint/src/types/builtinSignatures.ts
+++ b/quint/src/types/builtinSignatures.ts
@@ -106,6 +106,7 @@ const integerOperators = [
   { name: 'igte', type: '(int, int) => bool' },
   { name: 'to', type: '(int, int) => Set[int]' },
   { name: 'iuminus', type: '(int) => int' },
+  { name: 'generate', type: '(int) => Set[a]' },
 ]
 const temporalOperators = [
   { name: 'always', type: '(bool) => bool' },

--- a/quint/test/effects/NondetChecker.test.ts
+++ b/quint/test/effects/NondetChecker.test.ts
@@ -61,7 +61,7 @@ describe('checkNondets', () => {
     assert.sameDeepMembers(errors, [
       {
         code: 'QNT204',
-        message: "'oneOf' must be the outermost expression in a nondet definition",
+        message: "'oneOf' and 'generate' must be the outermost expressions in a nondet definition",
         reference: 8n,
         data: {},
       },


### PR DESCRIPTION
Hello :octocat:!

I would like to add an experimental contribution, namely, the operator `generate` that mirrors `Apalache!Gen`. This operator should unlock the feature of Apalache that is sometimes used to reason about inductive invariants. This PR:

- [x] adds the operator `generate`
- [x] adds an error for `generate` in the simulator, as it is not clear to me how one would implement that in the simulator
- [x] prepares the ground for translation in Apalache.
- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
