### PR TITLE
Fix CI issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,21 +74,21 @@ This repository hosts all Quint pieces:
 ## Developer docs
 
 - [ADR001: Transpiler
-  architecture](./docs/pages/docs/development-docs/architecture-decision-records/adr001-transpiler-architecture.md)
+  architecture](./docs/content/docs/development-docs/architecture-decision-records/adr001-transpiler-architecture.md)
 - [ADR002: Error
-  codes](./docs/pages/docs/development-docs/architecture-decision-records/adr002-errors.md)
+  codes](./docs/content/docs/development-docs/architecture-decision-records/adr002-errors.md)
 - [ADR003: Interface to visit Internal Representation
-   components](./docs/pages/docs/development-docs/architecture-decision-records/adr003-visiting-ir-components.md)
+   components](./docs/content/docs/development-docs/architecture-decision-records/adr003-visiting-ir-components.md)
 - [ADR004: An Effect System for
-  Quint](./docs/pages/docs/development-docs/architecture-decision-records/adr004-effect-system.md)
+  Quint](./docs/content/docs/development-docs/architecture-decision-records/adr004-effect-system.md)
 - [ADR005: A Type System for
-  Quint](./docs/pages/docs/development-docs/architecture-decision-records/adr005-type-system.md)
+  Quint](./docs/content/docs/development-docs/architecture-decision-records/adr005-type-system.md)
 - [ADR006: Design of modules and lookup
-  tables](./docs/pages/docs/development-docs/architecture-decision-records/adr006-modules.lit.md)
+  tables](./docs/content/docs/development-docs/architecture-decision-records/adr006-modules.lit.md)
 - [ADR007:
-  Flattening](./docs/pages/docs/development-docs/architecture-decision-records/adr007-flattening.md)
+  Flattening](./docs/content/docs/development-docs/architecture-decision-records/adr007-flattening.md)
 - [ADR008: Obtaining and Launching Apalache from
-  Quint](./docs/pages/docs/development-docs/architecture-decision-records/adr008-managing-apalache.md)
+  Quint](./docs/content/docs/development-docs/architecture-decision-records/adr008-managing-apalache.md)
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Quint is inspired by [TLA+][] (the language) but provides an alternative surface
 syntax for specifying systems in TLA (the logic). The most important feature of
 our syntax is that it is minimal and regular, making Quint an easy target for
 advanced developer tooling and static analysis (see our [design
-principles](./docs/pages/docs/design-principles.md) and [previews](./docs/pages/docs/previews.md) of the
+principles](./docs/content/docs/design-principles.md) and [previews](./docs/content/docs/previews.md) of the
 tooling).
 
 The syntax also aims to be familiar to engineers:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,18 @@
 
 ## Language
 
-- [Language tutorials](./pages/docs/lessons.md)
-- [Syntax specification](./pages/docs/lang.md)
+- [Language tutorials](./content/docs/lessons.md)
+- [Syntax specification](./content/docs/lang.md)
 - [Cheatsheet](./public/quint-cheatsheet.pdf)
-- [API documentation for built-in operators](./pages/docs/builtin.md)
+- [API documentation for built-in operators](./content/docs/builtin.md)
 
 ## Tooling
 
-- [REPL tutorial](./pages/docs/repl.md)
-- [CLI manual](./pages/docs/quint.md)
-- [Literate executable specifications](./pages/docs/literate.md)
+- [REPL tutorial](./content/docs/repl.md)
+- [CLI manual](./content/docs/quint.md)
+- [Literate executable specifications](./content/docs/literate.md)
 
 ## Design and Development
 
-- [Design Principles](./pages/docs/design-principles.md)
-- [Frequently asked questions](./pages/docs/faq.mdx)
+- [Design Principles](./content/docs/design-principles.md)
+- [Frequently asked questions](./content/docs/faq.mdx)

--- a/docs/codetour/Makefile
+++ b/docs/codetour/Makefile
@@ -20,7 +20,7 @@ tutorials: lesson0-helloworld/hello.qnt \
 	mv $*.tour .tours
 	cp -r img .tours/
 	# move the generated markdown files to the website directory
-	mv $*.md ../pages/docs/lessons/
+	mv $*.md ../content/docs/lessons/
 	cp -r img ../public/lessons/
 	# move the generated quint files to the examples directory
 	cp $*.qnt ../../examples/tutorials/

--- a/docs/content/docs/lessons/coin.md
+++ b/docs/content/docs/lessons/coin.md
@@ -101,7 +101,7 @@ type [name] = [tp];
 In the above definition, `[name]` is a unique identifier that will be associated
 with the type, and `[tp]` is the type to be associated with the name, e.g.,
 `int` or `Set[int]`. To see a complete description of all available types, visit the Section
-[Type System 1.2](https://github.com/informalsystems/quint/blob/main/docs/pages/docs/lang.md#type-system-12)
+[Type System 1.2](https://github.com/informalsystems/quint/blob/main/docs/content/docs/lang.md#type-system-12)
 of the language manual.
 
 Although it is convenient to declare type aliases, it is not mandatory.

--- a/evaluator/flake.nix
+++ b/evaluator/flake.nix
@@ -15,7 +15,7 @@
             pkgs.cargo-insta
           ];
           shellHook = ''
-            rustup default stable
+            rustup default 1.88
           '';
         };
       });

--- a/evaluator/src/builtins.rs
+++ b/evaluator/src/builtins.rs
@@ -153,7 +153,7 @@ pub fn compile_lazy_op(op: &str) -> CompiledExprWithLazyArgs {
                 }
                 None => Err(QuintError::new(
                     "QNT505",
-                    &format!("No match for variant {}", variant_label),
+                    &format!("No match for variant {variant_label}"),
                 )),
             }
         },
@@ -611,7 +611,7 @@ pub fn compile_eager_op(op: &str) -> CompiledExprWithArgs {
                 }
                 None => Err(QuintError::new(
                     "QNT507",
-                    format!("Called 'setBy' with a non- existing key {}", key).as_str(),
+                    format!("Called 'setBy' with a non- existing key {key}").as_str(),
                 )),
             }
         },

--- a/evaluator/src/evaluator.rs
+++ b/evaluator/src/evaluator.rs
@@ -370,7 +370,7 @@ impl<'a> Interpreter<'a> {
                 CompiledExpr::new(move |_| {
                     register.borrow().clone().value.ok_or(QuintError::new(
                         "QNT502",
-                        format!("Variable {} not set", name).as_str(),
+                        format!("Variable {name} not set").as_str(),
                     ))
                 })
             }

--- a/evaluator/src/value.rs
+++ b/evaluator/src/value.rs
@@ -182,7 +182,7 @@ impl Value {
                     .cardinality()
                     .pow(domain.cardinality().try_into().unwrap())
             }
-            _ => panic!("Cardinality not implemented for {:?}", self),
+            _ => panic!("Cardinality not implemented for {self:?}"),
         }
     }
 
@@ -206,7 +206,7 @@ impl Value {
                 // Check if domains are equal and all map values are in the range set
                 map_domain == **domain && map.values().all(|v| range.contains(v))
             }
-            _ => panic!("contains not implemented for {:?}", self),
+            _ => panic!("contains not implemented for {self:?}"),
         }
     }
 
@@ -367,7 +367,7 @@ impl Value {
         match self {
             Value::Tuple(elems) => elems,
             Value::List(elems) => elems,
-            _ => panic!("Expected list, got {:?}", self),
+            _ => panic!("Expected list, got {self:?}"),
         }
     }
 
@@ -443,9 +443,9 @@ pub fn powerset_at_index(base: &ImmutableSet<Value>, i: usize) -> Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Value::Int(n) => write!(f, "{}", n),
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::Str(s) => write!(f, "{:?}", s),
+            Value::Int(n) => write!(f, "{n}"),
+            Value::Bool(b) => write!(f, "{b}"),
+            Value::Str(s) => write!(f, "{s:?}"),
             Value::Set(_)
             | Value::Interval(_, _)
             | Value::CrossProduct(_)
@@ -456,7 +456,7 @@ impl fmt::Display for Value {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:#}", set)?;
+                    write!(f, "{set:#}")?;
                 }
                 write!(f, ")")
             }
@@ -466,7 +466,7 @@ impl fmt::Display for Value {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:#}", elem)?;
+                    write!(f, "{elem:#}")?;
                 }
                 write!(f, ")")
             }
@@ -476,7 +476,7 @@ impl fmt::Display for Value {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {:#}", name, value)?;
+                    write!(f, "{name}: {value:#}")?;
                 }
                 write!(f, " }}")
             }
@@ -486,7 +486,7 @@ impl fmt::Display for Value {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "Tup({:#}, {:#})", key, value)?;
+                    write!(f, "Tup({key:#}, {value:#})")?;
                 }
                 write!(f, ")")
             }
@@ -496,7 +496,7 @@ impl fmt::Display for Value {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:#}", elem)?;
+                    write!(f, "{elem:#}")?;
                 }
                 write!(f, ")")
             }
@@ -504,10 +504,10 @@ impl fmt::Display for Value {
             Value::Variant(label, value) => {
                 if let Value::Tuple(elems) = &**value {
                     if elems.is_empty() {
-                        return write!(f, "{}", label);
+                        return write!(f, "{label}");
                     }
                 }
-                write!(f, "{}({:#})", label, value)
+                write!(f, "{label}({value:#})")
             }
         }
     }

--- a/evaluator/tests/evaluation_tests.rs
+++ b/evaluator/tests/evaluation_tests.rs
@@ -23,7 +23,7 @@ fn assert_from_string(input: &str, expected: &str) -> Result<(), Box<dyn std::er
     let value = run(&parsed.table, &input_def.expr);
 
     if expected == "undefined" {
-        assert!(value.is_err(), "Expected error, got: {:?}", value);
+        assert!(value.is_err(), "Expected error, got: {value:?}");
         return Ok(());
     }
 

--- a/examples/tutorials/repl/Makefile
+++ b/examples/tutorials/repl/Makefile
@@ -4,7 +4,7 @@
 # @file
 # @version 0.1
 
-./repl/kettle.qnt: ../../../docs/pages/docs/repl.md
+./repl/kettle.qnt: ../../../docs/content/docs/repl.md
 	lmt $^
 	cat replTest.txt |\
 		egrep '^(>>>|\.\.\.) ' | sed 's/^>>> //g' | sed 's/^\.\.\. //g' \

--- a/quint/package.json
+++ b/quint/package.json
@@ -84,7 +84,7 @@
     "apalache-dist": "txm apalache-dist-tests.md",
     "generate": "npm run antlr && npm run compile && npm link && npm run api-docs && npm run update-fixtures",
     "antlr": "antlr4ts -visitor ./src/generated/Quint.g4 && antlr4ts -visitor ./src/generated/Effect.g4",
-    "api-docs": "quint docs ./src/builtin.qnt > ../docs/pages/docs/builtin.md",
+    "api-docs": "quint docs ./src/builtin.qnt > ../docs/content/docs/builtin.md",
     "update-fixtures": "./scripts/update-fixtures.sh",
     "format-check": "npx prettier --check '**/*.ts' && npx eslint '**/*.ts'",
     "format": "npx prettier --write '**/*.ts' && npx eslint --fix '**/*.ts'",


### PR DESCRIPTION
Hello :octocat: 

This fixes CI breaking in main:
1. Our clippy linting for Rust was breaking for a while due to it being updated upstream (I guess, in the CI workflow we use). I updated the flake (not in the best way possible, but it works) so developers like me have the 1.88 version, which includes new linting rules which are also fixed in this PR
2. Generating files was breaking due to the recent website changes that moved the `pages` folder to `content`. I then also noticed I forgot to update some links, which I did here as well.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [X] I have read and I understand the [Note on AI-assisted contributions](/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
