### PR TITLE
Upgrade Apalache to 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+- Bump Apalache to 0.49.0 (including support for `apalache::generate` [#3138](https://github.com/apalache-mc/apalache/pull/3138))
 - Bump Apalache to 0.47.3 (including Z3 4.13.4 with linux/arm64 support)
 
 ### Deprecated

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,7 +31,7 @@ quint verify --verbosity=1 ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution 0.47.3... done.
+Downloading Apalache distribution 0.49.0... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -108,7 +108,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-export const DEFAULT_APALACHE_VERSION_TAG = '0.47.3'
+export const DEFAULT_APALACHE_VERSION_TAG = '0.49.0'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 


### PR DESCRIPTION
Towards merging `apalache::generate`, see https://github.com/informalsystems/quint/pull/1455 and https://github.com/apalache-mc/apalache/pull/3139:

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
