### PR TITLE
Bump apalache to 0.50.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- Bump Apalache to 0.50.2 (increasing the GRPC message size to 1GB)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,7 +31,7 @@ quint verify --verbosity=1 ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution 0.50.0... done.
+Downloading Apalache distribution 0.50.2... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -108,7 +108,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-export const DEFAULT_APALACHE_VERSION_TAG = '0.50.0'
+export const DEFAULT_APALACHE_VERSION_TAG = '0.50.2'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 
@@ -354,8 +354,8 @@ function loadGrpcClient(serverEndpoint: ServerEndpoint, protoDef: ProtoPackageDe
   const connectionString = serverEndpointToConnectionString(serverEndpoint)
   // bump the maximal message sizes, as the Quint backend in Apalache may send very large JSON files
   const options: any = {
-    'grpc.max_receive_message_length': 1024 * 1024 * 1024,
-    'grpc.max_send_message_length': 1024 * 1024 * 1024,
+    'grpc.max_receive_message_length': 10 * 1024 * 1024 * 1024,
+    'grpc.max_send_message_length': 10 * 1024 * 1024 * 1024,
   }
   const stub: any = new pkg.cmdExecutor.CmdExecutor(connectionString, grpc.credentials.createInsecure(), options)
   return {


### PR DESCRIPTION
Increasing GRPC message size in Apalache to 1 GB, as I have just observed a Quint spec that have hit the current limits: https://github.com/apalache-mc/apalache/pull/3155