### PR TITLE
Normalize Apalache traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump Apalache to 0.50.3 (fix counterexamples for `apalache::generate`)
 - Bump Apalache to 0.50.2 (increasing the GRPC message size to 1GB)
+- Apalache traces are now normalized (#1760)
 
 ### Deprecated
 ### Removed

--- a/quint/apalache-tests.md
+++ b/quint/apalache-tests.md
@@ -189,6 +189,30 @@ An example execution:
 [violation] Found an issue (duration).
 ```
 
+## Violations are reported in normalized form
+
+NOTE: without trace normalization, the last map in the state may show with keys
+in any arbitrary order.
+
+<!-- !test in trace normalization -->
+```
+output=$(quint verify ./testFixture/apalache/mapStateVar.qnt --invariant never_full)
+exit_code=$?
+echo "$output" | grep '\[State 3\]'
+exit $exit_code
+```
+
+<!-- !test exit 1 -->
+<!-- !test err trace normalization -->
+```
+error: found a counterexample
+```
+
+<!-- !test out trace normalization -->
+```
+[State 3] { data: Map("a" -> 42, "b" -> 42, "c" -> 42) }
+```
+
 ## Temporal properties
 
 ### Can verify with single temporal property

--- a/quint/src/cliReporting.ts
+++ b/quint/src/cliReporting.ts
@@ -18,7 +18,7 @@ import {
 } from './cliCommands'
 import { writeFileSync } from 'fs'
 import { resolve } from 'path'
-import { ofItf, toItf } from './itf'
+import { ofItfNormalized, toItf } from './itf'
 import { addItfHeader, expandNamedOutputTemplate, expandOutputTemplate, mkErrorMessage, toExpr } from './cliHelpers'
 import { Either, left } from '@sweet-monads/either'
 import { cwd } from 'process'
@@ -136,7 +136,7 @@ export function processVerifyResult(
       return { ...stage, status: 'ok', errors: [] }
     })
     .mapLeft(err => {
-      const trace: QuintEx[] | undefined = err.traces ? ofItf(err.traces[0]) : undefined
+      const trace: QuintEx[] | undefined = err.traces ? ofItfNormalized(err.traces[0]) : undefined
       const status = trace !== undefined ? 'violation' : 'failure'
 
       if (trace !== undefined) {

--- a/quint/src/itf.ts
+++ b/quint/src/itf.ts
@@ -11,9 +11,8 @@
 
 import { Either, left, merge, right } from '@sweet-monads/either'
 import { chunk } from 'lodash'
-import { QuintApp, QuintStr } from './ir/quintIr'
-
-import { QuintEx } from './ir/quintIr'
+import { QuintApp, QuintEx, QuintStr } from './ir/quintIr'
+import rv from './runtime/impl/runtimeValue'
 
 /** The type of IFT traces.
  * See https://github.com/apalache-mc/apalache/blob/main/docs/src/adr/015adr-trace.md */
@@ -249,4 +248,17 @@ export function ofItf(itf: ItfTrace): QuintEx[] {
   }
 
   return itf.states.map(ofItfValue)
+}
+
+/**
+ * Normalizes the given ItfTrace by converting its state to runtime values and
+ * back to quint expressions. Note that this round trip results in normalized
+ * expression where, for example, maps and sets are sorted alphabetically.
+ * Usefull for pretty printing traces produced by Apalache.
+ *
+ * @param itf - The ItfTrace to normalize
+ * @returns An array of its states as normalized quint expressions
+ */
+export function ofItfNormalized(itf: ItfTrace): QuintEx[] {
+  return ofItf(itf).map(rv.fromQuintEx).map(rv.toQuintEx)
 }

--- a/quint/test/itf.test.ts
+++ b/quint/test/itf.test.ts
@@ -4,7 +4,7 @@ import { quintExAreEqual } from './util'
 import { zip } from '../src/util'
 
 import { buildExpression } from './builders/ir'
-import { ItfTrace, ofItf, toItf } from '../src/itf'
+import { ItfTrace, ofItf, ofItfNormalized, toItf } from '../src/itf'
 
 describe('toItf', () => {
   it('converts two states', () => {
@@ -111,5 +111,27 @@ describe('toItf', () => {
       zip(roundTripTrace, trace).every(([a, b]) => quintExAreEqual(a, b)),
       `round trip conversion of trace failed`
     )
+  })
+})
+
+describe('ofItfNormalized', () => {
+  it('returns normalized quint expressions', () => {
+    const unnormalized = `{
+  a: Set(3, 2, 1),
+  b: { c: 3, b: 2, a: 1  },
+  c: Map("c" -> 3, "b" -> 2, "a" -> 1)
+}`
+
+    const normalized = `{
+  a: Set(1, 2, 3),
+  b: { a: 1, b: 2, c: 3 },
+  c: Map("a" -> 1, "b" -> 2, "c" -> 3)
+}`
+
+    const unnormalizedTrace = [buildExpression(unnormalized)]
+    const normalizedTrace = [buildExpression(normalized)]
+    const unnormalizedItf = toItf(['a', 'b', 'c'], unnormalizedTrace).unwrap()
+    const normalizedExp = ofItfNormalized(unnormalizedItf)
+    assert(zip(normalizedExp, normalizedTrace).every(([a, b]) => quintExAreEqual(a, b)))
   })
 })

--- a/quint/testFixture/apalache/mapStateVar.qnt
+++ b/quint/testFixture/apalache/mapStateVar.qnt
@@ -1,0 +1,17 @@
+module mapStateVar {
+  pure val Keys = Set("a", "b", "c")
+
+  var data: str -> int
+
+  action init = {
+    data' = Map()
+  }
+
+  action step = {
+    nondet key = Keys.oneOf()
+    data' = data.put(key, 42)
+  }
+
+  // NOTE: Violates after all `Keys` have been added to `data`.
+  val never_full = data.keys().size() < Keys.size()
+}


### PR DESCRIPTION
Apalache's traces are not normalized like quint simulator traces are. That means, for example, that maps and sets are going to be printed with elements in random order as opposed to alphabetically sorted.

This patch makes use of quint runtime value conversions to normalize Apalache produced traces for better readability and conformance with other quint generated traces.

Closes https://github.com/informalsystems/quint/issues/1760.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
