### PR TITLE
Fix error reference conversion from Rust result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
+- Errors from the Rust evaluator now show the corresponding location (#1648)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/quint/src/quintRustWrapper.ts
+++ b/quint/src/quintRustWrapper.ts
@@ -24,6 +24,7 @@ import path from 'path'
 import os from 'os'
 import chalk from 'chalk'
 import { rustEvaluatorDir } from './config'
+import { QuintError } from './quintError'
 
 const QUINT_EVALUATOR_VERSION = 'v0.1.0'
 
@@ -112,6 +113,9 @@ export class QuintRustWrapper {
 
       // Convert traces to ITF
       parsed.bestTraces = parsed.bestTraces.map((trace: any) => ({ ...trace, states: ofItf(trace.states) }))
+
+      // Convert errors
+      parsed.errors = parsed.errors.map((err: any): QuintError => ({ ...err, reference: BigInt(err.reference) }))
 
       return parsed
     } catch (error) {


### PR DESCRIPTION
Hello :octocat: 

I noticed we were not showing the error locs from errors coming from Rust, even tho the info was there. Turns out it was just a conversion issue.

No tests as we haven't setup the integration tests yet - will do it soon.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
