### PR TITLE
VSCode Release v0.16.0

### DIFF
--- a/vscode/quint-vscode/CHANGELOG.md
+++ b/vscode/quint-vscode/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## v0.16.0 -- 2025-07-14
+
+### Added
 
 - Quick fix for common syntax error on map type definitions (#1682)
 

--- a/vscode/quint-vscode/package-lock.json
+++ b/vscode/quint-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "quint-vscode",
-	"version": "0.15.1",
+	"version": "0.16.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "quint-vscode",
-			"version": "0.15.1",
+			"version": "0.16.0",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/vscode/quint-vscode/package.json
+++ b/vscode/quint-vscode/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Quint",
 	"description": "Language support for Quint specifications",
 	"icon": "./icons/logo.png",
-	"version": "0.15.1",
+	"version": "0.16.0",
 	"publisher": "informal",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vscode/quint-vscode/server/package-lock.json
+++ b/vscode/quint-vscode/server/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@informalsystems/quint-language-server",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@informalsystems/quint-language-server",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "Apache 2.0",
       "dependencies": {
-        "@informalsystems/quint": "^0.24.0",
+        "@informalsystems/quint": "^0.26.0",
         "json-bigint": "^1.0.0",
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -478,9 +478,9 @@
       "dev": true
     },
     "node_modules/@informalsystems/quint": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.24.0.tgz",
-      "integrity": "sha512-J03rE1BjmpkOK0XGwj53jTVP4dfmkrEq6ditjcuqofEX5JChYgeAFCGEA1FzctNwhGHshJf80vB+cizH/7FKCg==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.26.0.tgz",
+      "integrity": "sha512-C1+q6EXpTd6pLBSPimCypDNQcx2D8EFDq+V4DDiEfBhPA9LhMGC0eRJmr14Obfv6r8L4tnjeuvPMgftnOfITnA==",
       "license": "Apache 2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.11.1",
@@ -7240,9 +7240,9 @@
       "dev": true
     },
     "@informalsystems/quint": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.24.0.tgz",
-      "integrity": "sha512-J03rE1BjmpkOK0XGwj53jTVP4dfmkrEq6ditjcuqofEX5JChYgeAFCGEA1FzctNwhGHshJf80vB+cizH/7FKCg==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.26.0.tgz",
+      "integrity": "sha512-C1+q6EXpTd6pLBSPimCypDNQcx2D8EFDq+V4DDiEfBhPA9LhMGC0eRJmr14Obfv6r8L4tnjeuvPMgftnOfITnA==",
       "requires": {
         "@grpc/grpc-js": "^1.11.1",
         "@grpc/proto-loader": "^0.7.7",

--- a/vscode/quint-vscode/server/package.json
+++ b/vscode/quint-vscode/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@informalsystems/quint-language-server",
   "description": "Language Server for the Quint specification language",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "author": "Informal Systems",
   "contributors": [
     {
@@ -43,7 +43,7 @@
     "test/**/*.ts"
   ],
   "dependencies": {
-    "@informalsystems/quint": "^0.24.0",
+    "@informalsystems/quint": "^0.26.0",
     "json-bigint": "^1.0.0",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",


### PR DESCRIPTION
## v0.16.0 -- 2025-07-14

### Added

- Quick fix for common syntax error on map type definitions (#1682)

### Changed
### Deprecated
### Removed
### Fixed
### Security

