### PR TITLE
[website] Remove announcement banner

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -5,7 +5,6 @@ import { getPageMap } from 'nextra/page-map'
 import { InformalSystemsLogo } from '../components/home/InformalSystemsLogo'
 import '../style.css'
 import { LogoSwitcher } from '../components/LogoSwitcher'
-import { AnnouncementBanner } from '../components/AnnouncementBanner'
 
 export const metadata = {
   title: 'Quint',
@@ -81,7 +80,6 @@ export default async function RootLayout({ children }) {
         <Layout
           navbar={navbar}
           footer={footer}
-          banner={<AnnouncementBanner />}
           pageMap={await getPageMap()}
           docsRepositoryBase="https://github.com/informalsystems/quint/blob/main/docs"
           sidebar={{


### PR DESCRIPTION
Hello :octocat: 

Removing the Choreo Launch banner from the website since the date has past. We still have a [new] badge by Choreo's tab which should draw people's attention.

I'm keeping the component for the banner as we'll likely have other announcements in the future, and then we can re-use that.

Preview here: https://gabriela-website-remove-banner--quint-docs.netlify.app/