### PR TITLE
ci: bump setup-node to v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,7 +61,7 @@ jobs:
           tool: cargo-criterion
 
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install Quint
         run: cd ../quint && npm ci && npm run compile && npm link

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - run: cd ./quint && npm ci
@@ -102,7 +102,7 @@ jobs:
         operating-system: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - run: cd ./quint && npm ci

--- a/.github/workflows/lint-vscode.yml
+++ b/.github/workflows/lint-vscode.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - name: Install quint deps

--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - run: npm install
@@ -62,7 +62,7 @@ jobs:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - run: npm install
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       - run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "17"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/test-evaluator.yml
+++ b/.github/workflows/test-evaluator.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
       - name: Install Quint
         run: cd ../quint && npm ci && npm run compile && npm link
       - name: Run tests


### PR DESCRIPTION
Bumps setup-node to v4 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/actions/setup-node/releases/tag/v4.0.0