### PR TITLE
fix: resolve Clippy warnings in evaluator

### DIFF
--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -302,7 +302,6 @@ fn to_outcome(source: Arc<String>, result: Result<SimulationResult, QuintError>)
     let best_traces = result.as_ref().ok().map_or_else(Vec::new, |r| {
         r.best_traces
             .iter()
-            .cloned()
             .map(|t| SimulationTrace {
                 // TODO: Fetch seed from the random generator state
                 seed: 0,

--- a/evaluator/tests/deserialization_tests.rs
+++ b/evaluator/tests/deserialization_tests.rs
@@ -1,5 +1,5 @@
 use quint_evaluator::ir::QuintOutput;
-use std::{env, fs::File};
+use std::fs::File;
 
 #[test]
 fn simple() {


### PR DESCRIPTION
Remove redundant `.cloned()` iterator call and unused `env` import.


- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality


