### PR TITLE
Apalache integration fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed several issues with the integration of Apalache (#1754)
+
 ### Security
 
 ## v0.27.0 -- 2025-08-29

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -79,6 +79,29 @@ quint verify --server-endpoint=0.0.0.0:8822 --max-steps=2 ../examples/verificati
 quint verify --invariant inv,inv2 ../examples/verification/defaultOpNames.qnt
 ```
 
+### Can verify `testFixture/apalache/genericRowParam.qnt`
+
+<!-- !test check can verify genericRowParam.qnt -->
+```
+quint verify ./testFixture/apalache/genericRowParam.qnt
+```
+
+### Can verify `testFixture/apalache/polyStateVar.qnt`
+
+<!-- !test check can verify polyStateVar.qnt -->
+```
+quint verify ./testFixture/apalache/polyStateVar.qnt
+```
+
+### Can compile `testFixture/apalache/inferredStateVar.qnt`
+
+This one still not works with `quint verify` (see #1755)
+
+<!-- !test check can compile inferredStateVar.qnt -->
+```
+quint compile --target tlaplus ./testFixture/apalache/inferredStateVar.qnt
+```
+
 ## Violations
 
 ### Variant violations are reported with traces

--- a/quint/src/types/aliasInliner.ts
+++ b/quint/src/types/aliasInliner.ts
@@ -133,7 +133,7 @@ class AliasInliner implements IRTransformer {
   }
 }
 
-function resolveAlias(lookupTable: LookupTable, type: QuintType): QuintType {
+export function resolveAlias(lookupTable: LookupTable, type: QuintType): QuintType {
   if (type.kind === 'const' && type.id) {
     const aliasValue = lookupTable.get(type.id)
     if (aliasValue && aliasValue.kind === 'typedef' && aliasValue.type) {

--- a/quint/src/types/constraintGenerator.ts
+++ b/quint/src/types/constraintGenerator.ts
@@ -108,6 +108,7 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
   protected tvs: Map<bigint, QuantifiedVariables> = new Map()
   // Temporary type map only for types in scope for a certain declaration
   protected typesInScope: Map<bigint, TypeScheme> = new Map()
+  protected savedTypesInScope: Map<bigint, TypeScheme> = new Map()
 
   // Track location descriptions for error tree traces
   private location: string = ''
@@ -275,8 +276,17 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
     this.addToResults(e.id, this.fetchResult(e.expr.id))
   }
 
-  exitDecl(_def: QuintDeclaration) {
-    this.typesInScope = new Map()
+  exitDecl(def: QuintDeclaration) {
+    if (def.kind == 'var' || def.kind == 'const') {
+      this.savedTypesInScope = new Map(this.typesInScope)
+    } else {
+      this.typesInScope.forEach((_, k) => {
+        if (!this.savedTypesInScope.has(k)) {
+          this.typesInScope.delete(k)
+        }
+      })
+    }
+    this.savedTypesInScope = new Map(this.typesInScope)
   }
 
   enterOpDef(def: QuintOpDef) {
@@ -390,15 +400,19 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
     } else {
       const def = this.table.get(nameId)
 
-      // FIXME: We have to check if the annotation is too general for var and consts as well
-      // https://github.com/informalsystems/quint/issues/691
-      if (def?.typeAnnotation) {
-        return right(def.typeAnnotation)
-      }
-
       const id = def?.id
       if (!def || !id) {
         return left(buildErrorLeaf(this.location, `Signature not found for name: ${name}`))
+      }
+
+      if (def.kind === 'var' || def.kind === 'const') {
+        return this.fetchResult(id).map(t => t.type)
+      }
+
+      // FIXME: We have to check if the annotation is too general for var and consts as well
+      // https://github.com/informalsystems/quint/issues/691
+      if (def.typeAnnotation) {
+        return right(def.typeAnnotation)
       }
 
       return this.fetchResult(id).map(t => this.newInstance(t))

--- a/quint/src/types/constraintGenerator.ts
+++ b/quint/src/types/constraintGenerator.ts
@@ -409,8 +409,6 @@ export class ConstraintGeneratorVisitor implements IRVisitor {
         return this.fetchResult(id).map(t => t.type)
       }
 
-      // FIXME: We have to check if the annotation is too general for var and consts as well
-      // https://github.com/informalsystems/quint/issues/691
       if (def.typeAnnotation) {
         return right(def.typeAnnotation)
       }

--- a/quint/src/types/substitutions.ts
+++ b/quint/src/types/substitutions.ts
@@ -190,7 +190,7 @@ function applySubstitutionToRow(table: LookupTable, s: Substitutions, r: Row): R
         other: applySubstitutionToRow(table, s, r.other),
       }
     case 'var': {
-      const sub = s.find(s => s.name === r.name)
+      const sub = s.find(s => s.name === r.name && s.kind === 'row')
       if (sub && sub.kind === 'row') {
         return sub.value
       } else {

--- a/quint/src/types/typeApplicationResolution.ts
+++ b/quint/src/types/typeApplicationResolution.ts
@@ -208,7 +208,7 @@ class TypeMapper implements IRTransformer {
     this.mapper = f
   }
 
-  exitType(t: QuintType): QuintType {
+  enterType(t: QuintType): QuintType {
     return this.mapper(t)
   }
 }

--- a/quint/testFixture/apalache/genericRowParam.qnt
+++ b/quint/testFixture/apalache/genericRowParam.qnt
@@ -1,0 +1,13 @@
+module base {
+  type Generic[other] = { foo: int | other }
+
+  var s: Generic[other]
+}
+
+module genericRowParam {
+  import base.*
+  type Concrete = Generic[{ bar: bool }]
+
+  action init = s' = { foo: 1, bar: true }
+  action step = s' = if (s.bar) { ...s, foo: s.foo + 1 } else s
+}

--- a/quint/testFixture/apalache/inferredStateVar.qnt
+++ b/quint/testFixture/apalache/inferredStateVar.qnt
@@ -1,0 +1,21 @@
+module base {
+  type Generic[other] = { foo: int | other }
+  type Uses[s] = { ctx: Generic[s] }
+
+  var s: Uses[s]
+}
+
+module inferredStateVar {
+  import base.*
+  type Fields = { bar: Set[int] }
+  type Concrete = Generic[Fields]
+  type U = Uses[Concrete]
+
+  pure def aux(s) = { foo: s, bar: Set() }
+  pure def aux2(c: U): U = if (c.ctx.bar.size() > 0) { ctx: c.ctx } else { ctx: c.ctx }
+
+  // By init, we still don't know the type of the bar field
+  action init = s' = { ctx: aux(1) }
+  // By step, we learn the full type
+  action step = s' = aux2(s)
+}

--- a/quint/testFixture/apalache/polyStateVar.qnt
+++ b/quint/testFixture/apalache/polyStateVar.qnt
@@ -1,0 +1,19 @@
+module base {
+  type Generic[other] = { foo: int | other }
+  type Uses[s] = { ctx: Generic[s] }
+
+  var s: Uses[s]
+}
+
+module polyStateVar {
+  import base.*
+  type Fields = { bar: bool }
+  type Concrete = Generic[Fields]
+  type U = Uses[Concrete]
+
+  pure def aux(s: Concrete): Concrete = if (s.bar) { ...s, foo: s.foo + 1 } else s
+  pure def aux2(c: U): U = if (c.ctx.bar) { ctx: { foo: 1, bar: true } } else { ctx: { foo: 2, bar: true } }
+
+  action init = s' = aux2({ ctx: { foo: 1, bar: true } })
+  action step = s' = { ctx: aux(s.ctx) }
+}


### PR DESCRIPTION
Hello :octocat: 

This fixes https://github.com/informalsystems/quint/issues/1698 and closes https://github.com/informalsystems/quint/issues/691 as we actually don't need to ensure that anymore, as long as we give Apalache a concrete inferred type (more on that in #1755)

There are three nasty bug fixes here, covered by the following integration tests that all break on main with Apalache errors:

<img width="1350" height="1493" alt="image" src="https://github.com/user-attachments/assets/cd17eb1a-f4cf-434e-ad6d-7e9e54277017" />

A note here on "bug": one of this was an actual bug, but the other two were more consequences of us not planning to allow polymorphic types for state variables. This constraint was a big problem for the new library/framework we are working on (launch is soon!), as we want to define polymorphic variables there that will be specialized as the library's users define their application-specific types. I'm solving this by actually allowing polymorphic variables and then using the inferred type to make Apalache happy.

<!-- Please ensure that your PR includes the following, as needed -->
- [X] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [X] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [X] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
