### PR TITLE
Make sure LSP logging is cheap when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved LSP-server compilation and analysis to its own worker thread (1876)
+- Improved memory allocation profile of LSP-server log messages (#1877)
 
 ### Deprecated
 ### Removed

--- a/vscode/quint-vscode/server/src/logger.ts
+++ b/vscode/quint-vscode/server/src/logger.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import * as util from 'util'
 import { isMainThread } from 'worker_threads'
 
 /**
@@ -55,14 +56,21 @@ const logStream = fs.createWriteStream(logFile, { flags: 'a' })
 const getTimestamp = (): string => new Date().toISOString().replace('T', ' ').replace('Z', '')
 
 /**
+ * Check if the given log level is enabled.
+ */
+export function isEnabled(level: LogLevel) {
+  return logLevels[LOG_LEVEL] >= logLevels[level]
+}
+
+/**
  * Writes a formatted log message if the current log level permits.
  *
  * @param level - Severity of the log message.
  * @param args - Message arguments to log.
  */
 function writeLog(level: LogLevel, ...args: any[]) {
-  if (logLevels[LOG_LEVEL] >= logLevels[level]) {
-    const message = `[${getTimestamp()}] [${level}] ${args.map(String).join(' ')}`
+  if (isEnabled(level)) {
+    const message = `[${getTimestamp()}] [${level}] ${util.format(...args)}`
     logStream.write(message + '\n')
   }
 }
@@ -79,10 +87,13 @@ export const logger = {
 }
 
 /**
- * Overrides global `console.log` and `console.error` methods with the logger's
- * `info` and `error` methods, respectively.
+ * Overrides global console log methods, with the logger's methods.
  */
 export function overrideConsole() {
+  console.trace = logger.trace
+  console.debug = logger.debug
+  console.info = logger.info
   console.log = logger.info
+  console.warn = logger.warn
   console.error = logger.error
 }

--- a/vscode/quint-vscode/server/src/reporting.ts
+++ b/vscode/quint-vscode/server/src/reporting.ts
@@ -32,7 +32,7 @@ export function diagnosticsFromErrors(errors: QuintError[], sourceMap: SourceMap
   errors.forEach(error => {
     const loc = sourceMap.get(error.reference!)!
     if (!loc) {
-      logger.debug(`Loc for ${error} not found in source map`)
+      logger.debug('Loc for %o not found in source map', error)
     } else {
       const diagnostic = assembleDiagnostic(error, loc)
       const previous = diagnostics.get(loc.source) ?? []

--- a/vscode/quint-vscode/server/src/server.ts
+++ b/vscode/quint-vscode/server/src/server.ts
@@ -36,7 +36,7 @@ import {
 } from 'vscode-languageserver/node'
 import { DocumentUri, TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
-import { logger, overrideConsole } from './logger'
+import { isEnabled, logger, overrideConsole } from './logger'
 
 import {
   AnalysisOutput,
@@ -266,10 +266,16 @@ export class QuintLanguageServer {
     })
 
     connection.onCompletion((params: CompletionParams): CompletionItem[] => {
-      logger.debug(`Completion requested at position ${JSON.stringify(params.position)} in ${params.textDocument.uri}`)
+      if (isEnabled('DEBUG')) {
+        logger.debug(
+          'Completion requested at position %s in %s',
+          JSON.stringify(params.position),
+          params.textDocument.uri
+        )
+      }
 
       if (params.context?.triggerKind !== CompletionTriggerKind.Invoked) {
-        logger.debug(`Completion triggered by non-invoked action, ignoring.`)
+        logger.debug('Completion triggered by non-invoked action, ignoring.')
         return []
       }
 
@@ -277,7 +283,7 @@ export class QuintLanguageServer {
       const document = this.documents.get(params.textDocument.uri)
 
       if (!parsedData || !document) {
-        logger.debug(`No parsed data or document found for completion.`)
+        logger.debug('No parsed data or document found for completion.')
         return []
       }
 
@@ -292,32 +298,34 @@ export class QuintLanguageServer {
       // Use available (possibly stale) analysis data
       const analysisOutput = this.analysisOutputByDocument.get(params.textDocument.uri)
       if (!analysisOutput) {
-        logger.debug(`No analysis output available for completion.`)
+        logger.debug('No analysis output available for completion.')
         return []
       }
 
       if (dotAccessMatch) {
         const baseIdentifier = dotAccessMatch[1]
-        logger.debug(`Detected dot-access on identifier: ${baseIdentifier}`)
+        logger.debug('Detected dot-access on identifier: %s', baseIdentifier)
 
         const ref = [...parsedData.table.entries()].find(([_, v]) => v.name === baseIdentifier)
         if (!ref) {
-          logger.debug(`Could not resolve identifier: ${baseIdentifier}`)
+          logger.debug('Could not resolve identifier: %s', baseIdentifier)
           return []
         }
 
         const [declId, _binding] = ref
         const type = analysisOutput.types.get(declId)?.type
         if (!type) {
-          logger.debug(`No type found for identifier: ${baseIdentifier}`)
+          logger.debug('No type found for identifier: %s', baseIdentifier)
           return []
         }
 
-        logger.debug(
-          `Resolved type for '${baseIdentifier}': ${JSON.stringify(type, (_, v) =>
-            typeof v === 'bigint' ? v.toString() : v
-          )}`
-        )
+        if (isEnabled('DEBUG')) {
+          logger.debug(
+            "Resolved type for '%s': %s",
+            baseIdentifier,
+            JSON.stringify(type, (_, v) => (typeof v === 'bigint' ? v.toString() : v))
+          )
+        }
 
         const builtinCompletions: CompletionItem[] = getSuggestedBuiltinsForType(type).map(op => {
           const docs = loadedBuiltInDocs.get(op.name)
@@ -336,7 +344,7 @@ export class QuintLanguageServer {
       // Fallback: regular identifier completion
       const identifierMatch = triggeringLine?.trim().match(/([a-zA-Z_][a-zA-Z0-9_]*)$/)
       if (!identifierMatch) {
-        logger.debug(`No matching identifier found in line: ${triggeringLine}`)
+        logger.debug('No matching identifier found in line: %s', triggeringLine)
         return []
       }
 
@@ -488,7 +496,7 @@ export class QuintLanguageServer {
     const sourceFile = URI.parse(uri).path
     const diagnostics = diagnosticsByFile.get(sourceFile) ?? []
     this.connection.sendDiagnostics({ uri, diagnostics })
-    logger.debug(`Analysis completed for: ${uri}, errors found: ${diagnostics.length}`)
+    logger.debug('Analysis completed for: %s, errors found: %d', uri, diagnostics.length)
   }
 }
 


### PR DESCRIPTION
Most log messages are interpolating with variables in scope. However, if the intended log level is disabled, those log messages are discarded. This can be specially expensive when calls to JSON.stringify are made in order to produce a log message.

This patch replaces string interpolation with varargs in most calls to the logger so that we only allocate strings that are actually going to be logged. Moveorver, it wraps calls to JSON.stringify into if statements so that we don't serialize objects that won't be shown by the logger.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
