### PR TITLE
Bump rust evaluator to v0.3.0

### DIFF
--- a/quint/src/quintRustWrapper.ts
+++ b/quint/src/quintRustWrapper.ts
@@ -28,7 +28,7 @@ import { spawn } from 'child_process'
 import { rustEvaluatorDir } from './config'
 import { QuintError } from './quintError'
 
-const QUINT_EVALUATOR_VERSION = 'v0.2.0'
+const QUINT_EVALUATOR_VERSION = 'v0.3.0'
 
 export type ParsedQuint = {
   modules: QuintModule[]


### PR DESCRIPTION
Hello :octocat: 

Bumping rust as I've just cut a release for it https://github.com/informalsystems/quint/actions/runs/18044128929

Following-up, a PR with the typescript release