### PR TITLE
Relax uppercase check for types qualified with a namespace

### DIFF
--- a/quint/src/parsing/ToIrListener.ts
+++ b/quint/src/parsing/ToIrListener.ts
@@ -294,9 +294,7 @@ export class ToIrListener implements QuintListener {
     const name = ctx.qualId()!.text
     const id = this.getId(ctx)
 
-    if (name[0].match('[a-z]')) {
-      this.errors.push(lowercaseTypeError(id, name))
-    }
+    this.checkForUppercaseTypeName(id, name)
 
     const def: QuintTypeDef = {
       id,
@@ -319,9 +317,8 @@ export class ToIrListener implements QuintListener {
     const type = this.popType().unwrap(() =>
       fail('internal error: type alias declaration parsed with no right hand side')
     )
-    if (name[0].match('[a-z]')) {
-      this.errors.push(lowercaseTypeError(id, name))
-    }
+
+    this.checkForUppercaseTypeName(id, name)
 
     let defWithoutParams: QuintTypeDef = { id: id, kind: 'typedef', name, type }
     const def: QuintTypeDef =
@@ -1295,6 +1292,15 @@ export class ToIrListener implements QuintListener {
         },
         expr: body,
       }
+    }
+  }
+
+  private checkForUppercaseTypeName(id: bigint, qualifiedName: string) {
+    const parts = qualifiedName.split('::')
+    const unqualifiedName = parts.pop()!
+
+    if (unqualifiedName[0].match('[a-z]')) {
+      this.errors.push(lowercaseTypeError(id, unqualifiedName, parts))
     }
   }
 }

--- a/quint/src/parsing/parseErrors.ts
+++ b/quint/src/parsing/parseErrors.ts
@@ -1,19 +1,21 @@
 import { QuintError } from '../quintError'
 
-export function lowercaseTypeError(id: bigint, name: string): QuintError {
+export function lowercaseTypeError(id: bigint, name: string, prefix: string[]): QuintError {
+  const original = [...prefix, name].join('::')
+  const newName = name[0].toUpperCase() + name.slice(1)
+  const replacement = [...prefix, newName].join('::')
+
   return {
     code: 'QNT007',
     message: 'type names must start with an uppercase letter',
     reference: id,
-    data: name[0].match('[a-z]')
-      ? {
-          fix: {
-            kind: 'replace',
-            original: `type ${name[0]}`,
-            replacement: `type ${name[0].toUpperCase()}`,
-          },
-        }
-      : {},
+    data: {
+      fix: {
+        kind: 'replace',
+        original: `type ${original}`,
+        replacement: `type ${replacement}`,
+      },
+    },
   }
 }
 


### PR DESCRIPTION
Allows `type foo::Bar = int` whereas it would previously fail with `type names must start with an uppercase letter` because the check was looking at the very first letter of the fully qualified name (ie. `foo::Bar`) instead of the unqualified name (ie. `Bar`).

## Example

```bluespec
module upper {
  type Foo = int
  type foo = int

  type foo::Bar = int
  type foo::bar = int
}
```


### Before

```
upper.qnt:2:3 - error: [QNT007] type names must start with an uppercase letter
2:   type Foo = int
     ^^^^^^^^^^^^^^

upper.qnt:3:3 - error: [QNT007] type names must start with an uppercase letter
3:   type foo = int
     ^^^^^^^^^^^^^^

upper.qnt:5:3 - error: [QNT007] type names must start with an uppercase letter
5:   type foo::Bar = int
     ^^^^^^^^^^^^^^^^^^^

upper.qnt:6:3 - error: [QNT007] type names must start with an uppercase letter
6:   type foo::bar = int
     ^^^^^^^^^^^^^^^^^^^

error: parsing failed
```


### After

```
/Users/romac/Informal/Code/quint/quint/upper.qnt:3:3 - error: [QNT007] type names must start with an uppercase letter
3:   type foo = int
     ^^^^^^^^^^^^^^

/Users/romac/Informal/Code/quint/quint/upper.qnt:5:3 - error: [QNT007] type names must start with an uppercase letter
5:   type foo::bar = int
     ^^^^^^^^^^^^^^^^^^^

error: parsing failed
```

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
