### PR TITLE
Introduce parallel simulations

### DIFF
--- a/evaluator/Cargo.toml
+++ b/evaluator/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [profile.release]
 codegen-units = 1
 lto = "thin"
+panic = 'abort'
+
+[profile.dev]
+panic = 'abort'
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/evaluator/src/simulator.rs
+++ b/evaluator/src/simulator.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 /// Simulation input that depends on the typescript Quint tool.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ParsedQuint {
     pub init: QuintEx,
     pub step: QuintEx,


### PR DESCRIPTION
This patch receives a `nthreads` input from the quint CLI. If present and more than 1, it runs simulations in parallel using the specified number of threads.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
