### PR TITLE
Bump apalache to 0.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump Apalache to 0.49.0 (including support for `apalache::generate` [#3138](https://github.com/apalache-mc/apalache/pull/3138))
+- Bump Apalache to 0.49.1 (including support for `apalache::generate` [#3138](https://github.com/apalache-mc/apalache/pull/3138))
 - Bump Apalache to 0.47.3 (including Z3 4.13.4 with linux/arm64 support)
 
 ### Deprecated

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,7 +31,7 @@ quint verify --verbosity=1 ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution 0.49.0... done.
+Downloading Apalache distribution 0.49.1... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -108,7 +108,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-export const DEFAULT_APALACHE_VERSION_TAG = '0.49.0'
+export const DEFAULT_APALACHE_VERSION_TAG = '0.49.1'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 


### PR DESCRIPTION
Sorry about bumping Apalache quite often over several days. There were quite important changes w.r.t. `apalache::generate`. After updating to 0.49.1, it should work pretty well.

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality
