### PR TITLE
Add the option `--apalache-version` to `quint verify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- `quint verify` has the option `--apalache-version` to pull a custom version (#1521)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,7 +31,7 @@ quint verify --verbosity=1 ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution... done.
+Downloading Apalache distribution 0.46.1... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -124,7 +124,7 @@ const compileCmd = {
         default: verbosity.defaultLevel,
       })
       .option('apalache-version', {
-        desc: 'The version of Apalache to use, if it has to be downloaded',
+        desc: 'The version of Apalache to use, if no running server is found (using this option may result in incompatibility)',
         type: 'string',
         default: DEFAULT_APALACHE_VERSION_TAG,
       })

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -328,7 +328,7 @@ const verifyCmd = {
         default: verbosity.defaultLevel,
       })
       .option('apalache-version', {
-        desc: 'The version of Apalache to use, if it has to be downloaded',
+        desc: 'The version of Apalache to use, if no running server is found (using this option may result in incompatibility)',
         type: 'string',
         default: DEFAULT_APALACHE_VERSION_TAG,
       })

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -31,7 +31,7 @@ import {
 import { verbosity } from './verbosity'
 
 import { version } from './version'
-import { parseServerEndpoint } from './apalache'
+import { DEFAULT_APALACHE_VERSION_TAG, parseServerEndpoint } from './apalache'
 
 const defaultOpts = (yargs: any) =>
   yargs.option('out', {
@@ -122,6 +122,11 @@ const compileCmd = {
         desc: 'control how much output is produced (0 to 5)',
         type: 'number',
         default: verbosity.defaultLevel,
+      })
+      .option('apalache-version', {
+        desc: 'The version of Apalache to use, if it has to be downloaded',
+        type: 'string',
+        default: DEFAULT_APALACHE_VERSION_TAG,
       })
       .option('server-endpoint', {
         desc: 'Apalache server endpoint hostname:port',
@@ -321,6 +326,11 @@ const verifyCmd = {
         desc: 'control how much output is produced (0 to 5)',
         type: 'number',
         default: verbosity.defaultLevel,
+      })
+      .option('apalache-version', {
+        desc: 'The version of Apalache to use, if it has to be downloaded',
+        type: 'string',
+        default: DEFAULT_APALACHE_VERSION_TAG,
       })
       .option('server-endpoint', {
         desc: 'Apalache server endpoint hostname:port',

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -710,8 +710,12 @@ export async function outputCompilationTarget(compiled: CompiledStage): Promise<
       process.stdout.write(parsedSpecJson)
       return right(compiled)
     case 'tlaplus': {
-      const toTlaResult =
-        await compileToTlaplus(args.serverEndpoint, args.apalacheVersion, parsedSpecJson, verbosityLevel)
+      const toTlaResult = await compileToTlaplus(
+        args.serverEndpoint,
+        args.apalacheVersion,
+        parsedSpecJson,
+        verbosityLevel
+      )
       return toTlaResult
         .mapRight(tla => {
           process.stdout.write(tla) // Write out, since all went right

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -710,7 +710,8 @@ export async function outputCompilationTarget(compiled: CompiledStage): Promise<
       process.stdout.write(parsedSpecJson)
       return right(compiled)
     case 'tlaplus': {
-      const toTlaResult = await compileToTlaplus(args.serverEndpoint, parsedSpecJson, verbosityLevel)
+      const toTlaResult =
+        await compileToTlaplus(args.serverEndpoint, args.apalacheVersion, parsedSpecJson, verbosityLevel)
       return toTlaResult
         .mapRight(tla => {
           process.stdout.write(tla) // Write out, since all went right
@@ -791,7 +792,7 @@ export async function verifySpec(prev: CompiledStage): Promise<CLIProcedure<Trac
 
   const startMs = Date.now()
 
-  return verify(args.serverEndpoint, config, verbosityLevel).then(res => {
+  return verify(args.serverEndpoint, args.apalacheVersion, config, verbosityLevel).then(res => {
     const elapsedMs = Date.now() - startMs
     return res
       .map(_ => {

--- a/quint/src/compileToTlaplus.ts
+++ b/quint/src/compileToTlaplus.ts
@@ -20,6 +20,9 @@ import { ApalacheResult, ServerEndpoint, connect } from './apalache'
  *
  * @param serverEndpoint
  *   a server endpoint
+ * 
+ * @param apalacheVersion
+ *  the version of Apalache to use if there is no active server connection
  *
  * @param parseDataJson the flattened, analyzed, parse data, in as a json string
  *
@@ -27,6 +30,7 @@ import { ApalacheResult, ServerEndpoint, connect } from './apalache'
  */
 export async function compileToTlaplus(
   serverEndpoint: ServerEndpoint,
+  apalacheVersion: string,
   parseDataJson: string,
   verbosityLevel: number
 ): Promise<ApalacheResult<string>> {
@@ -39,6 +43,6 @@ export async function compileToTlaplus(
       },
     },
   }
-  const connectionResult = await connect(serverEndpoint, verbosityLevel)
+  const connectionResult = await connect(serverEndpoint, apalacheVersion, verbosityLevel)
   return connectionResult.asyncChain(conn => conn.tla(config))
 }

--- a/quint/src/compileToTlaplus.ts
+++ b/quint/src/compileToTlaplus.ts
@@ -20,7 +20,7 @@ import { ApalacheResult, ServerEndpoint, connect } from './apalache'
  *
  * @param serverEndpoint
  *   a server endpoint
- * 
+ *
  * @param apalacheVersion
  *  the version of Apalache to use if there is no active server connection
  *

--- a/quint/src/quintVerifier.ts
+++ b/quint/src/quintVerifier.ts
@@ -30,9 +30,10 @@ import { ApalacheResult, ServerEndpoint, connect } from './apalache'
  */
 export async function verify(
   serverEndpoint: ServerEndpoint,
+  apalacheVersion: string,
   config: any,
   verbosityLevel: number
 ): Promise<ApalacheResult<void>> {
-  const connectionResult = await connect(serverEndpoint, verbosityLevel)
+  const connectionResult = await connect(serverEndpoint, apalacheVersion, verbosityLevel)
   return connectionResult.asyncChain(conn => conn.check(config))
 }


### PR DESCRIPTION
Since every release of Apalache requires a PR in Quint, this PR introduces the option `--apalache-version`. This option allows the Quint users to pull different versions of Apalache without waiting for a new release of Quint. For instance, the new version of Apalache v0.47.0 downgrades the version of z3. 

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality