### PR TITLE
Duplicate field on records should return parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed Quint hanging if Apalache server exits early (#1729)
 - Fixed a problem where the simulators failed to evaluate `oneOf` for nested `setOfMaps` (#1736)
+- Add parser error for duplicated record fields (#1677)
 
 ### Security
 
@@ -49,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `--out-itf` does not suppress outputs anymore. Shown output amount only depends on `--verbosity` now (#1664) 
+- `--out-itf` does not suppress outputs anymore. Shown output amount only depends on `--verbosity` now (#1664)
 
 ### Deprecated
 ### Removed
@@ -136,7 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
-- Changed the `--mbt` variables representation into `mbt::actionTaken` and `mbt::nondetPicks`. 
+- Changed the `--mbt` variables representation into `mbt::actionTaken` and `mbt::nondetPicks`.
 Added those variables to the `vars` field of the ITF json so that they are displayed correctly in the trace viewer.
 - Fixed a problem where traces other than the first one when `--n-traces` > 1
   and `--mbt` is true had the incorrect `action_taken` and `nondet_picks` values

--- a/quint/src/parsing/parseErrors.ts
+++ b/quint/src/parsing/parseErrors.ts
@@ -61,3 +61,15 @@ type variable 'a' is unbound. To fix it, write
     data: {},
   }
 }
+
+export function duplicatedRecordField(id: bigint, names: string[]): QuintError {
+  const joined = names.join(', ')
+  const plural = names.length > 1 ? 'Fields' : 'Field'
+
+  return {
+    code: 'QNT016',
+    message: `${plural} ${joined} cannot be defined more than once`,
+    reference: id,
+    data: {},
+  }
+}

--- a/quint/src/quintError.ts
+++ b/quint/src/quintError.ts
@@ -55,6 +55,8 @@ export type ErrorCode =
   | 'QNT014'
   /* QNT015: use a -> b instead of Map[a, b] */
   | 'QNT015'
+  /* QNT016: Duplicated field on record */
+  | 'QNT016'
   /* QNT098: Cyclic imports */
   | 'QNT098'
   /* QNT099: Found cyclic definitions */

--- a/quint/test/parsing/quintParserFrontend.test.ts
+++ b/quint/test/parsing/quintParserFrontend.test.ts
@@ -283,6 +283,30 @@ type variable 'a' is unbound. To fix it, write
     assert.deepEqual(error2.code, 'QNT008')
     assert.deepEqual(error2.message, `Reserved keyword 'export' cannot be used as an identifier.`)
   })
+
+  it('error on duplicate record fields', () => {
+    const code = `module duplicateFields { val a = { foo: 1, foo: 2 } }`
+    const errors = parseErrorsFrom(defaultSourceName, code)
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'QNT016')
+    assert.equal(errors[0].message, 'Field foo cannot be defined more than once')
+  })
+
+  it('error on duplicate record fields with spread operator', () => {
+    const code = `module duplicateFields { val a = {foo: 1, bar: 2} val b = {...a, bar: 2, bar: 3 } }`
+    const errors = parseErrorsFrom(defaultSourceName, code)
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'QNT016')
+    assert.equal(errors[0].message, 'Field bar cannot be defined more than once')
+  })
+
+  it('error on multiple duplicated record fields', () => {
+    const code = `module duplicateFields { val a = {foo: 1, bar: 2, foo: 1, bar: 2} }`
+    const errors = parseErrorsFrom(defaultSourceName, code)
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'QNT016')
+    assert.equal(errors[0].message, 'Fields foo, bar cannot be defined more than once')
+  })
 })
 
 // Test the JSON error output. Most of the tests here should migrate to the


### PR DESCRIPTION
Fixes #1677

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [X] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [X] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [X] Tests added for any new code
- [ ] Documentation added for any new functionality N/A
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality N/A

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->

<img width="520" height="223" alt="image" src="https://github.com/user-attachments/assets/06e18f96-81f8-4783-a34f-d917a8a9689d" />

I couldn't find how to not get this debug message (`[DEBUG] generating undefined expr to fill hole in: vala={foo:1,foo:2}`), it seems to be extremely trivial but since I'm not familiar with the codebase it's kinda hard to find, any help on this would be very appreciated. 
