### PR TITLE
Handle Apalache process termination when Java is missing

### DIFF
--- a/quint/README.md
+++ b/quint/README.md
@@ -7,10 +7,10 @@ with [the Quint specification language](https://github.com/informalsystems/quint
 
 - Node.js >= 18: Use your package manager or download [nodejs](https://nodejs.org/en/download).
 
-- Java Development Kit >= 17, if you are going to use `quint verify`.  We
+- **Java Development Kit (JDK) >= 17 is required for verification**: The `quint verify` command requires Java 17 or later. We
   recommend version 17 of the [Eclipse Temurin](https://adoptium.net/) or
   [Zulu](https://www.azul.com/downloads/?version=java-17-lts&package=jdk#download-openjdk)
-  builds of OpenJDK.
+  builds of OpenJDK. Without Java installed, the verify command will not work.
 
 ## Installation
 


### PR DESCRIPTION
Fixes #1502 

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality


- Add proper error handling for Apalache process exit events
- Improve error messages to guide users about Java requirement
- Update README to make Java dependency more prominent
- Ensure clean process termination when Java is not found