### PR TITLE
Force dowloading the Rust evaluator before release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           # Wait for the server to start
           sleep 5
           # Download the rust evaluator before the tests
-          quint run testFixture/simulator/gettingStarted.qnt --backend rust
+          quint run testFixture/simulator/gettingStarted.qnt --backend rust --max-samples=1 --max-steps=1
           # Run the integration tests
           npm run all-integration
         env:


### PR DESCRIPTION
Hello :octocat: 

We're hitting [problems on CI](https://github.com/informalsystems/quint/actions/runs/21139562605/job/60792590807) due to Rust evaluator not being available by the time we run tests, and then the tests are not prepared to handle downloading.
