### PR TITLE
Fix typo in getting-started.mdx

### DIFF
--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -135,7 +135,7 @@ Create a `bank.qnt` file and add the contents above to it. Then, let's try to ch
 
 ### Find a violation
 
-To look for violations of this invariant, we can use the `run` subcommand, which will simulate a bunch of executions while checking the invariant. In a terminal, whilw on the directory of this file, execute:
+To look for violations of this invariant, we can use the `run` subcommand, which will simulate a bunch of executions while checking the invariant. In a terminal, while on the directory of this file, execute:
 ```sh
 quint run bank.qnt --invariant=no_negatives
 ```


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
