### PR TITLE
fixed broken link for quint-cheatsheet.pdf in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 - [Language tutorials](../tutorials/README.md)
 - [Syntax specification](./lang.md)
-- [Cheatsheet](./quint-cheatsheet.pdf)
+- [Cheatsheet](./public/quint-cheatsheet.pdf)
 - [API documentation for built-in operators](./builtin.md)
 
 ## Tooling


### PR DESCRIPTION
Hello :octocat: 
I've fixed the broken quint-cheatsheet.pdf link in the [README.md](https://github.com/informalsystems/quint/blob/main/docs/README.md) file.