### PR TITLE
Remove stdout write from LSP-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed LSP-server stopping if `LOG_LEVEL` is not `NONE` (#1874)
+
 ### Security
 
 ## v0.30.0 -- 2026-01-19

--- a/vscode/quint-vscode/server/src/logger.ts
+++ b/vscode/quint-vscode/server/src/logger.ts
@@ -62,7 +62,6 @@ function writeLog(level: LogLevel, ...args: any[]) {
   if (logLevels[LOG_LEVEL] >= logLevels[level]) {
     const message = `[${getTimestamp()}] [${level}] ${args.map(String).join(' ')}`
     logStream.write(message + '\n')
-    process.stdout.write(message + '\n')
   }
 }
 


### PR DESCRIPTION
While debugging the LSP, it's common to enable logging. Current log strategy writes log messages to both stdout and the ~/quint-lsp.log files. However, the LSP process stdout is used to communicate with editors like Emacs using the LSP protocol, thus causing clients to break due to unexpected messages in the socket.

This patch drops logging messages to stdout and keep only the ~/quint-lsp.log file for logging LSP messages.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
