### PR TITLE
docs: fix broken links in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,19 +2,19 @@
 
 ## Language
 
-- [Language tutorials](../tutorials/README.md)
-- [Syntax specification](./lang.md)
+- [Language tutorials](./pages/docs/lessons.md)
+- [Syntax specification](./pages/docs/lang.md)
 - [Cheatsheet](./public/quint-cheatsheet.pdf)
-- [API documentation for built-in operators](./builtin.md)
+- [API documentation for built-in operators](./pages/docs/builtin.md)
 
 ## Tooling
 
-- [REPL tutorial](../tutorials/repl/repl.md)
-- [CLI manual](./quint.md)
-- [Literate executable specifications](./literate.md)
+- [REPL tutorial](./pages/docs/repl.md)
+- [CLI manual](./pages/docs/quint.md)
+- [Literate executable specifications](./pages/docs/literate.md)
 
 ## Design and Development
 
-- [Design Principles](./design-principles.md)
+- [Design Principles](./pages/docs/design-principles.md)
 - [Roadmap](./roadmap.md)
-- [Frequently asked questions](./faq.md)
+- [Frequently asked questions](./pages/docs/faq.mdx)


### PR DESCRIPTION
This PR fixes issue #1617 by updating the links in docs/README.md to point to the correct file locations.
The main problem was that many documentation files had been moved to the docs/pages/docs directory, but the links in docs/README.md were still pointing to the old locations. This PR updates all links to point to the actual locations of the referenced files.

### Changes made:
- Updated links to language-related documentation
- Updated links to tooling documentation
- Updated links to design and development documentation

Closes #1617 

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
