### PR TITLE
Hotfix for high memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed an issue that caused high memory usage on exploration (#1465)
+
 ### Security
 
 ## v0.21.0 -- 2024-06-16

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -149,7 +149,7 @@ export function compileAndTest(
             recorder.onRunReturn(toMaybe(result), [])
           }
 
-          const bestTrace = recorder.getBestTraces(1)[0].frame
+          const bestTrace = recorder.bestTraces[0].frame
           // evaluate the result
           if (result.isLeft()) {
             // if the test failed, return immediately
@@ -210,7 +210,7 @@ export function compileAndTest(
         }
 
         // the test was run maxSamples times, and no errors were found
-        const bestTrace = recorder.getBestTraces(1)[0].frame
+        const bestTrace = recorder.bestTraces[0].frame
         saveTrace(bestTrace, index, name, 'passed')
         return {
           name,

--- a/quint/src/runtime/trace.ts
+++ b/quint/src/runtime/trace.ts
@@ -16,7 +16,6 @@ import { EvalResult } from './runtime'
 import { verbosity } from './../verbosity'
 import { Rng } from './../rng'
 import { rv } from './impl/runtimeValue'
-import { take } from 'lodash'
 
 /**
  * A snapshot of how a single operator (e.g., an action) was executed.

--- a/quint/src/runtime/trace.ts
+++ b/quint/src/runtime/trace.ts
@@ -174,16 +174,14 @@ export interface TraceRecorder extends ExecutionListener {
   clear: () => void
 
   /**
-   * Get the best recorded traces.
-   * @param n the number of traces to get
-   * @returns the best recorded traces.
+   * The best recorded traces.
    */
-  getBestTraces(n: number): Trace[]
+  bestTraces: Trace[]
 }
 
 // a trace recording listener
-export const newTraceRecorder = (verbosityLevel: number, rng: Rng): TraceRecorder => {
-  return new TraceRecorderImpl(verbosityLevel, rng)
+export const newTraceRecorder = (verbosityLevel: number, rng: Rng, tracesToRecord: number = 1): TraceRecorder => {
+  return new TraceRecorderImpl(verbosityLevel, rng, tracesToRecord)
 }
 
 // a private implementation of a trace recorder
@@ -191,8 +189,10 @@ class TraceRecorderImpl implements TraceRecorder {
   verbosityLevel: number
   rng: Rng
   currentFrame: ExecutionFrame
-  // all trace are stored here with their respective seeds
-  private traces: Trace[]
+  // how many traces to store
+  private tracesToStore: number
+  // best traces are stored here with their respective seeds
+  bestTraces: Trace[]
   // whenever a run is entered, we store its seed here
   private runSeed: bigint
   // During simulation, a trace is built here.
@@ -202,25 +202,22 @@ class TraceRecorderImpl implements TraceRecorder {
   // a tree of calls.
   private frameStack: ExecutionFrame[]
 
-  constructor(verbosityLevel: number, rng: Rng) {
+  constructor(verbosityLevel: number, rng: Rng, tracesToStore: number) {
     this.verbosityLevel = verbosityLevel
     this.rng = rng
     const bottom = this.newBottomFrame()
-    this.traces = []
+    this.tracesToStore = tracesToStore
+    this.bestTraces = []
     this.runSeed = this.rng.getState()
     this.currentFrame = bottom
     this.frameStack = [bottom]
   }
 
   clear() {
-    this.traces = []
+    this.bestTraces = []
     const bottom = this.newBottomFrame()
     this.currentFrame = bottom
     this.frameStack = [bottom]
-  }
-
-  getBestTraces(n: number): Trace[] {
-    return take(this.tracesByQuality(), n)
   }
 
   onUserOperatorCall(app: QuintApp) {
@@ -331,10 +328,17 @@ class TraceRecorderImpl implements TraceRecorder {
     traceToSave.result = outcome
     traceToSave.args = trace
 
-    this.traces.push({ frame: traceToSave, seed: this.runSeed })
+    const traceWithSeed = { frame: traceToSave, seed: this.runSeed }
+
+    this.bestTraces.push(traceWithSeed)
+    this.sortTracesByQuality()
+    // Remove the worst trace (if there more traces than needed)
+    if (this.bestTraces.length > this.tracesToStore) {
+      this.bestTraces.pop()
+    }
   }
 
-  private tracesByQuality(): Trace[] {
+  private sortTracesByQuality() {
     const fromResult = (r: Maybe<EvalResult>) => {
       if (r.isNone()) {
         return true
@@ -344,7 +348,7 @@ class TraceRecorderImpl implements TraceRecorder {
       }
     }
 
-    return this.traces.sort((a, b) => {
+    this.bestTraces.sort((a, b) => {
       // Prefer short traces for error, and longer traces for non error.
       // Therefore, trace a is better than trace b iff
       //  - when a has an error: a is shorter or b has no error;

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -108,7 +108,7 @@ export function compileAndRun(
   const newMainModuleCode = code.slice(mainStart, mainEnd - 1) + '\n' + extraDefs.join('\n')
   const codeWithExtraDefs = code.slice(0, mainStart) + newMainModuleCode + code.slice(mainEnd)
 
-  const recorder = newTraceRecorder(options.verbosity, options.rng)
+  const recorder = newTraceRecorder(options.verbosity, options.rng, options.numberOfTraces)
   const ctx = compileFromCode(
     idGen,
     codeWithExtraDefs,
@@ -134,7 +134,7 @@ export function compileAndRun(
     res.value.eval()
   }
 
-  const topTraces: Trace[] = recorder.getBestTraces(options.numberOfTraces)
+  const topTraces: Trace[] = recorder.bestTraces
   const vars = evaluationState.vars.map(v => v.name)
 
   topTraces.forEach((trace, index) => {


### PR DESCRIPTION
Hello :octocat: 

Closes #1456 

In https://github.com/informalsystems/quint/pull/1365 I prioritized performance over memory consumption without thinking too much about it and it was a bad choice. I've heard complains from three people (@josef-widder, @cason and @konnov) about a ridiculous increase in memory consumption by Quint, and this was the cause.

This PR fixes the problem by sacrificing a bit of performance (making a sort operation at every trace) and therefore not having to store all traces found (which would enable a single sorting operation).

Most importantly, the new approach should only impact performance when the new `--n-traces` flag is used. All previously existing operations should no longer be affected by this change. This was the biggest problem, since even when the flag was not used and users wanted a single trace, we were still storing all explored traces and using a lot of memory.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
