### PR TITLE
Use parallel simulations with rust backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for passing commands to the REPL (#1768)
+- Added support for running simulations in multiple threads with the rust backend (#1637)
 
 ### Changed
 

--- a/quint/rust-backend-tests.md
+++ b/quint/rust-backend-tests.md
@@ -13,10 +13,14 @@ Asserts that on an empty `QUINT_HOME` directory, it downloads the latest Rust
 evaluator from GitHub releases. Note that a successful run indicates a
 successful download and execution of the spec with the set backend.
 
+This test passes the `--n-threads` flag to the rust backend to check that the
+CLI accepts it correctly.
+
 <!-- !test in download and run -->
 ```
-QUINT_HOME=$(mktemp -d) quint run \
+QUINT_HOME="$(mktemp -d)" quint run \
   --backend=rust \
+  --n-threads=4 \
   ./testFixture/simulator/gettingStarted.qnt \
   | grep -o "Downloading Rust evaluator from https://api.github.com/repos/informalsystems/quint/releases/assets/"
 ```

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -10,6 +10,7 @@
  * @author Igor Konnov, konnov.phd, 2024
  */
 
+import os from 'os'
 import yargs from 'yargs/yargs'
 
 import {
@@ -256,6 +257,11 @@ const runCmd = {
         desc: 'the maximum on the number of steps in every trace',
         type: 'number',
         default: 20,
+      })
+      .option('n-threads', {
+        desc: 'the number of threads to use when running simulations with the `rust` backend',
+        type: 'number',
+        default: os.cpus().length,
       })
       .option('init', {
         desc: 'name of the initializer action',

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -423,7 +423,8 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
       witnesses,
       prev.args.maxSamples,
       prev.args.maxSteps,
-      prev.args.nTraces ?? 1
+      prev.args.nTraces ?? 1,
+      prev.args.nThreads
     )
   } else {
     // Use the typescript simulator

--- a/quint/src/quintRustWrapper.ts
+++ b/quint/src/quintRustWrapper.ts
@@ -69,7 +69,8 @@ export class QuintRustWrapper {
     witnesses: QuintEx[],
     nruns: number,
     nsteps: number,
-    ntraces: number
+    ntraces: number,
+    nthreads: number
   ): Promise<Outcome> {
     const exe = await getRustEvaluatorPath()
     const args = ['simulate-from-stdin']
@@ -81,6 +82,7 @@ export class QuintRustWrapper {
         nruns: nruns,
         nsteps: nsteps,
         ntraces: ntraces,
+        nthreads: nthreads,
       },
       replacer
     )


### PR DESCRIPTION
This patch makes the CLI call the rust backend with the available number of CPUs by default, thus runnig simulations in parallel.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->

Closes #1637.