### PR TITLE
Bump Apalache to 0.45.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Some error scenarios when importing files on Windows were fixed (#1498)
+- `quint verify` on Windows should now properly start an Apalache server on the
+  background (#1499)
+
 ### Security
 
 ## v0.22.0 -- 2024-09-09

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -75,7 +75,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-const APALACHE_VERSION_TAG = '0.45.6'
+const APALACHE_VERSION_TAG = '0.46.1'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -75,7 +75,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-const APALACHE_VERSION_TAG = '0.44.11'
+const APALACHE_VERSION_TAG = '0.45.6'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 


### PR DESCRIPTION
Hello :octocat: 

We just released a version of Apalache that includes an `apalache-mc.bat` file, enabling Quint to start that file in order to run Apalache on Windows.

This PR bumps the Apalache version so we can use that, and then adds CHANGELOG entries related to Windows so we can cut a release
