### PR TITLE
Counting witnesses

### DIFF
--- a/examples/games/tictactoe/tictactoe.qnt
+++ b/examples/games/tictactoe/tictactoe.qnt
@@ -127,7 +127,7 @@ module tictactoe {
 
   action MoveX = all {
     nextTurn == X,
-    not(won(O)),
+    not(gameOver),
     if (boardEmpty) StartInCorner else
     if (canWin) Win else
     if (canBlock) Block else
@@ -139,7 +139,7 @@ module tictactoe {
 
   action MoveO = all {
     nextTurn == O,
-    not(won(X)),
+    not(gameOver),
     MoveToEmpty(O),
     nextTurn' = X,
   }

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -1461,3 +1461,22 @@ exit $exit_code
 
 error: parsing failed
 ```
+### Prints witnesses counts
+
+<!-- !test exit 0 -->
+<!-- !test in witnesses -->
+```
+output=$(quint run ../examples/games/tictactoe/tictactoe.qnt --witnesses="won(X)" stalemate --max-samples=100 --seed=0x2b442ab439177 --verbosity=1)
+exit_code=$?
+echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g'
+exit $exit_code
+```
+
+<!-- !test out witnesses -->
+```
+[ok] No violation found (duration).
+Witnesses:
+won(X) was witnessed in 98 traces
+stalemate was witnessed in 2 traces
+Use --seed=0x2b442ab439177 to reproduce.
+```

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -273,6 +273,11 @@ const runCmd = {
         type: 'string',
         default: 'true',
       })
+      .option('witnesses', {
+        desc: 'space separated list of witnesses to report on (counting for how many samples the witness is true)',
+        type: 'array',
+        default: '[]',
+      })
       .option('seed', {
         desc: 'random seed to use for non-deterministic choice',
         type: 'string',

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -276,7 +276,7 @@ const runCmd = {
       .option('witnesses', {
         desc: 'space separated list of witnesses to report on (counting for how many states the witness is true)',
         type: 'array',
-        default: '[]',
+        default: [],
       })
       .option('seed', {
         desc: 'random seed to use for non-deterministic choice',

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -274,7 +274,7 @@ const runCmd = {
         default: 'true',
       })
       .option('witnesses', {
-        desc: 'space separated list of witnesses to report on (counting for how many samples the witness is true)',
+        desc: 'space separated list of witnesses to report on (counting for how many states the witness is true)',
         type: 'array',
         default: '[]',
       })

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -616,7 +616,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
         if (r.counters.length > 0) {
           console.log(chalk.green('Witnesses:'))
         }
-        r.counters.forEach((c, i) => console.log(chalk.yellow(prev.args.witnesses[i]), 'was true for', c, 'samples'))
+        r.counters.forEach((c, i) => console.log(chalk.yellow(prev.args.witnesses[i]), 'was true for', c, 'states'))
       })
 
       return right({

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -613,10 +613,19 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
         }
       }
       evalResult.map(r => {
-        if (r.counters.length > 0) {
+        if (r.witnessResults.states.length > 0) {
           console.log(chalk.green('Witnesses:'))
         }
-        r.counters.forEach((c, i) => console.log(chalk.yellow(prev.args.witnesses[i]), 'was true for', c, 'states'))
+        r.witnessResults.states.forEach((c, i) =>
+          console.log(
+            chalk.yellow(prev.args.witnesses[i]),
+            'was true for',
+            c,
+            'states and',
+            r.witnessResults.traces[i],
+            'traces'
+          )
+        )
       })
 
       return right({
@@ -627,7 +636,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
 
     case 'violation':
       maybePrintCounterExample(verbosityLevel, states, frames)
-      evalResult.map(r => r.counters.forEach((c, i) => console.log(prev.args.witnesses[i], c)))
+      // TODO: print witnesses
       if (verbosity.hasResults(verbosityLevel)) {
         console.log(chalk.red(`[violation]`) + ' Found an issue ' + chalk.gray(`(${elapsedMs}ms).`))
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -487,12 +487,10 @@ function maybePrintWitnesses(
 ) {
   if (verbosity.hasWitnessesOutput(verbosityLevel)) {
     evalResult.map(r => {
-      if (r.witnessResults.states.length > 0) {
+      if (r.witnessingTraces.length > 0) {
         console.log(chalk.green('Witnesses:'))
       }
-      r.witnessResults.states.forEach((c, i) =>
-        console.log(chalk.yellow(witnesses[i]), 'was true for', c, 'states and', r.witnessResults.traces[i], 'traces')
-      )
+      r.witnessingTraces.forEach((n, i) => console.log(chalk.yellow(witnesses[i]), 'was witnessed in', n, 'traces'))
     })
   }
 }

--- a/quint/src/runtime/impl/evaluator.ts
+++ b/quint/src/runtime/impl/evaluator.ts
@@ -164,8 +164,7 @@ export class Evaluator {
     const stepEval = buildExpr(this.builder, step)
     const invEval = buildExpr(this.builder, inv)
     const witnessesEvals = witnesses.map(w => buildExpr(this.builder, w))
-    const stateCounters = new Array(witnesses.length).fill(0)
-    const traceCounters = new Array(witnesses.length).fill(0)
+    const witnessingTraces = new Array(witnesses.length).fill(0)
 
     for (let runNo = 0; errorsFound < ntraces && !failure && runNo < nruns; runNo++) {
       progressBar.update(runNo)
@@ -217,7 +216,6 @@ export class Evaluator {
             witnessesEvals.forEach((witnessEval, i) => {
               const witnessResult = witnessEval(this.ctx)
               if (isTrue(witnessResult)) {
-                stateCounters[i] = stateCounters[i] + 1
                 traceWitnessed[i] = true
               }
             })
@@ -231,7 +229,7 @@ export class Evaluator {
 
           traceWitnessed.forEach((witnessed, i) => {
             if (witnessed) {
-              traceCounters[i] = traceCounters[i] + 1
+              witnessingTraces[i] = witnessingTraces[i] + 1
             }
           })
         }
@@ -242,11 +240,9 @@ export class Evaluator {
     }
     progressBar.stop()
 
-    const witnessResults = { states: stateCounters, traces: traceCounters }
-
     return failure
       ? left(failure)
-      : right({ result: { id: 0n, kind: 'bool', value: errorsFound == 0 }, witnessResults })
+      : right({ result: { id: 0n, kind: 'bool', value: errorsFound == 0 }, witnessingTraces })
   }
 
   /**

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -41,5 +41,5 @@ export type Outcome =
  */
 export interface SimulationResult {
   result: QuintEx
-  witnessResults: { states: number[]; traces: number[] }
+  witnessingTraces: number[]
 }

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -39,10 +39,7 @@ export type Outcome =
 /**
  * A result returned by the simulator.
  */
-export interface SimulatorResult {
-  outcome: Outcome
-  vars: string[]
-  states: QuintEx[]
-  frames: ExecutionFrame[]
-  seed: bigint
+export interface SimulationResult {
+  result: QuintEx
+  witnessResults: { states: number[]; traces: number[] }
 }

--- a/quint/src/verbosity.ts
+++ b/quint/src/verbosity.ts
@@ -64,6 +64,13 @@ export const verbosity = {
   },
 
   /**
+   * Shall the tool output witnesses counts.
+   */
+  hasWitnessesOutput: (level: number): boolean => {
+    return level >= 1
+  },
+
+  /**
    * Shall the tool track and output actions that were executed.
    */
   hasActionTracking: (level: number): boolean => {


### PR DESCRIPTION
Hello :octocat: 

On recent projects, we found ourselves wanting to estimate how many of our simulations were "interesting", as in hitting interesting scenarios with specific interactions. To that purpose, I implemented a simple counter for witnesses, which I'm including here.

I see this as a start of a feature. We should have ways to dump witnesses to JSON as well, but this requires a bit more design work as I'm unsure how the interface should look like for that, and how it should interact with traces for violations.

Also, at first, I was also printing the state count (not only the trace count), but that information is harder to interpret and wasn't useful in the instances I looked at it.

This is how the coloring looks like (adding it here as it doesn't show up in the integration test):

![image](https://github.com/user-attachments/assets/134aefb2-d82d-4096-a59a-3c288711dab3)

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
