### PR TITLE
Add write permission to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     defaults:
       run:
         working-directory: ./quint
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Hello :octocat: 

We are getting
```
👩‍🏭 Creating new GitHub release for tag v0.30.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.30.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (1 retries remaining)
👩‍🏭 Creating new GitHub release for tag v0.30.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (0 retries remaining)
❌ Too many retries. Aborting...
```

When trying to greate a GitHub release in our release workflow. https://github.com/softprops/action-gh-release/issues/400 says we should add this permission or enable the following config, which can't be enabled:
<img width="1662" height="495" alt="image" src="https://github.com/user-attachments/assets/1fc290e4-f30c-454d-b487-ff4073b9b888" />


