### PR TITLE
Stream JSON values in/out to avoid extra mallocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved LSP-server compilation and analysis to its own worker thread (1876)
 - Improved memory allocation profile of LSP-server log messages (#1877)
+- Stream JSON in and out or rust evaluator to reduce memory allocations (#1882)
 
 ### Deprecated
 ### Removed

--- a/evaluator/src/log.rs
+++ b/evaluator/src/log.rs
@@ -1,7 +1,7 @@
 //! Logging module for the simulation, used by the CLI.
 
-use std::fmt;
 use std::sync::atomic::AtomicBool;
+use std::{fmt, io};
 
 static _HEADERS: &[&str] = &["Parsing", "Simulation", "Result", "Elapsed"];
 
@@ -45,7 +45,7 @@ pub fn log(header: &str, message: &fmt::Arguments<'_>) {
             "header": header,
             "message": message,
         });
-        println!("{json}");
+        serde_json::to_writer(io::stdout(), &json).expect("failed to write log to stdout");
     } else {
         println!("{:>12} {}", header.yellow(), message);
     }

--- a/evaluator/src/progress.rs
+++ b/evaluator/src/progress.rs
@@ -54,7 +54,7 @@ impl Reporter for JsonStdErr {
     fn next_sample(&mut self) {
         self.current_samples += 1;
         let progress = Self::fmt(self.current_samples, self.total_samples);
-        eprintln!("{progress}");
+        serde_json::to_writer(io::stderr(), &progress).expect("failed to write progress to stdout");
     }
 }
 


### PR DESCRIPTION
Serde supports reader/writer interface which avoid the allocation of an intermediate string in memory for json serialization. This can reduce peak memory allocation when serializing large traces back to quint CLI.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
