### PR TITLE
Fixed the duplicate entry for 'Action' in the modes table of the language manual

### DIFF
--- a/docs/pages/docs/lang.md
+++ b/docs/pages/docs/lang.md
@@ -151,7 +151,6 @@ M`.
 | Stateless         | n/a                        |
 | State             | Stateless                  |
 | Non-determinism   | Stateless, State                    |
-| Action            | Stateless, State           |
 | Run               | Stateless, State, Action   |
 | Action            | Non-determinism, Stateless, State   |
 | Temporal          | Stateless, State           |


### PR DESCRIPTION
### Description

This pr removes the outdated and duplicate entry for 'Action' in the modes table found in `quint/docs/pages/docs/lang.md`. 

Closes #1508 