### PR TITLE
Fix StateVariable deduplication to use value equality

### DIFF
--- a/quint/src/effects/simplification.ts
+++ b/quint/src/effects/simplification.ts
@@ -94,8 +94,17 @@ function deduplicateEntity(entity: Entity): Entity {
   switch (entity.kind) {
     case 'variable':
       return entity
-    case 'concrete':
-      return { kind: 'concrete', stateVariables: Array.from(new Set<StateVariable>(entity.stateVariables)) }
+    case 'concrete': {
+      // Deduplicate state variables using value equality (name + reference),
+      // not object reference equality which Set would use
+      const unique: StateVariable[] = []
+      entity.stateVariables.forEach(v => {
+        if (!unique.some(u => isEqual(u, v))) {
+          unique.push(v)
+        }
+      })
+      return { kind: 'concrete', stateVariables: unique }
+    }
     case 'union': {
       const nestedEntities = entity.entities.map(v => deduplicateEntity(v))
       const unique: Entity[] = []


### PR DESCRIPTION
The previous implementation used `new Set<StateVariable>()` for deduplication, which relies on object reference equality. This meant that two StateVariable objects with identical `name` and `reference` properties would not be deduplicated if they were different object instances.

Fix: Replace Set-based deduplication with explicit iteration using lodash's `isEqual` for value comparison, matching the approach already used for Entity deduplication in the `union` case.

This ensures StateVariables are properly deduplicated based on their actual property values rather than object identity.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [ ] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
