### PR TITLE
Convert init into predicates when compiling to TLA+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Init definitions are now properly transpiled into TLA+ without assignments (#1613)
+
 ### Security
 
 ## v0.23.1 -- 2025-03-10

--- a/examples/classic/distributed/ewd426/check_with_tlc.sh
+++ b/examples/classic/distributed/ewd426/check_with_tlc.sh
@@ -24,16 +24,12 @@ for file in "${FILES[@]}"; do
         exit 1
     fi
 
-    # Step 2: Fix init to be a predicate instead of an assignment
-    perl -0777 -i -pe "s/(.*)'\s+:= (.*_self_stabilization_.*?initial)/\1 = \2/s" "$tla_file"
-
-
     if [[ $? -ne 0 ]]; then
         echo "Error: Failed to edit $tla_file"
         exit 1
     fi
 
-    # Step 3: Create the .cfg file
+    # Step 2: Create the .cfg file
     cat <<EOF > "$cfg_file"
 INIT
 q_init
@@ -48,10 +44,10 @@ INVARIANT
 q_inv
 EOF
 
-    # Step 4: Run TLC with the required Apalache lib files and check output
+    # Step 3: Run TLC with the required Apalache lib files and check output
     output=$(java $JAVA_OPTS -cp "$APALACHE_JAR" tlc2.TLC -deadlock "$tla_file" 2>&1)
 
-    # Step 5: Delete the generated .tla and .cfg files
+    # Step 4: Delete the generated .tla and .cfg files
     rm -f "$tla_file" "$cfg_file"
 
     if echo "$output" | grep -q "Model checking completed. No error has been found."; then

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -308,9 +308,7 @@ ApalacheCompilation_ModuleToInstantiate_instantiatedValue ==
   @type: (() => Bool);
 *)
 init ==
-  x'
-    := (importedValue
-      + ApalacheCompilation_ModuleToInstantiate_instantiatedValue)
+  x = importedValue + ApalacheCompilation_ModuleToInstantiate_instantiatedValue
 
 (*
   @type: (() => Bool);

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -406,3 +406,24 @@ VARIABLE
   clockSync3_clockSync3Spec_time
 
 ```
+
+### Test error case when something is re-used between init and step, on TLA+ compilation
+
+<!-- !test in ApalacheCompliationError.qnt to TLA+ -->
+```
+quint compile --target tlaplus ./testFixture/ApalacheCompilationError.qnt 2> >(sed -E 's#(/[^ ]*/)testFixture/ApalacheCompilationError.qnt#HOME/ApalacheCompilationError.qnt#g' >&2)
+```
+
+<!-- !test exit 1 -->
+<!-- !test err ApalacheCompliationError.qnt to TLA+ -->
+```
+HOME/ApalacheCompilationError.qnt:19:5 - error: [QNT409] Action A is used both for init and for step, and therefore can't be converted into TLA+. You can duplicate this with a different name to use on init. Sorry Quint can't do it for you yet.
+19:     A,
+        ^
+
+HOME/ApalacheCompilationError.qnt:20:5 - error: [QNT409] Action parameterizedAction is used both for init and for step, and therefore can't be converted into TLA+. You can duplicate this with a different name to use on init. Sorry Quint can't do it for you yet.
+20:     parameterizedAction(x),
+        ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Failed to convert init to predicate
+```

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -53,6 +53,7 @@ import { compileToTlaplus } from './compileToTlaplus'
 import { Evaluator } from './runtime/impl/evaluator'
 import { NameResolver } from './names/resolver'
 import { walkExpression } from './ir/IRVisitor'
+import { convertInit } from './ir/initToPredicate'
 
 export type stage =
   | 'loading'
@@ -730,11 +731,14 @@ export async function outputCompilationTarget(compiled: CompiledStage): Promise<
   const stage: stage = 'outputting target'
   const args = compiled.args
   const verbosityLevel = deriveVerbosity(args)
+  const target = (compiled.args.target as string).toLowerCase()
+
+  const main = target == 'tlaplus' ? convertInit(compiled.mainModule, compiled.table) : compiled.mainModule
 
   const parsedSpecJson = jsonStringOfOutputStage(
-    pickOutputStage({ ...compiled, modules: [compiled.mainModule], table: compiled.table })
+    pickOutputStage({ ...compiled, modules: [main], table: compiled.table })
   )
-  switch ((compiled.args.target as string).toLowerCase()) {
+  switch (target) {
     case 'json':
       process.stdout.write(parsedSpecJson)
       return right(compiled)

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -733,10 +733,18 @@ export async function outputCompilationTarget(compiled: CompiledStage): Promise<
   const verbosityLevel = deriveVerbosity(args)
   const target = (compiled.args.target as string).toLowerCase()
 
-  const main = target == 'tlaplus' ? convertInit(compiled.mainModule, compiled.table) : compiled.mainModule
+  const main =
+    target == 'tlaplus' ? convertInit(compiled.mainModule, compiled.table, compiled.modes) : right(compiled.mainModule)
+
+  if (main.isLeft()) {
+    return cliErr('Failed to convert init to predicate', {
+      ...compiled,
+      errors: main.value.map(mkErrorMessage(compiled.sourceMap)),
+    })
+  }
 
   const parsedSpecJson = jsonStringOfOutputStage(
-    pickOutputStage({ ...compiled, modules: [main], table: compiled.table })
+    pickOutputStage({ ...compiled, modules: [main.value], table: compiled.table })
   )
   switch (target) {
     case 'json':

--- a/quint/src/ir/initToPredicate.ts
+++ b/quint/src/ir/initToPredicate.ts
@@ -1,3 +1,19 @@
+/* ----------------------------------------------------------------------------------
+ * Copyright 2025 Informal Systems
+ * Licensed under the Apache License, Version 2.0.
+ * See LICENSE in the project root for license information.
+ * --------------------------------------------------------------------------------- */
+
+/**
+ * Convert init definitions to predicates to be compatible with TLA+.
+ * Returns errors if some action is re-used between init and step, as that would require generating new actions.
+ * We ask for user intervention in such edge cases.
+ *
+ * @author Gabriela Moreira
+ *
+ * @module
+ */
+
 import { Either, left, right } from '@sweet-monads/either'
 import { LookupTable } from '../names/base'
 import { QuintError } from '../quintError'
@@ -5,6 +21,18 @@ import { IRTransformer, transformModule } from './IRTransformer'
 import { IRVisitor, walkDefinition, walkModule } from './IRVisitor'
 import { OpQualifier, QuintApp, QuintDef, QuintModule, QuintName } from './quintIr'
 
+/**
+ * Converts the the action named as "q::init" and all its dependencies to
+ * predicates (transforming assignments into equalities). If one of the
+ * converted dependencies is also used outside of init, this produces an error
+ * as that case would be more complicated to handle.
+ *
+ * @param module: the module with the init definition and its dependencies
+ * @param lookupTable: the lookup table for the module
+ * @param modes: the result of mode checking the module
+ *
+ * @returns The converted module, or errors intructing manual fix.
+ */
 export function convertInit(
   module: QuintModule,
   lookupTable: LookupTable,

--- a/quint/src/ir/initToPredicate.ts
+++ b/quint/src/ir/initToPredicate.ts
@@ -1,0 +1,84 @@
+import { LookupTable } from '../names/base'
+import { IRTransformer, transformModule } from './IRTransformer'
+import { IRVisitor, walkDefinition, walkModule } from './IRVisitor'
+import { QuintApp, QuintDef, QuintModule, QuintName } from './quintIr'
+
+export function convertInit(module: QuintModule, lookupTable: LookupTable): QuintModule {
+  const defsFinder = new InitDefsFinder(lookupTable)
+  walkModule(defsFinder, module)
+  return transformModule(new InitConverter(defsFinder.insideInitDefs), module)
+}
+
+class InitDefsFinder implements IRVisitor {
+  insideInitDefs = ['q::init']
+  private insideInit = 0
+  private lookupTable: LookupTable
+
+  constructor(lookupTable: LookupTable) {
+    this.lookupTable = lookupTable
+  }
+
+  enterDef(def: QuintDef) {
+    if (this.insideInitDefs.includes(def.name)) {
+      this.insideInit++
+    }
+  }
+
+  exitDef(def: QuintDef) {
+    if (this.insideInitDefs.includes(def.name)) {
+      this.insideInit--
+    }
+  }
+
+  enterName(expr: QuintName) {
+    if (this.insideInit > 0) {
+      this.insideInitDefs.push(expr.name)
+
+      const def = this.lookupTable.get(expr.id)
+      if (def) walkDefinition(this, def as QuintDef)
+    }
+  }
+
+  enterApp(app: QuintApp) {
+    if (this.insideInit > 0) {
+      this.insideInitDefs.push(app.opcode)
+
+      const def = this.lookupTable.get(app.id)
+      if (def) walkDefinition(this, def as QuintDef)
+    }
+  }
+}
+
+class InitConverter implements IRTransformer {
+  private insideInit = 0
+  private insideInitDefs: String[]
+
+  constructor(insideInitDefs: String[]) {
+    this.insideInitDefs = insideInitDefs
+  }
+
+  enterDef(def: QuintDef): QuintDef {
+    if (this.insideInitDefs.includes(def.name)) {
+      this.insideInit++
+    }
+
+    return def
+  }
+
+  exitDef(def: QuintDef): QuintDef {
+    if (this.insideInitDefs.includes(def.name)) {
+      this.insideInit--
+    }
+
+    return def
+  }
+
+  enterApp(app: QuintApp): QuintApp {
+    if (this.insideInit && app.opcode == 'assign') {
+      console.log('updating', app)
+      return { ...app, opcode: 'eq' }
+    }
+
+    return app
+  }
+}

--- a/quint/src/ir/initToPredicate.ts
+++ b/quint/src/ir/initToPredicate.ts
@@ -32,19 +32,25 @@ class InitDefsFinder implements IRVisitor {
 
   enterName(expr: QuintName) {
     if (this.insideInit > 0) {
-      this.insideInitDefs.push(expr.name)
-
       const def = this.lookupTable.get(expr.id)
-      if (def) walkDefinition(this, def as QuintDef)
+      if (!def || def.kind != 'def') {
+        return
+      }
+
+      this.insideInitDefs.push(expr.name)
+      walkDefinition(this, def as QuintDef)
     }
   }
 
   enterApp(app: QuintApp) {
     if (this.insideInit > 0) {
-      this.insideInitDefs.push(app.opcode)
-
       const def = this.lookupTable.get(app.id)
-      if (def) walkDefinition(this, def as QuintDef)
+      if (!def || def.kind != 'def') {
+        return
+      }
+
+      this.insideInitDefs.push(app.opcode)
+      walkDefinition(this, def as QuintDef)
     }
   }
 }
@@ -75,7 +81,6 @@ class InitConverter implements IRTransformer {
 
   enterApp(app: QuintApp): QuintApp {
     if (this.insideInit && app.opcode == 'assign') {
-      console.log('updating', app)
       return { ...app, opcode: 'eq' }
     }
 

--- a/quint/src/quintError.ts
+++ b/quint/src/quintError.ts
@@ -85,6 +85,8 @@ export type ErrorCode =
   | 'QNT407'
   /* QNT408: Case-sensitive filenames */
   | 'QNT408'
+  /* QNT409: Init cannot be converted to TLA+ */
+  | 'QNT409'
   /* QNT500: Uninitialized constant */
   | 'QNT500'
   /* QNT501: Internal compiler error */

--- a/quint/testFixture/ApalacheCompilationError.qnt
+++ b/quint/testFixture/ApalacheCompilationError.qnt
@@ -1,0 +1,22 @@
+module ApalacheCompilationError {
+  var x: int
+  var y: int
+
+  action A = x' = 42
+
+  action parameterizedAction(v) = {
+    nondet v2 = 2.to(5).oneOf()
+    y' = v + v2
+  }
+
+  action init = all {
+    A,
+    nondet v = 1.to(10).oneOf()
+    parameterizedAction(v)
+  }
+
+  action step = all {
+    A,
+    parameterizedAction(x),
+  }
+}


### PR DESCRIPTION
Hello :octocat: 

Closes https://github.com/apalache-mc/apalache/issues/2863. Towards https://github.com/informalsystems/quint/issues/1424

This fixes an old issue where we failed to properly transpile Quint into TLA+ as Quint init definitions are actions with assignments, while TLA+ expects predicates with equalities for the initial state.

The strategy is:
1. Collect all definition names that are called from `q::init`, recursively
2. Iterate again, now replacing assignments whenever they are found inside of those definitions
3. In this second iteration, if this definitions are ever found also outside of the `q::init` context (being referred to by names outside of the tracked scope), we check if they have assignments (mode is `action`) and, if so, report an error.
  - If we update this type of action, we would break the other usages inside non-init actions.
  - This should be quite an edge case, and it would be complicated to handle, so I prefer to report an informative error and request a manual fix.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
