### PR TITLE
Print commands in file's expression history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- The REPL now prints file embedded expressions when executing them (#1774)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -1052,6 +1052,36 @@ quint -q -r \
 cd - > /dev/null
 ```
 
+### REPL prints command history
+
+<!-- !test in repl prints command history -->
+```
+quint -r ../examples/tutorials/repl/kettle.qnt | tail -n +2 | head -n 19
+```
+
+<!-- !test out repl prints command history -->
+```
+Type ".exit" to exit, or ".help" for more information
+Evaluating expression history in ../examples/tutorials/repl/kettle.qnt
+>>> 1 + 3
+4
+>>> Set(1, 2, 3).map(i => i * 2)
+Set(2, 4, 6)
+>>> fahrenheit(freezingTemperature)
+32
+>>> fahrenheit(boilingTemperature)
+212
+>>> 0.to(100).exists(celsius => fahrenheit(celsius) == celsius)
+false
+>>> (-100).to(100).exists(celsius => fahrenheit(celsius) == celsius)
+true
+>>> veryCold
+-40
+>>> veryHot
+104
+>>> temperature
+```
+
 ### test --verbosity=3 outputs a trace
 
 <!-- !test exit 1 -->

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -291,11 +291,11 @@ export function quintRepl(
     }
 
     if (newState.exprHist) {
-      const expressionsToEvaluate = newState.exprHist
+      const exprHist = newState.exprHist
       newState.exprHist = []
-      expressionsToEvaluate.forEach(expr => {
-        tryEvalAndClearRecorder(out, newState, expr)
-      })
+      if (exprHist.length > 0) {
+        replayExprHistory(newState, filename, exprHist)
+      }
     }
 
     state.moduleHist = newState.moduleHist
@@ -303,6 +303,20 @@ export function quintRepl(
     state.compilationState = newState.compilationState
     state.evaluator = newState.evaluator
     state.nameResolver = newState.nameResolver
+  }
+
+  function replayExprHistory(state: ReplState, filename: string, exprHist: string[]) {
+    if (verbosity.hasReplBanners(options.verbosity)) {
+      out(chalk.gray(`Evaluating expression history in ${filename}\n`))
+    }
+    exprHist.forEach(expr => {
+      if (verbosity.hasReplPrompt(options.verbosity)) {
+        out(settings.prompt)
+        out(expr.replaceAll('\n', `\n${settings.continuePrompt}`))
+        out('\n')
+      }
+      tryEvalAndClearRecorder(out, state, expr)
+    })
   }
 
   // the read-eval-print loop


### PR DESCRIPTION
When entering the repl, if expressions exist in the form of /*! expr !*/ comments in the quint source code, those are evaluated by the repl upon loading the file. However, the repl won't show what commands were executed, only their output.

This patch changes this behavior so that when loading a module, unless in quiet mode, the reply will show which commands were executed after loading.

This changes the output from:

```
$ quint -r examples/tutorials/repl/kettle.qnt
Quint REPL 0.28.0
Type ".exit" to exit, or ".help" for more information
4
Set(2, 4, 6)
32
212
false
true
-40
104
runtime error: error: [QNT502] Variable temperature not set
temperature
^^^^^^^^^^^
```

To:

```
$ quint -r examples/tutorials/repl/kettle.qnt
Quint REPL 0.28.0
Type ".exit" to exit, or ".help" for more information
Evaluating expression history in ../examples/tutorials/repl/kettle.qnt
>>> 1 + 3
4
>>> Set(1, 2, 3).map(i => i * 2)
Set(2, 4, 6)
>>> fahrenheit(freezingTemperature)
32
>>> fahrenheit(boilingTemperature)
212
>>> 0.to(100).exists(celsius => fahrenheit(celsius) == celsius)
false
>>> (-100).to(100).exists(celsius => fahrenheit(celsius) == celsius)
true
>>> veryCold
-40
>>> veryHot
104
>>> temperature
runtime error: error: [QNT502] Variable temperature not set
temperature
^^^^^^^^^^^
```

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
