### PR TITLE
Introduce a shared reporter and reporting thread

### DIFF
--- a/evaluator/src/progress.rs
+++ b/evaluator/src/progress.rs
@@ -1,5 +1,15 @@
 //! The evaluator's progress report module.
 
+use std::{
+    io::{self, Write},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
 use serde_json::Value;
 
 /// A progress reporter.
@@ -53,5 +63,67 @@ pub fn json_std_err_report(total_samples: usize) -> impl Reporter {
     JsonStdErr {
         total_samples,
         ..Default::default()
+    }
+}
+
+/// The interval beteween reports when using a reporter thread.
+const REPORT_THREAD_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A reporter thread handler.
+///
+/// It holds a reference to a `Reporter` that can be shared across threads, and
+/// a `JoinHandler` for its running thread. The thread gets dropped when the
+/// `ReporterThread` instance gets dropped.
+pub struct ReporterThread {
+    pub reporter: Arc<SharedReporter>,
+    _handler: JoinHandle<()>,
+}
+
+/// A shared implementation of the `Reporter` trait.
+///
+/// Reports only mutate local state atomically. The reporter thread flushes
+/// reports to std error periodically.
+pub struct SharedReporter {
+    current_samples: AtomicUsize,
+    total_samples: usize,
+}
+
+impl Reporter for Arc<SharedReporter> {
+    fn next_sample(&mut self) {
+        self.current_samples.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+pub fn spawn_reporter_thread(total_samples: usize) -> ReporterThread {
+    let reporter = Arc::new(SharedReporter {
+        current_samples: AtomicUsize::new(0),
+        total_samples,
+    });
+
+    let handler = {
+        let reporter = Arc::clone(&reporter);
+        thread::Builder::new()
+            .name("reporter-thread".to_owned())
+            .spawn(|| reporter_thread_loop(reporter))
+            .expect("failed to spawn reporter thread")
+    };
+
+    ReporterThread {
+        _handler: handler,
+        reporter,
+    }
+}
+
+fn reporter_thread_loop(reporter: Arc<SharedReporter>) {
+    let mut stderr = io::stderr().lock();
+    let mut last_report = 0;
+    loop {
+        let curr_report = reporter.current_samples.load(Ordering::Relaxed);
+        if curr_report != last_report {
+            last_report = curr_report;
+            let progress = JsonStdErr::fmt(curr_report, reporter.total_samples);
+            writeln!(stderr, "{progress}").expect("failed to write to stderr");
+        }
+        thread::sleep(REPORT_THREAD_INTERVAL);
     }
 }


### PR DESCRIPTION
This patch introduces an instance of a reporter that can be shared between multiple threads. Reports accumulate in memory atomically and are periodically reported by a separate thread.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
