### PR TITLE
Prevent init errors from being reported for runs

### DIFF
--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -785,8 +785,14 @@ export async function outputCompilationTarget(compiled: CompiledStage): Promise<
   const verbosityLevel = deriveVerbosity(args)
   const target = (compiled.args.target as string).toLowerCase()
 
+  const removeRuns = (module: QuintModule): QuintModule => {
+    return { ...module, declarations: module.declarations.filter(d => d.kind !== 'def' || d.qualifier !== 'run') }
+  }
+
   const main =
-    target == 'tlaplus' ? convertInit(compiled.mainModule, compiled.table, compiled.modes) : right(compiled.mainModule)
+    target == 'tlaplus'
+      ? convertInit(removeRuns(compiled.mainModule), compiled.table, compiled.modes)
+      : right(compiled.mainModule)
 
   if (main.isLeft()) {
     return cliErr('Failed to convert init to predicate', {

--- a/quint/testFixture/ApalacheCompilation.qnt
+++ b/quint/testFixture/ApalacheCompilation.qnt
@@ -28,7 +28,6 @@ module ApalacheCompilation {
   // Tests whether we will sanitize identifiers
   def foo::bar(__123) = __123
 
-  // TODO: Tests that we remove primes from assignments in the init function
   action init = {
     x' = importedValue + instantiatedValue
   }
@@ -47,4 +46,6 @@ module ApalacheCompilation {
 
   // Tests that we can specify an alternative invariant via CLI args
   def altInv = x >= 0
+
+  run test = init.then(step)
 }


### PR DESCRIPTION
Hello :octocat: 

We recently added the conversion of `init` actions into TLA+ predicates when transpiling. This would result in an error in the rare scenario where `init` is used in an action context (other than the one being converted - for example, inside `step`).

I now realize this "rare scenario" happens often in runs. However, runs are discarded by Apalache anyway and there's no translation of runs into TLA+. So what I'm doing now is just dicarding the runs before we go into this init conversion step. This happens only on transpilation to TLA+.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
