### PR TITLE
ci: wait for npm in ubuntu runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             echo "Waiting for NPM to publish version ${REF_NAME#v}..."
             sleep 30
           done
-  arches:
+  check-on-arch:
     strategy:
       matrix:
         os:
@@ -82,8 +82,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           deno run --allow-all --node-modules-dir=auto --allow-scripts "npm:@informalsystems/quint@${REF_NAME#v}" --version
-  binaries:
-    needs: arches
+  upload-binaries:
+    needs: check-on-arch
     runs-on: ubuntu-latest
     steps:
       - name: Install Deno

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,19 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  wait-for-npm:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for NPM
+        timeout-minutes: 30
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          while ! curl -s https://registry.npmjs.org/@informalsystems/quint | jq -er ".versions.\"${REF_NAME#v}\""; do
+            echo "Waiting for NPM to publish version ${REF_NAME#v}..."
+            sleep 30
+          done
   arches:
     strategy:
       matrix:
@@ -55,7 +68,7 @@ jobs:
           - macos-13
           # pc-amd64
           - windows-2022
-    needs: release
+    needs: wait-for-npm
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Deno
@@ -63,16 +76,11 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Wait for NPM
+      - name: Check Quint
         timeout-minutes: 30
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
-          while ! curl -s https://registry.npmjs.org/@informalsystems/quint | jq -er ".versions.\"${REF_NAME#v}\""; do
-            echo "Waiting for NPM to publish version ${REF_NAME#v}..."
-            sleep 30
-          done
-
           deno run --allow-all --node-modules-dir=auto --allow-scripts "npm:@informalsystems/quint@${REF_NAME#v}" --version
   binaries:
     needs: arches


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

Closes #1632

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
