### PR TITLE
Relax node version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a requirement from the package configuration that would lead to always installing v0.18.3 on node versions > 20 (#1602)
+
 ### Security
 
 ## v0.23.0 -- 2025-01-24

--- a/quint/package.json
+++ b/quint/package.json
@@ -2,13 +2,7 @@
   "name": "@informalsystems/quint",
   "version": "0.23.0",
   "description": "Core tool for the Quint specification language",
-  "keywords": [
-    "temporal",
-    "logic",
-    "formal",
-    "specification",
-    "verification"
-  ],
+  "keywords": ["temporal", "logic", "formal", "specification", "verification"],
   "homepage": "https://github.com/informalsystems/quint",
   "bugs": "https://github.com/informalsystems/quint/issues",
   "license": "Apache 2.0",
@@ -35,13 +29,9 @@
   "bin": {
     "quint": "dist/src/cli.js"
   },
-  "files": [
-    "README.md",
-    "dist/**/*",
-    "test/**/*.ts"
-  ],
+  "files": ["README.md", "dist/**/*", "test/**/*.ts"],
   "engines": {
-    "node": "18 - 20"
+    "node": ">=18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello :octocat: 

After seeing some people struggling to install Quint and consistently getting an older version (`v0.18.3`) installed, @xuanmir shed a light into this and it's a very simple problem.

I was somehow convinced this was specific to MacOS and that jeopardized my investigation significantly. This was simply a node version requirement problem, where we started requiring `20` as a maximum in `v0.19.0` and this led to newer versions of node installing the latest version that supported that engine, which was `v0.18.3`.

Fixes #1602 

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [X] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
