### PR TITLE
Hotfix: Properly reset metadata variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a problem where traces other than the first one when `--n-traces` > 1
+  and `--mbt` is true had the incorrect `action_taken` and `nondet_picks` values
+  (#1553).
+
 ### Security
 
 ## v0.22.3 -- 2024-10-28

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -894,14 +894,16 @@ rm out-itf-example.itf.json
 
 <!-- !test in run with n-traces itf -->
 ```
-quint run --out-itf=out-itf-example.itf.json --n-traces=3 --max-steps=5 --seed=123  ../examples/tutorials/coin.qnt
+quint run --out-itf=out-itf-example.itf.json --n-traces=3 --mbt --max-steps=5 --seed=123  ../examples/tutorials/coin.qnt
 cat out-itf-example0.itf.json | jq '.["#meta"].status'
+cat out-itf-example1.itf.json | jq '.states[0].action_taken'
 rm out-itf-example*.itf.json
 ```
 
 <!-- !test out run with n-traces itf -->
 ```
 "ok"
+"init"
 ```
 
 ### Run to generate multiple ITF traces with violation

--- a/quint/src/runtime/impl/VarStorage.ts
+++ b/quint/src/runtime/impl/VarStorage.ts
@@ -140,6 +140,12 @@ export class VarStorage {
   reset() {
     this.vars.forEach(reg => (reg.value = initialRegisterValue(reg.name)))
     this.nextVars.forEach(reg => (reg.value = initialRegisterValue(reg.name)))
+    if (this.storeMetadata) {
+      this.actionTaken = undefined
+      this.nondetPicks.forEach((_, key) => {
+        this.nondetPicks.set(key, undefined)
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
Hello :octocat: 

This fixes a bug where traces other then the first one when `--n-traces` > 1 had the wrong metadata values on the first state (inheriting them from the last execution instead of starting from `init`).

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
