### PR TITLE
Remove GH bear token from rust backend download

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,6 +84,11 @@ jobs:
         # These tests fail on windows currently
         # See https://github.com/anko/txm/issues/10
         if: matrix.operating-system != 'windows-latest'
+      - name: Rust backend integration tests
+        run: cd ./quint && npm run rust-integration
+        # These tests fail on windows currently
+        # See https://github.com/anko/txm/issues/10
+        if: matrix.operating-system != 'windows-latest'
 
   quint-integration-tests-aggregator:
     name: TXM tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed several issues with the integration of Apalache (#1754)
+- Fixed unauthorized errors when downloading the Rust backend (#1763)
 
 ### Security
 

--- a/quint/package.json
+++ b/quint/package.json
@@ -82,6 +82,7 @@
     "integration": "txm cli-tests.md && txm io-cli-tests.md",
     "apalache-integration": "txm apalache-tests.md",
     "apalache-dist": "txm apalache-dist-tests.md",
+    "rust-integration": "txm rust-backend-tests.md",
     "generate": "npm run antlr && npm run compile && npm link && npm run api-docs && npm run update-fixtures",
     "antlr": "antlr4ts -visitor ./src/generated/Quint.g4 && antlr4ts -visitor ./src/generated/Effect.g4",
     "api-docs": "quint docs ./src/builtin.qnt > ../docs/content/docs/builtin.md",

--- a/quint/rust-backend-tests.md
+++ b/quint/rust-backend-tests.md
@@ -1,0 +1,27 @@
+# Integration tests with the Rust backend
+
+Tests in this script verify that Quint can download and run simulation with the
+`rust` backend (`--backend rust`).
+
+<!-- !test program
+bash -
+-->
+
+## Downloads the rust backend and run a simulation
+
+Asserts that on an empty `QUINT_HOME` directory, it downloads the latest Rust
+evaluator from GitHub releases. Note that a successful run indicates a
+successful download and execution of the spec with the set backend.
+
+<!-- !test in download and run -->
+```
+QUINT_HOME=$(mktemp -d) quint run \
+  --backend=rust \
+  ./testFixture/simulator/gettingStarted.qnt \
+  | grep -o "Downloading Rust evaluator from https://api.github.com/repos/informalsystems/quint/releases/assets/"
+```
+
+<!-- !test out download and run -->
+```
+Downloading Rust evaluator from https://api.github.com/repos/informalsystems/quint/releases/assets/
+```

--- a/quint/src/quintRustWrapper.ts
+++ b/quint/src/quintRustWrapper.ts
@@ -226,7 +226,7 @@ async function fetchEvaluator(version: string, assetName: string, executable: st
   console.log(chalk.gray(`Fetching Rust evaluator ${version}...`))
 
   // Create a GitHub client
-  const client = new GitHubClient(process.env.GITHUB_TOKEN)
+  const client = new GitHubClient()
 
   // Fetch the release from GitHub
   const release = await client.fetchRelease(version)
@@ -354,12 +354,6 @@ async function exists(filePath: string): Promise<boolean> {
 }
 
 class GitHubClient {
-  private token: string | undefined
-
-  constructor(token: string | undefined) {
-    this.token = token
-  }
-
   async fetch(url: string, accept: string): Promise<Response> {
     const options: any = {
       redirect: 'follow',
@@ -368,10 +362,6 @@ class GitHubClient {
         'User-Agent': 'quint-evaluator-fetch',
         Accept: accept,
       },
-    }
-
-    if (this.token) {
-      options.headers['Authorization'] = `Bearer ${this.token} `
     }
 
     const response = await fetch(url, options)


### PR DESCRIPTION
GitHub seems to validate tokens regardless of the resource visibility. If the user has an invalid token in their environment, downloading the rust backend will fail even though it's publicly available in the project's release assets.

This patch removes the GITHUB_TOKEN from the requests to list and download assets from GitHub to avoid unauthorized issues. Moreover, it includes an integration test that verifies quint is able to download the latest rust banckend for further coverages of this workflow.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->

Closes https://github.com/informalsystems/quint/issues/1763.