### PR TITLE
Fix doc links in coin lesson

### DIFF
--- a/docs/codetour/lesson3-anatomy/coin.template.qnt
+++ b/docs/codetour/lesson3-anatomy/coin.template.qnt
@@ -116,7 +116,7 @@ type [name] = [tp];
 In the above definition, `[name]` is a unique identifier that will be associated
 with the type, and `[tp]` is the type to be associated with the name, e.g.,
 `int` or `Set[int]`. To see a complete description of all available types, visit the Section
-[Type System 1.2](https://github.com/informalsystems/quint/blob/main/doc/lang.md#type-system-12)
+[Type System 1.2](https://github.com/informalsystems/quint/blob/main/docs/content/docs/lang.md#type-system-12)
 of the language manual.
 
 Although it is convenient to declare type aliases, it is not mandatory.
@@ -400,7 +400,7 @@ The user may submit different inputs, even if the protocol resides in
 two identical states.
 
 For more details, check
-[oneOf](https://github.com/informalsystems/quint/blob/main/doc/builtin.md#pure-def-oneof-seta--a)
+[oneOf](https://github.com/informalsystems/quint/blob/main/docs/content/docs/builtin.md#oneof)
 in the reference manual.
 
         </description>
@@ -483,14 +483,14 @@ the explanation:
    in the map `balances`. If the key `receiver` has no value assigned in
    the map `balances`, REPL would show a runtime error.
    For more details, check
-   [get](https://github.com/informalsystems/quint/blob/main/doc/builtin.md#pure-def-get-a---b-a--b)
+   [get](https://github.com/informalsystems/quint/blob/main/docs/content/docs/builtin.md#get)
    in the reference manual.
 
  - `balances.set(receiver, newBal)` produces a new map, that assigns
    the value of `newBal` to the key `receiver`, and keeps the other key-value
    pairs as in `balances`.
    For more details, check
-   [set](https://github.com/informalsystems/quint/blob/main/doc/builtin.md#pure-def-set-a---b-a-b--a---b)
+   [set](https://github.com/informalsystems/quint/blob/main/docs/content/docs/builtin.md#set)
    in the reference manual.
 
 Now it's time to mint some coins in REPL! Try the following:

--- a/docs/content/docs/lessons/coin.md
+++ b/docs/content/docs/lessons/coin.md
@@ -407,7 +407,7 @@ The user may submit different inputs, even if the protocol resides in
 two identical states.
 
 For more details, check
-[oneOf](https://github.com/informalsystems/quint/blob/main/doc/builtin.md#pure-def-oneof-seta--a)
+[oneOf](https://github.com/informalsystems/quint/blob/main/docs/content/docs/builtin.md#oneof)
 in the reference manual.
 
         
@@ -495,14 +495,14 @@ the explanation:
    in the map `balances`. If the key `receiver` has no value assigned in
    the map `balances`, REPL would show a runtime error.
    For more details, check
-   [get](https://github.com/informalsystems/quint/blob/main/doc/builtin.md#pure-def-get-a---b-a--b)
+   [get](https://github.com/informalsystems/quint/blob/main/docs/content/docs/builtin.md#get)
    in the reference manual.
 
  - `balances.set(receiver, newBal)` produces a new map, that assigns
    the value of `newBal` to the key `receiver`, and keeps the other key-value
    pairs as in `balances`.
    For more details, check
-   [set](https://github.com/informalsystems/quint/blob/main/doc/builtin.md#pure-def-set-a---b-a-b--a---b)
+   [set](https://github.com/informalsystems/quint/blob/main/docs/content/docs/builtin.md#set)
    in the reference manual.
 
 Now it's time to mint some coins in REPL! Try the following:


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
