### PR TITLE
editor-plugins: add hashbang line highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Hashbang lines are now properly highlighted as comments in vscode and in highlight.js.
+
 ### Security
 
 ## v0.22.2 -- 2024-10-08

--- a/editor-plugins/highlight.js/quint.js
+++ b/editor-plugins/highlight.js/quint.js
@@ -38,6 +38,7 @@ function quintHljs(hljs) {
         scope: 'number',
         begin: '-?(0x[0-9a-fA-F]([0-9a-fA-F]|_[0-9a-fA-F])*|0|[1-9]([0-9]|_[0-9])*)',
       },
+      hljs.SHEBANG, // file-leading hashbang
       hljs.C_LINE_COMMENT_MODE,  // single line comments
       hljs.C_BLOCK_COMMENT_MODE, // multiline comments
     ],

--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -3,6 +3,9 @@
 	"name": "Quint",
 	"patterns": [
 		{
+			"include": "#hashbangLine"
+		},
+		{
 			"include": "#lineComments"
 		},
 		{
@@ -89,6 +92,14 @@
 				{
 					"name": "constant.language.quint",
 					"match": "(false|true|Bool|Int|Nat)"
+				}
+			]
+		},
+		"hashbangLine": {
+			"patterns": [
+				{
+					"name": "comment.line.hashbang.quint",
+					"match": "^#!.*$"
 				}
 			]
 		},


### PR DESCRIPTION
This adds supports for highlighting an hashbang line as a comment, in vscode and in highlight.js.

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality