### PR TITLE
`quint run`: report information on trace length and speed

### DIFF
--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -448,7 +448,7 @@ The command `run` finds an invariant violation.
 output=$(quint run --seed=0x308623f2a48e7 --max-steps=4 \
   --invariant='n < 10' ../examples/language-features/counters.qnt 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*counters.qnt#      HOME/counters.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*counters.qnt#      HOME/counters.qnt#g'
 exit $exit_code
 ```
 
@@ -482,7 +482,7 @@ The command `run` finds an invariant violation and outputs metadata for MBT, whe
 output=$(quint run --seed=0x308623f2a4957 --mbt --max-steps=4 \
   --invariant='n < 10' ../examples/language-features/counters.qnt 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*counters.qnt#      HOME/counters.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*counters.qnt#      HOME/counters.qnt#g'
 exit $exit_code
 ```
 
@@ -516,7 +516,7 @@ Make sure the bank spec we use at the Getting Started guide has correct tracking
 output=$(quint run --seed=0xcc198528dea8b --mbt \
   --invariant=no_negatives ./testFixture/simulator/gettingStarted.qnt 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*gettingStarted.qnt#      HOME/gettingStarted.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*gettingStarted.qnt#      HOME/gettingStarted.qnt#g'
 exit $exit_code
 ```
 
@@ -553,7 +553,7 @@ output=$(quint run --seed=0xcc198528dea8b --mbt \
   --hide balances mbt::nondetPicks \
   --invariant=no_negatives ./testFixture/simulator/gettingStarted.qnt 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*gettingStarted.qnt#      HOME/gettingStarted.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*gettingStarted.qnt#      HOME/gettingStarted.qnt#g'
 exit $exit_code
 ```
 
@@ -579,7 +579,7 @@ The command `run` finds an example.
 <!-- !test in run finds example -->
 ```
 quint run --seed=17 --max-steps=4 --invariant='n < 100' ../examples/language-features/counters.qnt 2>&1 | \
-  sed 's/([0-9]*ms)/(duration)/g' | \
+  sed 's/([0-9]*ms.*)/(duration)/g' | \
   sed 's#^.*counters.qnt#      HOME/counters.qnt#g'
 ```
 
@@ -598,6 +598,7 @@ An example execution:
 [State 4] { n: 3 }
 
 [ok] No violation found (duration).
+Trace length statistics: max=5, min=5, average=5.00
 You may increase --max-samples and --max-steps.
 Use --verbosity to produce more (or less) output.
 Use --seed=0x11 to reproduce.
@@ -633,7 +634,7 @@ The command `run` finds an overflow in Coin.
 output=$(quint run --max-steps=5 --seed=0x1e352e160ffb15 --invariant=totalSupplyDoesNotOverflowInv \
   ../examples/tutorials/coin.qnt 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
 exit $exit_code
 ```
 
@@ -695,7 +696,7 @@ output=$(quint run --max-steps=5 --seed=0x1786e678d460ed \
   --verbosity=3 \
   ../examples/tutorials/coin.qnt 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
 exit $exit_code
 ```
 
@@ -1149,7 +1150,7 @@ error: --seed must be a big integer, found: NotANumber
 ```
 output=$(quint run --seed=NotANumber ../examples/tutorials/coin.qnt)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' -e 's#^.*coin.qnt#      HOME/coin.qnt#g'
 exit $exit_code
 ```
 
@@ -1223,7 +1224,7 @@ FIXME: this should not be a runtime error
 ```
 output=$(quint run testFixture/_1041compileConst.qnt --seed=1 2>&1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g' \
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g' \
   -e 's#^.*_1041compileConst.qnt#HOME/_1041compileConst.qnt#g'
 exit $exit_code
 ```
@@ -1469,7 +1470,7 @@ error: parsing failed
 ```
 output=$(quint run ../examples/games/tictactoe/tictactoe.qnt --witnesses="won(X)" stalemate --max-samples=100 --seed=0x2b442ab439177 --verbosity=1)
 exit_code=$?
-echo "$output" | sed -e 's/([0-9]*ms)/(duration)/g'
+echo "$output" | sed -e 's/([0-9]*ms.*)/(duration)/g'
 exit $exit_code
 ```
 

--- a/quint/src/runtime/impl/evaluator.ts
+++ b/quint/src/runtime/impl/evaluator.ts
@@ -14,7 +14,7 @@
  * @module
  */
 
-import { Either, left, right } from '@sweet-monads/either'
+import { Either, left, mergeInMany, right } from '@sweet-monads/either'
 import { QuintApp, QuintEx } from '../../ir/quintIr'
 import { LookupDefinition, LookupTable } from '../../names/base'
 import { QuintError } from '../../quintError'
@@ -28,7 +28,8 @@ import { zerog } from '../../idGenerator'
 import { List } from 'immutable'
 import { Builder, buildDef, buildExpr, nameWithNamespaces } from './builder'
 import { Presets, SingleBar } from 'cli-progress'
-import { SimulationResult } from '../../simulation'
+import { getTraceStatistics, Outcome, SimulationTrace } from '../../simulation'
+import assert from 'assert'
 
 /**
  * An evaluator for Quint in Node TS runtime.
@@ -135,8 +136,8 @@ export class Evaluator {
    * @param nruns - The number of simulation runs to perform.
    * @param nsteps - The number of steps to perform in each simulation run.
    * @param ntraces - The number of error traces to collect before stopping the simulation.
-   * @returns a boolean expression indicating whether all simulations passed without errors,
-              or an error if the simulation cannot be completed.
+   * @param onTrace - A callback function to be called with trace information for each simulation run.
+   * @returns a simulation outcome with all data to report
    */
   simulate(
     init: QuintEx,
@@ -145,8 +146,9 @@ export class Evaluator {
     witnesses: QuintEx[],
     nruns: number,
     nsteps: number,
-    ntraces: number
-  ): Either<QuintError, SimulationResult> {
+    ntraces: number,
+    onTrace?: (index: number, status: string, vars: string[], states: QuintEx[]) => void
+  ): Outcome {
     let errorsFound = 0
     let failure: QuintError | undefined = undefined
     const startTime = Date.now()
@@ -166,6 +168,7 @@ export class Evaluator {
     const invEval = buildExpr(this.builder, inv)
     const witnessesEvals = witnesses.map(w => buildExpr(this.builder, w))
     const witnessingTraces = new Array(witnesses.length).fill(0)
+    const traceLengths: number[] = []
 
     let runNo = 0
     for (; errorsFound < ntraces && !failure && runNo < nruns; runNo++) {
@@ -203,6 +206,8 @@ export class Evaluator {
 
             const stepResult = stepEval(this.ctx).mapLeft(error => (failure = error))
             if (!isTrue(stepResult)) {
+              traceLengths.push(this.trace.get().length)
+
               // The run cannot be extended. In some cases, this may indicate a deadlock.
               // Since we are doing random simulation, it is very likely
               // that we have not generated good values for extending
@@ -236,6 +241,8 @@ export class Evaluator {
               witnessingTraces[i] = witnessingTraces[i] + 1
             }
           })
+
+          traceLengths.push(this.trace.get().length)
         }
       }
 
@@ -244,10 +251,40 @@ export class Evaluator {
     }
     progressBar.stop()
 
-    return failure
-      ? left(failure)
-      : right({ result: { id: 0n, kind: 'bool', value: errorsFound == 0 }, witnessingTraces, samples: runNo })
+    const results: Either<QuintError[], SimulationTrace[]> = mergeInMany(
+      this.recorder.bestTraces.map((trace, index) => {
+        const maybeEvalResult = trace.frame.result
+        if (maybeEvalResult.isLeft()) {
+          return left(maybeEvalResult.value)
+        }
+        const quintExResult = maybeEvalResult.value.toQuintEx(zerog)
+        assert(quintExResult.kind === 'bool', 'invalid simulation produced non-boolean value ')
+        const simulationSucceeded = quintExResult.value
+        const status = simulationSucceeded ? 'ok' : 'violation'
+        const states = trace.frame.args.map(e => e.toQuintEx(zerog))
+
+        if (onTrace !== undefined) {
+          onTrace(index, status, this.varNames(), states)
+        }
+
+        return right({ states, result: simulationSucceeded, seed: trace.seed })
+      })
+    )
+
+    const runtimeErrors = results.isLeft() ? results.value : []
+
+    let traces = results.isRight() ? results.value : []
+
+    return {
+      status: failure ? 'error' : errorsFound == 0 ? 'ok' : 'violation',
+      errors: (failure ? [failure, ...runtimeErrors] : runtimeErrors),
+      bestTraces: traces,
+      witnessingTraces,
+      samples: runNo,
+      traceStatistics: getTraceStatistics(traceLengths)
+    }
   }
+
 
   /**
    * Run a specified test definition a given number of times, and report the result.
@@ -407,12 +444,19 @@ export class Evaluator {
    * @returns the result of the simulation, or an error if the simulation cannot be completed.
    */
   private evaluateSimulation(expr: QuintApp): Either<QuintError, QuintEx> {
+    let result: Outcome
     if (expr.opcode === 'q::testOnce') {
       const [nsteps, ntraces, init, step, inv] = expr.args
-      return this.simulate(init, step, inv, [], 1, toNumber(nsteps), toNumber(ntraces)).map(r => r.result)
+      result = this.simulate(init, step, inv, [], 1, toNumber(nsteps), toNumber(ntraces))
     } else {
       const [nruns, nsteps, ntraces, init, step, inv] = expr.args
-      return this.simulate(init, step, inv, [], toNumber(nruns), toNumber(nsteps), toNumber(ntraces)).map(r => r.result)
+      result = this.simulate(init, step, inv, [], toNumber(nruns), toNumber(nsteps), toNumber(ntraces))
+    }
+
+    if (result.status === 'error') {
+      return left(result.errors[0])
+    } else {
+      return right({ kind: 'str', value: result.status, id: 0n })
     }
   }
 }

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -45,6 +45,7 @@ export interface Outcome {
   bestTraces: SimulationTrace[]
   witnessingTraces: number[]
   samples: number
+  traceStatistics: TraceStatistics
 }
 
 /**
@@ -54,4 +55,23 @@ export interface SimulationResult {
   result: QuintEx
   witnessingTraces: number[]
   samples: number
+  traceStatistics: TraceStatistics
+}
+
+export interface TraceStatistics {
+  averageTraceLength: number
+  minTraceLength: number
+  maxTraceLength: number
+}
+
+export function getTraceStatistics(traceLengths: number[]): TraceStatistics {
+  return {
+    maxTraceLength: Math.max(...traceLengths),
+    minTraceLength: Math.min(...traceLengths),
+    averageTraceLength: traceLengths.reduce((a, b) => a + b, 0) / traceLengths.length,
+  }
+}
+
+export function showTraceStatistics(stats: TraceStatistics): string {
+  return `Trace length statistics: max=${stats.maxTraceLength}, min=${stats.minTraceLength}, average=${stats.averageTraceLength.toFixed(2)}`
 }

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -684,13 +684,13 @@ describe('repl ok', () => {
       |>>> val Inv = n < 10
       |
       |>>> q::testOnce(5, 1, Init, Next, Inv)
-      |true
+      |"ok"
       |>>> q::testOnce(10, 1, Init, Next, Inv)
-      |false
+      |"violation"
       |>>> q::test(5, 5, 1, Init, Next, Inv)
-      |true
+      |"ok"
       |>>> q::test(5, 10, 1, Init, Next, Inv)
-      |false
+      |"violation"
       |>>> q::lastTrace.length()
       |11
       |>>> q::lastTrace.nth(q::lastTrace.length() - 1)


### PR DESCRIPTION
Hello :octocat: 

This adds extra report info to the `quint run` command, including speed (which is now available in the progress bar, but you can't see it after the command finishes, and I found that annoying) and trace length.

The trace length is an attempt to make it more explicit when the simulator fails to expand a trace further. I'm currently working on improvements on the simulation in this regard, and this makes it more visible. Ideally, in most cases, min = max = avg, but that's not the reality right now since the simulator "gives up" on traces to easily. See this example for the tendermint spec:

```sh
quint run ../examples/cosmos/tendermint/TendermintModels.qnt --invariant=n5_f2::AgreementOrAmnesia --init n5_f2::Init --step n5_f2::Next --max-steps=50
```

![2025-05-26_09-26](https://github.com/user-attachments/assets/e7228945-26c8-4a81-a139-4f21674a44b4)


<!-- Please ensure that your PR includes the following, as needed -->

- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
