### PR TITLE
Bump apalache to 0.50.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+- Bump Apalache to 0.50.3 (fix counterexamples for `apalache::generate`)
 - Bump Apalache to 0.50.2 (increasing the GRPC message size to 1GB)
 
 ### Deprecated

--- a/quint/apalache-dist-tests.md
+++ b/quint/apalache-dist-tests.md
@@ -31,7 +31,7 @@ quint verify --verbosity=1 ../examples/language-features/booleans.qnt | \
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution 0.50.2... done.
+Downloading Apalache distribution 0.50.3... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -108,7 +108,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-export const DEFAULT_APALACHE_VERSION_TAG = '0.50.2'
+export const DEFAULT_APALACHE_VERSION_TAG = '0.50.3'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 


### PR DESCRIPTION
This fixes a tricky bug in `apalache::generate`.

- [x] Entries added to the respective `CHANGELOG.md` for any new functionality