### PR TITLE
Fix double free when using LocalHipStr

### DIFF
--- a/evaluator/src/ir.rs
+++ b/evaluator/src/ir.rs
@@ -2,13 +2,16 @@
 //! input.
 
 use fxhash::FxBuildHasher;
-use hipstr::LocalHipStr;
+use hipstr::HipStr;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub type QuintId = u64;
-pub type QuintName = LocalHipStr<'static>;
+// NOTE: be aware of a bug in HipStr where a LocalHipStr is allowed to cross
+// thread boundaries by implementing Send, however, it causes a double free on
+// large heap-allocated strings.
+pub type QuintName = HipStr<'static>;
 
 #[derive(Debug, Clone, Error, PartialEq, Serialize)]
 #[error("[{code}] {message}")]

--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -234,8 +234,8 @@ fn simulate_in_parallel(
     for i in 0..nthreads {
         // FIXME: it should be possible to share the `ParsedQuint` across
         // threads since it's immutable after the parsing phase. However, its
-        // internals use `hipstr::LocalHipStr` and other data structures that
-        // are thread-local. We'll clone the whole `ParsedQuint` here for now.
+        // internals use data structures that are thread-local. We'll clone the
+        // whole `ParsedQuint` here for now.
         let parsed = parsed.clone();
 
         // In the case of a non-exact split, the first thread executes the

--- a/evaluator/src/value.rs
+++ b/evaluator/src/value.rs
@@ -37,10 +37,10 @@ pub type ImmutableVec<T> = GenericVector<T, RcK>;
 /// structure to hold them
 pub type ImmutableMap<K, V> = GenericHashMap<K, V, fxhash::FxBuildHasher, RcK>;
 
-/// Quint strings are immutable, use hipstr's LocalHipStr type, which provides
+/// Quint strings are immutable, use hipstr's HipStr type, which provides
 /// inlined (stack allocated) strings of length up to 23 bytes, and cheap clones
 /// for longer strings.
-pub type Str = hipstr::LocalHipStr<'static>;
+pub type Str = hipstr::HipStr<'static>;
 
 /// A Quint value produced by evaluation of a Quint expression.
 ///


### PR DESCRIPTION
The LocalHipStr is allowed to cross thread boundaries by implementing the Send auto trait. However, on large heap-allocated strings, it causes a double free due to unsynchronized drops.

For the moment, I'm changing the representation of strings to the thread-safe version of HipStr since I've tested it and it works well. We can re-evaluate the library itself as I review #1761 soon.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [x] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
