### PR TITLE
VSCode Release v0.14.8

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## v0.14.8 -- 2024-10-18
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## v0.14.7 -- 2024-10-08
 
 ### Added

--- a/vscode/quint-vscode/package-lock.json
+++ b/vscode/quint-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quint-vscode",
-	"version": "0.14.7",
+	"version": "0.14.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-vscode",
-			"version": "0.14.7",
+			"version": "0.14.8",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Quint",
 	"description": "Language support for Quint specifications",
 	"icon": "./icons/logo.png",
-	"version": "0.14.7",
+	"version": "0.14.8",
 	"publisher": "informal",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vscode/quint-vscode/server/package-lock.json
+++ b/vscode/quint-vscode/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@informalsystems/quint-language-server",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint-language-server",
-      "version": "0.14.7",
+      "version": "0.14.8",
       "license": "Apache 2.0",
       "dependencies": {
         "@informalsystems/quint": "^0.22.2",

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@informalsystems/quint-language-server",
   "description": "Language Server for the Quint specification language",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "author": "Informal Systems",
   "contributors": [
     {


### PR DESCRIPTION
Hello :octocat: 

Due to a problem in our still very manual release process, the release 0.14.7 (#1528) didn't properly update the Quint dependency inside it, so I'm cutting a new one.