### PR TITLE
Clariy `quint test` commands in the Alpenglow blog post

### DIFF
--- a/docs/content/posts/alpenglow.mdx
+++ b/docs/content/posts/alpenglow.mdx
@@ -426,7 +426,7 @@ For me, this run is like a space/time diagram that I would draw on a whiteboard 
 
 The Quint run is like this drawing but saved within a file in the repository as an executable artifact. Indeed, you can call `disagreementExampleTest` from within the REPL, which will execute the run. You will now be in the final state of this run, and you can use `s` to explore it.
 
-From the command line (outside of the REPL), you can also call `quint test statemachine.qnt` that will execute the test and show the result. You can use `quint test` in CI within Github to make sure that changing the specification didn't introduce weird behaviors.
+From the command line (outside of the REPL), you can also call `quint test statemachine.qnt --main too_many_byz` that will execute the test and show the result. You can use `quint test <file> --main <module>` in CI within Github to make sure that changing the specification didn't introduce weird behaviors.
 
 
 So, Quint runs are executable whiteboard drawings! You can use the run above to explain to your friends why Alpenglow needs more than ⅘ of correct voting power!


### PR DESCRIPTION
The current wording in the Alpenglow blog post leads inexperienced users to believe that by running `quint test statemachine.qnt` all tests in the file will be executed, which isn't true. The test command must be called with the spec file and the main module in this example.

Moreover, it mentions that `quint test` can be used in CI to run tests, which is true but, the wording is overloaded by other commonly used tooling, like `npm test` for example, where the expectation is that by simply running `test` it runs all tests in the codebase. That isn't true for quint (yet), so it's worth expanding to the full command one would use in CI right now.

~Finally, the final spec ended having the run [called](https://github.com/informalsystems/Alpenglow-spec/blob/main/statemachine.qnt#L453) `disagreement_example_Test` instead of `disagreementExampleTest`.~ (discussed [here](https://github.com/informalsystems/quint/pull/1765#discussion_r2349498552))