### PR TITLE
Remove REPL version line from test expectation

### DIFF
--- a/quint/io-cli-tests.md
+++ b/quint/io-cli-tests.md
@@ -1627,12 +1627,11 @@ amWrong
 
 <!-- !test in repl diff -->
 ```
-quint -r ../examples/language-features/counters.qnt::counters init OnPositive OnEven .exit
+quint -r ../examples/language-features/counters.qnt::counters init OnPositive OnEven .exit | tail -n11
 ```
 
 <!-- !test out repl diff -->
 ```
-Quint REPL 0.28.0
 Type ".exit" to exit, or ".help" for more information
 >>> init
 true


### PR DESCRIPTION
Hello :octocat: 

I've forgot to remove the REPL banner from the test output before and now the test fails on new versions of Quint :facepalm: 

Here's the fix