### PR TITLE
Fix problem with missing constants being cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed a problem on `pure val`s referring to constants resulting in errors in the Rust evaluator (#1647)
+
 ### Security
 
 ## v0.24.0 -- 2025-04-08

--- a/evaluator/fixtures/instances.qnt
+++ b/evaluator/fixtures/instances.qnt
@@ -5,6 +5,7 @@ module A {
 
   pure def f(a) = x + 1
   pure def g(b) = not(b)
+  pure val v = x
 }
 
 module withVar {
@@ -43,4 +44,6 @@ module instances {
 
   // The two variables should increment independently
   val inv = V1::counter == 0 or V2::counter > V1::counter
+  // pure val referencing constant works
+  val inv2 = A1::v == 33
 }

--- a/evaluator/tests/simulator_tests.rs
+++ b/evaluator/tests/simulator_tests.rs
@@ -41,3 +41,18 @@ fn instances_ok() {
     // Should not find violation
     assert!(result.unwrap().result);
 }
+
+#[test]
+/// inv2 of the same spec ensures constants and values referencing them are compiled correctly
+fn instance_overrides_ok() {
+    let file_path: &Path = Path::new("fixtures/instances.qnt");
+
+    let parsed =
+        helpers::parse_from_path(file_path, "init", "step", Some("inv2"), Some("instances"))
+            .unwrap();
+    // Pass an invariant that should hold
+    let result = parsed.simulate(10, 100, 0);
+    assert!(result.is_ok());
+    // Should not find violation
+    assert!(result.unwrap().result);
+}


### PR DESCRIPTION
Hello :octocat: 

This fixes a problem where we'd get an error about uninitialized constants even if they were properly initialized. I tried adding an optimization when writing the Rust version, but it was wrong. I thought we could just evaluate pure values in a "fake" environment, as they can't reference variables in any way; and then just save that value in the cache. Now I realize we still need the closure behavior as it ensures that the value is only evaluated in the correct context, where the constants are properly set - since even pure vals can refer to constants.

This was already the behavior in the Typescript, I was just a bit naive in the rewriting and we didn't have test coverage for this scenario yet.

<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [X] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
