### PR TITLE
feat: Support single-argument q::debug calls via macro-like transformation

### DIFF
--- a/evaluator/tests/evaluation_tests.rs
+++ b/evaluator/tests/evaluation_tests.rs
@@ -1203,3 +1203,14 @@ fn run_q_debug() -> Result<(), Box<dyn std::error::Error>> {
          run run1 = (n' = 1).then(n' = q::debug(\"n plus one\", n + 1))",
     )
 }
+
+#[test]
+fn run_q_debug_single_arg() -> Result<(), Box<dyn std::error::Error>> {
+    assert_var_after_run(
+        "n",
+        "2",
+        "run1",
+        "var n: int\n
+         run run1 = (n' = 1).then(n' = q::debug(n + 1))",
+    )
+}

--- a/quint/src/builtin.qnt
+++ b/quint/src/builtin.qnt
@@ -708,7 +708,7 @@ module builtin {
   ///
   /// The weak fairness condition can be expressed in English as (from Specifying Systems):
   ///
-  /// 1. It’s always the case that, if A is enabled forever, then an A step eventually occurs.
+  /// 1. It's always the case that, if A is enabled forever, then an A step eventually occurs.
   /// 1. A is infinitely often disabled, or infinitely many A steps occur.
   /// 1. If A is eventually enabled forever, then infinitely many A steps occur.
   ///
@@ -881,6 +881,9 @@ module builtin {
   /// It also returns the given value unchanged,
   /// so that it can be used directly within expressions.
   ///
+  /// When called with a single argument as `q::debug(expr)`, it prints the
+  /// expression itself as the message, followed by its value.
+  ///
   /// ### Examples
   ///
   /// ```quint
@@ -889,6 +892,13 @@ module builtin {
   /// > new x: 1
   /// > new x: 2
   /// > new x: 3
+  /// true
+  /// ```
+  ///
+  /// ```quint
+  /// var x: int
+  /// >>> (x' = 0).then(x' = q::debug(x + 1))
+  /// > x + 1: 1
   /// true
   /// ```
   pure def q::debug(msg, value): (str, a) => a

--- a/quint/src/parsing/ToIrListener.ts
+++ b/quint/src/parsing/ToIrListener.ts
@@ -1183,6 +1183,29 @@ export class ToIrListener implements QuintListener {
   // stack of expressions
   private pushApplication(ctx: any, name: string, args: QuintEx[]) {
     const id = this.getId(ctx)
+    
+    // Special handling for q::debug with a single argument
+    if (name === 'q::debug' && args.length === 1) {
+      // Get the expression text from the context
+      const expressionText = ctx.text;
+      
+      // Create a string literal with the expression text
+      const expressionStrLiteral: QuintStr = {
+        id: this.idGen.nextId(),
+        kind: 'str',
+        value: expressionText,
+      };
+      
+      // Create the application with two arguments: the expression text and the original argument
+      this.exprStack.push({
+        id,
+        kind: 'app',
+        opcode: name,
+        args: [expressionStrLiteral, args[0]],
+      });
+      return;
+    }
+    
     this.exprStack.push({
       id,
       kind: 'app',


### PR DESCRIPTION
Fixes #1567  

This PR adds support for calling `q::debug` with a single argument by implementing a macro-like transformation in the parser. When `q::debug` is called with one argument, the parser automatically transforms it to include the expression text as the first argument.

Changes:
- Added transformation in `ToIrListener.ts` for single-argument calls
- Updated documentation in `builtin.qnt`
- Added test case in `evaluation_tests.rs`
