### PR TITLE
Fix empty sets not being detected properly in new oneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+
 - Added the operator `apalache::generate` to mirror `Apalache!Gen` (see #1455).
 
 ### Changed
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed Quint hanging if Apalache server exits early (#1729)
 - Fixed a problem where the simulators failed to evaluate `oneOf` for nested `setOfMaps` (#1736)
+- Fixed a problem where calling `oneOf` in empty sets would still result in an error instead of `false` (#1745)
 
 ### Security
 

--- a/quint/src/runtime/impl/nondet.ts
+++ b/quint/src/runtime/impl/nondet.ts
@@ -47,7 +47,7 @@ export function evalNondet(
 ): EvalFunction {
   return ctx =>
     setEval(ctx).chain(set => {
-      if (set.cardinality().unwrap() === 0n) {
+      if (set.cardinality().isRight() && set.cardinality().unwrap() === 0n) {
         // The whole let expression is false if there are no elements to be picked.
         return right(rv.mkBool(false))
       }

--- a/quint/src/runtime/impl/nondet.ts
+++ b/quint/src/runtime/impl/nondet.ts
@@ -47,7 +47,7 @@ export function evalNondet(
 ): EvalFunction {
   return ctx =>
     setEval(ctx).chain(set => {
-      if (isEqual(set.cardinality(), right(0n))) {
+      if (set.cardinality().unwrap() === 0n) {
         // The whole let expression is false if there are no elements to be picked.
         return right(rv.mkBool(false))
       }

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -562,6 +562,7 @@ describe('repl ok', () => {
       |Int.contains(x)
       |nondet m = 1.to(5).setOfMaps(Int).oneOf(); x' = m.get(3)
       |x.in(Int)
+      |nondet m = Set().oneOf(); x' = m
       |`
     )
     const output = dedent(
@@ -599,6 +600,8 @@ describe('repl ok', () => {
       |true
       |>>> x.in(Int)
       |true
+      |>>> nondet m = Set().oneOf(); x' = m
+      |false
       |>>> `
     )
     await assertRepl(input, output)


### PR DESCRIPTION
Hello :octocat:

I realized that my check for empty sets on `oneOf` was not working properly, and I found the root cause to be this `isEqual` comparison that was not working as I expected.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [X] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [X] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [X] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
