### PR TITLE
Move rust integration tests to a pre-release step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,11 +84,6 @@ jobs:
         # These tests fail on windows currently
         # See https://github.com/anko/txm/issues/10
         if: matrix.operating-system != 'windows-latest'
-      - name: Rust backend integration tests
-        run: cd ./quint && npm run rust-integration
-        # These tests fail on windows currently
-        # See https://github.com/anko/txm/issues/10
-        if: matrix.operating-system != 'windows-latest'
 
   quint-integration-tests-aggregator:
     name: TXM tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,20 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Compile
         run: npm ci
-      - name: Test
+      - name: Run unit tests
         run: npm run test
+      - name: Run integration tests
+        run: |
+          # Link quint to the system path
+          npm link
+          # Fetch the latest apalache release
+          make -C .. apalache
+          # Start the apalache server
+          _build/apalache/bin/apalache-mc server &
+          # Wait for the server to start
+          sleep 5
+          # Run the integration tests
+          npm run all-integration
       - name: Extract release notes
         # Get the release notes for the version by printing all lines between lines
         # starting with the version header and ending with the next version header,

--- a/quint/package.json
+++ b/quint/package.json
@@ -83,6 +83,7 @@
     "apalache-integration": "txm apalache-tests.md",
     "apalache-dist": "txm apalache-dist-tests.md",
     "rust-integration": "txm rust-backend-tests.md",
+    "all-integration": "npm run integration && npm run apalache-integration && npm run rust-integration",
     "generate": "npm run antlr && npm run compile && npm link && npm run api-docs && npm run update-fixtures",
     "antlr": "antlr4ts -visitor ./src/generated/Quint.g4 && antlr4ts -visitor ./src/generated/Effect.g4",
     "api-docs": "quint docs ./src/builtin.qnt > ../docs/content/docs/builtin.md",

--- a/quint/rust-backend-tests.md
+++ b/quint/rust-backend-tests.md
@@ -3,6 +3,8 @@
 Tests in this script verify that Quint can download and run simulation with the
 `rust` backend (`--backend rust`).
 
+Note that these tests only run before releases.
+
 <!-- !test program
 bash -
 -->


### PR DESCRIPTION
Rust integration tests are flaky when running on a per PR basis due to the GH API rate limit that prevents us from downloading the evaluator multiple times in parallel. This patch moves the integration test to a pre-release step so it runs only as a sanity check before releases.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
