### PR TITLE
Reintroduce pre-release integration tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,32 +17,29 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: "17"
+          node-version: "18"
           registry-url: "https://registry.npmjs.org"
       - name: Compile
         run: npm ci
       - name: Run unit tests
         run: npm run test
-      # FIXME: the Rust backend tests keep failing the CI
-      #        while trying to download the latest binaries
-      #        from GH.
-      # - name: Run integration tests
-      #   run: |
-      #     # Link quint to the system path
-      #     npm link
-      #     # Fetch the latest apalache release
-      #     make -C .. apalache
-      #     # Start the apalache server
-      #     _build/apalache/bin/apalache-mc server &
-      #     # Wait for the server to start
-      #     sleep 5
-      #     # Run the integration tests
-      #     npm run all-integration
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
-      #   # These tests fail on windows currently
-      #   # See https://github.com/anko/txm/issues/10
-      #   if: matrix.operating-system != 'windows-latest'
+      - name: Run integration tests
+        run: |
+          # Link quint to the system path
+          npm link
+          # Fetch the latest apalache release
+          make -C .. apalache
+          # Start the apalache server
+          _build/apalache/bin/apalache-mc server &
+          # Wait for the server to start
+          sleep 5
+          # Run the integration tests
+          npm run all-integration
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # These tests fail on windows currently
+        # See https://github.com/anko/txm/issues/10
+        if: matrix.operating-system != 'windows-latest'
       - name: Extract release notes
         # Get the release notes for the version by printing all lines between lines
         # starting with the version header and ending with the next version header,


### PR DESCRIPTION
These tests were dropped because they were failing and blocking the release. The most likely reason for the failure is that the pipeline was running with node 17, instead of 18, which does not have a globally available `fetch` function.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
