### PR TITLE
ci: remove sha256 checksums in release assets

### DIFF
--- a/.github/upload-binaries.sh
+++ b/.github/upload-binaries.sh
@@ -73,15 +73,11 @@ for target_config in "${TARGETS[@]}"; do
     --output "quint-$SUFFIX" \
     "npm:@informalsystems/quint@$VERSION"
 
-  echo "Generating SHA256 hash for quint-$SUFFIX"
-  sha256sum "quint-$SUFFIX" > "quint-$SUFFIX.sha256"
-
   if [ "$DRY_RUN" == true ]; then
-    echo "[dry run] gh release upload \"$RELEASE_TAG\" \"quint-$SUFFIX\" \"quint-$SUFFIX.sha256\" --repo \"$REPO\" --clobber"
+    echo "[dry run] gh release upload \"$RELEASE_TAG\" \"quint-$SUFFIX\" --repo \"$REPO\" --clobber"
   else
     gh release upload "$RELEASE_TAG" \
       "quint-$SUFFIX" \
-      "quint-$SUFFIX.sha256" \
       --repo "$REPO" \
       --clobber
   fi


### PR DESCRIPTION
<!-- Please ensure that your PR includes the following, as needed -->

Closes #1690

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
