### PR TITLE
site: Spec Languages -> Quint

### DIFF
--- a/docs/components/home/index.tsx
+++ b/docs/components/home/index.tsx
@@ -21,7 +21,7 @@ const benefits = [
   ],
   [
     'Abstract',
-    ['Specification Languages', ['define only what you care about']],
+    ['Quint', ['define only what matters']],
     ['Programming Languages', ['define how things happen, in detail']],
   ],
   [


### PR DESCRIPTION
I know what's true of Quint here is true of all Spec Languages and so that is more correct but this is on the Quint site homepage and theres a lot going on that's already a little hard to parse so to simplify and guide the eye I thought they should all say Quint on the left of the table 