### PR TITLE
Refactor progress reporter into a trait

### DIFF
--- a/evaluator/benches/simulation.rs
+++ b/evaluator/benches/simulation.rs
@@ -5,11 +5,12 @@ use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use quint_evaluator::helpers;
+use quint_evaluator::progress;
 
 fn run_in_rust(file_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let parsed = helpers::parse_from_path(file_path, "init", "step", Some("inv"), None)?;
 
-    let result = parsed.simulate(10, 1_000, 0, None);
+    let result = parsed.simulate(10, 1_000, 0, progress::no_report());
 
     match result {
         Ok(r) => assert!(r.result),

--- a/evaluator/src/lib.rs
+++ b/evaluator/src/lib.rs
@@ -12,6 +12,7 @@ pub mod log;
 pub mod nondet;
 pub mod normalizer;
 pub mod picker;
+pub mod progress;
 pub mod rand;
 pub mod simulator;
 pub mod storage;

--- a/evaluator/src/progress.rs
+++ b/evaluator/src/progress.rs
@@ -1,0 +1,57 @@
+//! The evaluator's progress report module.
+
+use serde_json::Value;
+
+/// A progress reporter.
+pub trait Reporter {
+    /// Reports that the system has moved to the next sample.
+    fn next_sample(&mut self);
+}
+
+/// A noop reporter that produces no output.
+struct NoReport;
+
+impl Reporter for NoReport {
+    fn next_sample(&mut self) {}
+}
+
+#[inline]
+pub fn no_report() -> impl Reporter {
+    NoReport
+}
+
+/// A reporter that writes progress in JSON format to the std error output.
+#[derive(Default)]
+struct JsonStdErr {
+    current_samples: usize,
+    total_samples: usize,
+}
+
+impl JsonStdErr {
+    #[inline]
+    fn fmt(samples: usize, total: usize) -> Value {
+        let percentage = (samples as f64 / total as f64 * 100.0).round() as u32;
+        serde_json::json!({
+            "type": "progress",
+            "current": samples,
+            "total": total,
+            "percentage": percentage
+        })
+    }
+}
+
+impl Reporter for JsonStdErr {
+    fn next_sample(&mut self) {
+        self.current_samples += 1;
+        let progress = Self::fmt(self.current_samples, self.total_samples);
+        eprintln!("{progress}");
+    }
+}
+
+#[inline]
+pub fn json_std_err_report(total_samples: usize) -> impl Reporter {
+    JsonStdErr {
+        total_samples,
+        ..Default::default()
+    }
+}

--- a/evaluator/tests/simulator_tests.rs
+++ b/evaluator/tests/simulator_tests.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use quint_evaluator::helpers;
+use quint_evaluator::{helpers, progress};
 
 #[test]
 fn tictactoe_ok() {
@@ -8,7 +8,7 @@ fn tictactoe_ok() {
 
     let parsed = helpers::parse_from_path(file_path, "init", "step", Some("inv"), None).unwrap();
     // Pass an invariant that should hold
-    let result = parsed.simulate(10, 100, 0, None);
+    let result = parsed.simulate(10, 100, 0, progress::no_report());
     assert!(result.is_ok());
     // Should not find violation
     assert!(result.unwrap().result);
@@ -21,7 +21,7 @@ fn tictactoe_violation() {
     let parsed =
         helpers::parse_from_path(file_path, "init", "step", Some("XHasNotWon"), None).unwrap();
     // Pass an invariant that should not hold
-    let result = parsed.simulate(10, 100, 0, None);
+    let result = parsed.simulate(10, 100, 0, progress::no_report());
     assert!(result.is_ok());
     // Should find violation
     assert!(!result.unwrap().result);
@@ -36,7 +36,7 @@ fn instances_ok() {
         helpers::parse_from_path(file_path, "init", "step", Some("inv"), Some("instances"))
             .unwrap();
     // Pass an invariant that should hold
-    let result = parsed.simulate(10, 100, 0, None);
+    let result = parsed.simulate(10, 100, 0, progress::no_report());
     assert!(result.is_ok());
     // Should not find violation
     assert!(result.unwrap().result);
@@ -51,7 +51,7 @@ fn instance_overrides_ok() {
         helpers::parse_from_path(file_path, "init", "step", Some("inv2"), Some("instances"))
             .unwrap();
     // Pass an invariant that should hold
-    let result = parsed.simulate(10, 100, 0, None);
+    let result = parsed.simulate(10, 100, 0, progress::no_report());
     assert!(result.is_ok());
     // Should not find violation
     assert!(result.unwrap().result);
@@ -71,7 +71,7 @@ fn one_of_empty_set_ok() {
     )
     .unwrap();
 
-    let result = parsed.simulate(10, 100, 0, None);
+    let result = parsed.simulate(10, 100, 0, progress::no_report());
 
     // The simulation should succeed without runtime errors
     assert!(result.is_ok());


### PR DESCRIPTION
In preparation to introducing parallelism to the simulator, this patch separates reporting into its own trait so that in the future it's possible to implement a type of progress reporter that can be shared between threads.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
