### PR TITLE
Always override console.{log,error} for LSP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed LSP-server stopping if `LOG_LEVEL` is not `NONE` (#1874)
+- Fixed LSP-server crashing upon console.{log, error} messages (#1875)
 
 ### Security
 

--- a/vscode/quint-vscode/server/src/logger.ts
+++ b/vscode/quint-vscode/server/src/logger.ts
@@ -77,13 +77,10 @@ export const logger = {
 }
 
 /**
- * Overrides global `console.log` and `console.error` methods
- * with the logger's `info` and `error` methods, respectively,
- * unless logging is completely disabled (`LOG_LEVEL='NONE'`).
+ * Overrides global `console.log` and `console.error` methods with the logger's
+ * `info` and `error` methods, respectively.
  */
 export function overrideConsole() {
-  if (LOG_LEVEL !== 'NONE') {
-    console.log = logger.info
-    console.error = logger.error
-  }
+  console.log = logger.info
+  console.error = logger.error
 }

--- a/vscode/quint-vscode/server/src/reporting.ts
+++ b/vscode/quint-vscode/server/src/reporting.ts
@@ -15,6 +15,7 @@
 import { Loc, QuintError, QuintModule, SourceMap, findExpressionWithId, findTypeWithId } from '@informalsystems/quint'
 import { Diagnostic, DiagnosticSeverity, Position, Range } from 'vscode-languageserver'
 import { compact } from 'lodash'
+import { logger } from './logger'
 
 /**
  * Assembles a list of diagnostics from pairs of expression ids and their errors
@@ -31,7 +32,7 @@ export function diagnosticsFromErrors(errors: QuintError[], sourceMap: SourceMap
   errors.forEach(error => {
     const loc = sourceMap.get(error.reference!)!
     if (!loc) {
-      console.log(`loc for ${error} not found in source map`)
+      logger.debug(`Loc for ${error} not found in source map`)
     } else {
       const diagnostic = assembleDiagnostic(error, loc)
       const previous = diagnostics.get(loc.source) ?? []


### PR DESCRIPTION
Currently, the code only overrides stdout and stderr if logging is set. However, LSP clients that use std in and out for protocol communication with the LSP server break if non-conforming messages are printed out.

This patch makes it so the code always overrides both std out and err and let the global LOG_LEVEL constant define weather the message is logged or not.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
