### PR TITLE
Bump apalache to 0.47.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- Bump Apalache to 0.47.3 (including Z3 4.13.4 with linux/arm64 support)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,7 +31,7 @@ quint verify --verbosity=1 ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution 0.47.2... done.
+Downloading Apalache distribution 0.47.3... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -108,7 +108,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-export const DEFAULT_APALACHE_VERSION_TAG = '0.47.2'
+export const DEFAULT_APALACHE_VERSION_TAG = '0.47.3'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 


### PR DESCRIPTION
This PR bumps the default version of Apalache to 0.47.3. It contains an important improvement in Z3:

```
Upgrade Z3 to 4.13.4 (restores linux/arm64 support), see #3057
```
