### PR TITLE
Add documentation for `getOnlyElement` method for sets

### DIFF
--- a/docs/pages/docs/lang.md
+++ b/docs/pages/docs/lang.md
@@ -1119,6 +1119,9 @@ S.allListsUpTo(2)
 // CHOOSE x \in S: TRUE
 // The operator name is deliberately made long, so it would not be the user's default choice.
 S.chooseSome()
+// Get the only element of a set with exactly one element.
+// Will cause an error if the set has zero or more than one element.
+S.getOnlyElement()
 // There is no special syntax for CHOOSE x \in S: P
 // Instead, you can filter a set and then pick an element of it.
 S.filter(x => P).chooseSome


### PR DESCRIPTION
## Description
This PR addresses issue #1619, which identified that the `getOnlyElement` method for sets is missing from some of the Quint documentation.

## Changes Made
- Added documentation for `getOnlyElement` to the `docs/pages/docs/lang.md` file in the "Set operations" section

## Remaining Work
- The Quint cheatsheet also needs to be updated, but it appears to be in PDF format only.

## Testing
- Verified that the `getOnlyElement` method is now documented in the `lang.md` file

## Related Issues
- Closes #1619

## Notes
If the source for the cheatsheet is not available or if there's a different process for updating the cheatsheet, please let me know and I'll follow that process to complete the documentation update. 

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
