### PR TITLE
Improve interface of `check_with_tlc.sh`

### DIFF
--- a/examples/classic/distributed/ewd426/README.md
+++ b/examples/classic/distributed/ewd426/README.md
@@ -8,8 +8,8 @@ This folder contains Quint specifications for the three different self-stabiliza
 Due to the presence of temporal properties and fairness, we need to use TLC to model check these specs. As the integration with TLC is not completed, we provide a script to automate running it for these specific specifications: [check_with_tlc.sh](../../../../tlc/check_with_tlc.sh). Usage:
 
 ```sh
-sh check_with_tlc.sh --file ewd426_3.qnt --temporal convergence,closure,persistence
-sh check_with_tlc.sh --file ewd426_4.qnt --temporal convergence,closure,persistence
+check_with_tlc.sh ewd426_3.qnt --temporal convergence,closure,persistence
+check_with_tlc.sh ewd426_4.qnt --temporal convergence,closure,persistence
 ```
 
 If you are trying to learn/understand these algorithms, we recommend playing with the Quint REPL. For that, pick one of the files (for example [ewd426.qnt](ewd426.qnt)) and run the following command in the terminal:


### PR DESCRIPTION
Hello :octocat: 

This improves the TLC script interface a bit, namely:
1. Taking the file as a positional argument instead of under a flag
2. Taking the invariant as an expression, as in `quint run`
3. Using `--workers=auto` as default
4. Taking init and step optionally, as well as `main`, which then produces a `tla` and `cfg` file with that main's name so TLC won't complain the module doesn't match.