### PR TITLE
Flip DEPLOY_PRIME_URL and SITE_URL precedence

### DIFF
--- a/docs/config/site.ts
+++ b/docs/config/site.ts
@@ -1,12 +1,12 @@
 function getSiteUrl(): string {
-  // Check for Netlify deploy preview URL
-  if (process.env.DEPLOY_PRIME_URL) {
-    return process.env.DEPLOY_PRIME_URL
-  }
-
   // Check for custom site URL environment variable
   if (process.env.SITE_URL) {
     return process.env.SITE_URL
+  }
+
+  // Check for Netlify deploy URL
+  if (process.env.DEPLOY_PRIME_URL) {
+    return process.env.DEPLOY_PRIME_URL
   }
 
   // Default to production URL


### PR DESCRIPTION
According to Netfliy [docs][1], the DEPLOY_PRIME_URL env var is always available, therefore, we need SITE_URL to be on top if we want to override the site URL in production.

[1]: https://docs.netlify.com/build/configure-builds/environment-variables/

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
