### PR TITLE
Fix copy and past for multi-line expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed copying and pasting multi-line expressions from the REPL (#1776)
+
 ### Security
 
 ## v0.28.0 -- 2025-09-16

--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -327,7 +327,9 @@ export function quintRepl(
     const g = (s: string): string => {
       return chalk.gray(s)
     }
-    if (!line.startsWith('.')) {
+    // The continue prompt is handled by `nextLine` as the input may be acopy
+    // and paste from the reply itself.
+    if (!line.startsWith('.') || line.startsWith(settings.continuePrompt)) {
       // an input to evaluate
       nextLine(line)
     } else {

--- a/quint/test/repl.test.ts
+++ b/quint/test/repl.test.ts
@@ -707,6 +707,11 @@ describe('repl ok', () => {
     const input = dedent(
       `>>> 1 + 1
       |
+      |>>> all {
+      |...   true,
+      |...   true
+      |... }
+      |
       | >>> if (true) {
       | ...   3
       | ... } else {
@@ -726,6 +731,12 @@ describe('repl ok', () => {
       `>>> >>> 1 + 1
       |... 
       |2
+      |>>> >>> all {
+      |... ...   true,
+      |... ...   true
+      |... ... }
+      |... 
+      |true
       |>>>  >>> if (true) {
       |...  ...   3
       |...  ... } else {


### PR DESCRIPTION
The repl supports trimming the prompt and the continue prompt prefixes when copying and pasting previous expressions form the repl. However, the '...' prefix of multi-line expressions confuses the interpreter into thinking that those lines are special commands instead.

This patches fixes the repl's line handler so that lines starting with '...' continue prompt prefix are interpreted as quint expressions, thus allowing for copying and pasting multi-line commands from the repl itself.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
