### PR TITLE
Introduce diagnostics to Rust evaluator

### DIFF
--- a/evaluator/Cargo.lock
+++ b/evaluator/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "serde_repr",
  "squares-rnd",
  "tempfile",
  "thiserror",
@@ -1068,6 +1069,17 @@ checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/evaluator/Cargo.toml
+++ b/evaluator/Cargo.toml
@@ -14,6 +14,7 @@ panic = 'unwind'
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_repr = "0.1"
 fxhash = "0.2.1"
 indexmap = { version = "2.7", features = ["serde"] }
 rand = "0.8.5"

--- a/evaluator/benches/evaluator.rs
+++ b/evaluator/benches/evaluator.rs
@@ -4,6 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use quint_evaluator::evaluator::{Env, Interpreter};
 use quint_evaluator::helpers;
 use quint_evaluator::simulator::ParsedQuint;
+use quint_evaluator::Verbosity;
 
 fn simulate(
     parsed: &ParsedQuint,
@@ -11,7 +12,7 @@ fn simulate(
     samples: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut interpreter = Interpreter::new(parsed.table.clone());
-    let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42);
+    let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42, Verbosity::default());
 
     let init = interpreter.compile(&parsed.init);
     let step = interpreter.compile(&parsed.step);

--- a/evaluator/benches/simulation.rs
+++ b/evaluator/benches/simulation.rs
@@ -6,11 +6,19 @@ use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 use quint_evaluator::helpers;
 use quint_evaluator::progress;
+use quint_evaluator::Verbosity;
 
 fn run_in_rust(file_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let parsed = helpers::parse_from_path(file_path, "init", "step", Some("inv"), None)?;
 
-    let result = parsed.simulate(10, 1_000, 0, progress::no_report(), None);
+    let result = parsed.simulate(
+        10,
+        1_000,
+        0,
+        progress::no_report(),
+        None,
+        Verbosity::default(),
+    );
 
     match result {
         Ok(r) => assert!(r.result),

--- a/evaluator/src/builtins.rs
+++ b/evaluator/src/builtins.rs
@@ -21,6 +21,7 @@
 
 use crate::evaluator::{CompiledExprWithArgs, CompiledExprWithLazyArgs};
 use crate::ir::QuintError;
+use crate::itf::DebugMessage;
 use crate::value::{ImmutableMap, ImmutableSet, ImmutableVec, Value, ValueInner};
 use fxhash::FxHashSet;
 use itertools::Itertools;
@@ -262,8 +263,12 @@ pub fn compile_lazy_op(op: &str) -> CompiledExprWithLazyArgs {
                 let next_vars_snapshot = env.var_storage.borrow().take_snapshot();
                 env.shift();
                 // Drop the state from the trace, as we don't want to include it
-                // (expect is checking a condition and then rolling back)
-                env.trace.pop();
+                // (expect is checking a condition and then rolling back). Note
+                // that we move diagnostics back to the environment so they are
+                // not lost.
+                if let Some(trace) = env.trace.pop() {
+                    env.diagnostics.extend(trace.diagnostics);
+                }
                 let predicate_result = predicate.execute(env)?;
                 env.var_storage.borrow_mut().restore(&next_vars_snapshot);
 
@@ -892,9 +897,14 @@ pub fn compile_eager_op(op: &str) -> CompiledExprWithArgs {
             Ok(set.iter().next().cloned().unwrap())
         },
 
-        // Print a value to the console, and return it
-        "q::debug" => |_env, args| {
-            println!("> {} {}", args[0].as_str(), args[1]);
+        // Collect debug message when verbosity has debug output, and return the value
+        "q::debug" => |env, args| {
+            if env.verbosity.has_diagnostics() {
+                env.diagnostics.push(DebugMessage {
+                    label: args[0].as_str(),
+                    value: args[1].clone(),
+                });
+            }
             Ok(args[1].clone())
         },
 

--- a/evaluator/src/evaluator.rs
+++ b/evaluator/src/evaluator.rs
@@ -3,9 +3,11 @@
 //! Includes the compilation types and stateful datastructures used for
 //! memoization, caching, state variable storage, etc.
 
+use crate::itf::{DebugMessage, State};
 use crate::nondet;
 use crate::rand::Rand;
 use crate::storage::{Storage, VariableRegister};
+use crate::verbosity::Verbosity;
 use crate::{builtins::*, ir::*, value::*};
 use fxhash::FxHashMap;
 use std::cell::RefCell;
@@ -85,25 +87,39 @@ pub struct Env {
 
     // The trace collector, used to track state transitions during evaluation.
     // This is collected whenever `then` advances the state by calling `shift()`.
-    pub trace: Vec<Value>,
-    // TODO: trace recorder (for --verbosity)
+    pub trace: Vec<State>,
+
+    // Diagnostic messages for the current step. These are moved into the Step
+    // when `shift()` is called.
+    pub diagnostics: Vec<DebugMessage>,
+
+    // Verbosity level controlling debug output collection.
+    pub verbosity: Verbosity,
 }
 
 impl Env {
-    pub fn new(var_storage: Rc<RefCell<Storage>>) -> Self {
+    pub fn new(var_storage: Rc<RefCell<Storage>>, verbosity: Verbosity) -> Self {
         Self {
             var_storage,
             rand: Rand::new(),
             trace: Vec::new(),
+            diagnostics: Vec::new(),
+            verbosity,
         }
     }
 
     /// Create a new environment with a specific random state.
-    pub fn with_rand_state(var_storage: Rc<RefCell<Storage>>, state: u64) -> Self {
+    pub fn with_rand_state(
+        var_storage: Rc<RefCell<Storage>>,
+        state: u64,
+        verbosity: Verbosity,
+    ) -> Self {
         Self {
             var_storage,
             rand: Rand::with_state(state),
             trace: Vec::new(),
+            diagnostics: Vec::new(),
+            verbosity,
         }
     }
 
@@ -111,8 +127,9 @@ impl Env {
     pub fn shift(&mut self) {
         self.var_storage.borrow_mut().shift_vars();
         // After shifting, the current state is in `vars`, so we record it
-        let state = self.var_storage.borrow().as_record();
-        self.trace.push(state);
+        let value = self.var_storage.borrow().as_record();
+        let diagnostics = std::mem::take(&mut self.diagnostics);
+        self.trace.push(State { value, diagnostics });
     }
 }
 
@@ -707,7 +724,7 @@ fn can_cache(def: &LookupDefinition) -> Cache {
 /// Utility to compile and evaluate an expression in a new interpreter
 pub fn run(table: &LookupTable, expr: &QuintEx) -> Result<Value, QuintError> {
     let mut interpreter = Interpreter::new(table.clone());
-    let mut env = Env::new(interpreter.var_storage.clone());
+    let mut env = Env::new(interpreter.var_storage.clone(), Verbosity::default());
 
     interpreter.eval(&mut env, expr.clone())
 }

--- a/evaluator/src/lib.rs
+++ b/evaluator/src/lib.rs
@@ -19,3 +19,6 @@ pub mod simulator;
 pub mod storage;
 pub mod tester;
 pub mod value;
+mod verbosity;
+
+pub use verbosity::Verbosity;

--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -16,6 +16,7 @@ use quint_evaluator::ir::{LookupDefinition, LookupTable, QuintError};
 use quint_evaluator::progress;
 use quint_evaluator::simulator::{ParsedQuint, SimulationError, SimulationResult, TraceStatistics};
 use quint_evaluator::tester::{TestCase, TestResult, TestStatus};
+use quint_evaluator::Verbosity;
 use quint_evaluator::{helpers, log};
 use serde::{Deserialize, Serialize};
 
@@ -92,7 +93,7 @@ struct TestQuintArgs {}
 struct ReplFromStdinArgs {}
 
 /// Data expected on STDIN for simulation
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 struct SimulateInput {
     parsed: ParsedQuint,
     source: String,
@@ -104,6 +105,8 @@ struct SimulateInput {
     /// Optional seed for reproducibility. If provided, the simulation will use this seed.
     #[serde(default)]
     seed: Option<u64>,
+    #[serde(default)]
+    verbosity: Verbosity,
 }
 
 #[derive(Eq, PartialEq, Serialize)]
@@ -144,6 +147,8 @@ struct TestInput {
     #[serde(default)]
     seed: Option<u64>,
     max_samples: usize,
+    #[serde(default)]
+    verbosity: Verbosity,
 }
 
 #[derive(Serialize)]
@@ -217,6 +222,7 @@ fn run_simulation(args: RunArgs) -> eyre::Result<()> {
         args.n_traces,
         progress::no_report(),
         args.seed,
+        Verbosity::default(),
     );
 
     let elapsed = start.elapsed();
@@ -254,6 +260,7 @@ fn simulate_from_stdin() -> eyre::Result<()> {
         ntraces,
         nthreads,
         seed,
+        verbosity,
         ..
     } = serde_json::from_reader(io::stdin())?;
 
@@ -261,10 +268,10 @@ fn simulate_from_stdin() -> eyre::Result<()> {
 
     // When a seed is provided, we use single-threaded execution for reproducibility
     let outcome = if nthreads > 1 && seed.is_none() {
-        simulate_in_parallel(source, parsed, nsteps, nruns, ntraces, nthreads)
+        simulate_in_parallel(source, parsed, nsteps, nruns, ntraces, nthreads, verbosity)
     } else {
         let reporter = progress::json_std_err_report(nruns);
-        let result = parsed.simulate(nsteps, nruns, ntraces, reporter, seed);
+        let result = parsed.simulate(nsteps, nruns, ntraces, reporter, seed, verbosity);
         to_sim_output(source, result)
     };
 
@@ -286,6 +293,7 @@ fn test_from_stdin() -> eyre::Result<()> {
         table,
         seed,
         max_samples,
+        verbosity,
     } = serde_json::from_reader(io::stdin())?;
 
     // Create test case and execute with progress reporting
@@ -295,7 +303,7 @@ fn test_from_stdin() -> eyre::Result<()> {
         name,
     };
     let reporter = progress::json_std_err_report(max_samples);
-    let result = test_case.execute(seed, max_samples, reporter);
+    let result = test_case.execute(seed, max_samples, reporter, verbosity);
     let output = to_test_output(result);
     serde_json::to_writer(io::stdout(), &output)?;
 
@@ -312,6 +320,7 @@ fn simulate_in_parallel(
     nruns: usize,
     ntraces: usize,
     mut nthreads: usize,
+    verbosity: Verbosity,
 ) -> SimOutput {
     assert!(nthreads > 1, "nthreads must be > 1");
     nthreads = nthreads.min(nruns); //avoid spawning threads with no work
@@ -342,7 +351,7 @@ fn simulate_in_parallel(
         let thread = std::thread::Builder::new()
             .name(format!("simulator-thread-{i}"))
             .spawn(move || {
-                let result = parsed.simulate(nsteps, nruns, ntraces, reporter, None);
+                let result = parsed.simulate(nsteps, nruns, ntraces, reporter, None, verbosity);
                 let outcome = to_sim_output(source, result);
                 let _ = out_tx.send(outcome);
             })
@@ -392,11 +401,11 @@ fn simulate_in_parallel(
 fn to_test_output(result: TestResult) -> TestOutput {
     let traces = result
         .traces
-        .iter()
+        .into_iter()
         .map(|t| TestTrace {
-            seed: t.seed as usize,
-            states: t.clone().to_itf(result.name.clone()),
             result: !t.violation,
+            seed: t.seed as usize,
+            states: t.to_itf(result.name.clone()),
         })
         .collect();
 
@@ -419,50 +428,51 @@ fn to_sim_output(
     source: Arc<String>,
     result: Result<SimulationResult, SimulationError>,
 ) -> SimOutput {
-    let status = match &result {
-        Ok(r) if r.result => SimulationStatus::Success,
-        Ok(_) => SimulationStatus::Violation,
-        Err(_) => SimulationStatus::Error,
-    };
+    match result {
+        Ok(result) => {
+            let SimulationResult {
+                result,
+                best_traces,
+                trace_statistics,
+                witnessing_traces,
+                samples,
+            } = result;
 
-    let errors = result
-        .as_ref()
-        .err()
-        .map_or_else(Vec::new, |e| vec![e.error.clone()]);
+            SimOutput {
+                samples,
+                trace_statistics,
+                witnessing_traces,
+                status: if result {
+                    SimulationStatus::Success
+                } else {
+                    SimulationStatus::Violation
+                },
+                best_traces: best_traces
+                    .into_iter()
+                    .map(|t| SimulationTrace {
+                        seed: t.seed as usize,
+                        result: !t.violation,
+                        states: t.to_itf(source.to_string()),
+                    })
+                    .collect(),
+                errors: vec![],
+            }
+        }
+        Err(error) => {
+            let SimulationError { seed, trace, error } = error;
 
-    let best_traces = result.as_ref().map_or_else(
-        |e| {
-            // Include the error trace in best_traces so it gets reported to the user
-            vec![SimulationTrace {
-                seed: e.seed as usize,
-                states: e.trace.clone().to_itf((*source).clone()),
-                result: false,
-            }]
-        },
-        |r| {
-            r.best_traces
-                .iter()
-                .map(|t| SimulationTrace {
-                    seed: t.seed as usize,
-                    states: t.clone().to_itf((*source).clone()),
-                    result: !t.violation,
-                })
-                .collect()
-        },
-    );
-
-    SimOutput {
-        status,
-        errors,
-        best_traces,
-        trace_statistics: result
-            .as_ref()
-            .ok()
-            .map_or_else(TraceStatistics::default, |r| r.trace_statistics.clone()),
-        samples: result.as_ref().map_or(0, |r| r.samples),
-        witnessing_traces: result
-            .as_ref()
-            .ok()
-            .map_or_else(Vec::new, |r| r.witnessing_traces.clone()),
+            SimOutput {
+                samples: 0,
+                status: SimulationStatus::Error,
+                trace_statistics: TraceStatistics::default(),
+                errors: vec![error],
+                best_traces: vec![SimulationTrace {
+                    seed: seed as usize,
+                    states: trace.to_itf(source.to_string()),
+                    result: false,
+                }],
+                witnessing_traces: vec![],
+            }
+        }
     }
 }

--- a/evaluator/src/repl.rs
+++ b/evaluator/src/repl.rs
@@ -7,6 +7,7 @@
 use crate::evaluator::{Env, Interpreter};
 use crate::ir::{LookupTable, QuintEx};
 use crate::value::Value;
+use crate::Verbosity;
 use itf;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufRead, Write};
@@ -22,7 +23,7 @@ enum ReplCommand {
         #[serde(default)]
         seed: Option<u64>,
         #[serde(default)]
-        verbosity: u8,
+        verbosity: Verbosity,
     },
     /// Update the lookup table with new definitions
     UpdateTable { table: LookupTable },
@@ -80,7 +81,7 @@ pub struct ReplEvaluator {
     interpreter: Option<Interpreter>,
     env: Option<Env>,
     trace_states: Vec<Value>,
-    verbosity: u8,
+    verbosity: Verbosity,
 }
 
 impl ReplEvaluator {
@@ -88,7 +89,12 @@ impl ReplEvaluator {
         Self::default()
     }
 
-    fn initialize(&mut self, table: LookupTable, seed: Option<u64>, verbosity: u8) -> ReplResponse {
+    fn initialize(
+        &mut self,
+        table: LookupTable,
+        seed: Option<u64>,
+        verbosity: Verbosity,
+    ) -> ReplResponse {
         self.verbosity = verbosity;
 
         // Create the interpreter with the table
@@ -97,9 +103,9 @@ impl ReplEvaluator {
 
         self.interpreter = Some(interpreter);
         self.env = Some(if let Some(seed) = seed {
-            Env::with_rand_state(storage, seed)
+            Env::with_rand_state(storage, seed, verbosity)
         } else {
-            Env::new(storage)
+            Env::new(storage, verbosity)
         });
 
         self.trace_states = Vec::new();

--- a/evaluator/src/simulator.rs
+++ b/evaluator/src/simulator.rs
@@ -5,10 +5,11 @@ use crate::{
     ir::{LookupTable, QuintError, QuintEx},
     itf::Trace,
     progress::Reporter,
+    verbosity::Verbosity,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::{cmp::Ordering, fmt};
 
 /// Simulation input that depends on the typescript Quint tool.
 #[derive(Serialize, Deserialize, Clone)]
@@ -77,11 +78,12 @@ impl ParsedQuint {
         n_traces: usize,
         mut reporter: R,
         seed: Option<u64>,
+        verbosity: Verbosity,
     ) -> Result<SimulationResult, SimulationError> {
         let mut interpreter = Interpreter::new(self.table.clone());
         let mut env = match seed {
-            Some(s) => Env::with_rand_state(interpreter.var_storage.clone(), s),
-            None => Env::new(interpreter.var_storage.clone()),
+            Some(s) => Env::with_rand_state(interpreter.var_storage.clone(), s, verbosity),
+            None => Env::new(interpreter.var_storage.clone(), verbosity),
         };
 
         let init = interpreter.compile(&self.init);
@@ -182,6 +184,7 @@ impl ParsedQuint {
                             violation: !success,
                             seed,
                         },
+                        verbosity,
                     );
 
                     if !success {
@@ -264,8 +267,13 @@ fn get_trace_statistics(trace_lengths: &[usize]) -> TraceStatistics {
 /// Collect a trace of the simulation, up to a maximum of `n_traces`.
 ///
 /// Assumes `best_traces` is sorted by quality.
-fn collect_trace(best_traces: &mut Vec<Trace>, n_traces: usize, trace: Trace) {
-    insert_trace_sorted_by_quality(best_traces, trace);
+fn collect_trace(
+    best_traces: &mut Vec<Trace>,
+    n_traces: usize,
+    trace: Trace,
+    verbosity: Verbosity,
+) {
+    insert_trace_sorted_by_quality(best_traces, trace, verbosity);
     if best_traces.len() > n_traces {
         best_traces.pop();
     }
@@ -273,22 +281,49 @@ fn collect_trace(best_traces: &mut Vec<Trace>, n_traces: usize, trace: Trace) {
 
 /// Compare two traces by quality.
 ///
-/// Prefer short traces for error, and longer traces for non error.
-/// Therefore, trace a is better than trace b iff
+/// Prefer short traces for error, and longer traces for non error. Therefore,
+/// trace a is better than trace b iff:
+///
 ///  - when a has an error: a is shorter or b has no error;
 ///  - when a has no error: a is longer and b has no error.
-fn compare_traces_by_quality(a: &Trace, b: &Trace) -> std::cmp::Ordering {
-    match (a.violation, b.violation) {
-        (true, true) => a.states.len().cmp(&b.states.len()),
-        (true, false) => std::cmp::Ordering::Less,
-        (false, true) => std::cmp::Ordering::Greater,
-        (false, false) => b.states.len().cmp(&a.states.len()),
+///
+/// For traces considered of equal value, both errors or both non-errors, we
+/// consider the one with diagnostics to be better.
+fn compare_traces_by_quality(a: &Trace, b: &Trace, verbosity: Verbosity) -> Ordering {
+    #[inline]
+    fn flag_cmp<F>(a: bool, b: bool, elze: F) -> Ordering
+    where
+        F: FnOnce(bool) -> Ordering,
+    {
+        match (a, b) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => elze(a), // a and b can only be equal here
+        }
     }
+
+    flag_cmp(a.violation, b.violation, |both_violations| {
+        flag_cmp(
+            verbosity.has_diagnostics() && a.has_diagnostics(),
+            verbosity.has_diagnostics() && b.has_diagnostics(),
+            |_| {
+                if both_violations {
+                    a.states.len().cmp(&b.states.len())
+                } else {
+                    b.states.len().cmp(&a.states.len())
+                }
+            },
+        )
+    })
 }
 
 /// Insert a trace into a sorted vector of traces, maintaining the order by quality.
-fn insert_trace_sorted_by_quality(best_traces: &mut Vec<Trace>, trace: Trace) {
-    let index = best_traces.binary_search_by(|t| compare_traces_by_quality(t, &trace));
+fn insert_trace_sorted_by_quality(
+    best_traces: &mut Vec<Trace>,
+    trace: Trace,
+    verbosity: Verbosity,
+) {
+    let index = best_traces.binary_search_by(|t| compare_traces_by_quality(t, &trace, verbosity));
     match index {
         Ok(index) => best_traces.insert(index, trace),
         Err(index) => best_traces.insert(index, trace),

--- a/evaluator/src/verbosity.rs
+++ b/evaluator/src/verbosity.rs
@@ -1,0 +1,19 @@
+use serde_repr::Deserialize_repr;
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize_repr, Debug)]
+#[repr(u8)]
+pub enum Verbosity {
+    Quiet = 0,
+    Results = 1,
+    #[default]
+    Normal = 2,
+    Diagnostics = 3,
+    Debug = 4,
+    Maximum = 5,
+}
+
+impl Verbosity {
+    pub fn has_diagnostics(&self) -> bool {
+        *self >= Verbosity::Diagnostics
+    }
+}

--- a/evaluator/tests/evaluation_tests.rs
+++ b/evaluator/tests/evaluation_tests.rs
@@ -4,6 +4,7 @@ use quint_evaluator::{
     evaluator::{run, Env, EvalResult, Interpreter},
     helpers,
     value::Value,
+    Verbosity,
 };
 
 fn assert_from_string(input: &str, expected: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -70,7 +71,7 @@ fn eval_run(callee: &str, input: &str) -> EvalResult {
     let parsed = helpers::parse(&quint_content, "init", "step", None).unwrap();
     let run_def = parsed.find_definition_by_name(callee).unwrap();
     let mut interpreter = Interpreter::new(parsed.table.clone());
-    let mut env = Env::new(Rc::clone(&interpreter.var_storage));
+    let mut env = Env::new(Rc::clone(&interpreter.var_storage), Verbosity::default());
 
     interpreter.eval(&mut env, run_def.expr.clone())
 }
@@ -96,7 +97,7 @@ fn assert_var_after_run(
     let parsed = helpers::parse(&quint_content, "init", "step", None)?;
     let run_def = parsed.find_definition_by_name(callee)?;
     let mut interpreter = Interpreter::new(parsed.table.clone());
-    let mut env = Env::new(Rc::clone(&interpreter.var_storage));
+    let mut env = Env::new(Rc::clone(&interpreter.var_storage), Verbosity::default());
 
     let run_result = interpreter.eval(&mut env, run_def.expr.clone());
 

--- a/evaluator/tests/picker_tests.rs
+++ b/evaluator/tests/picker_tests.rs
@@ -2,6 +2,7 @@ use quint_evaluator::{
     evaluator::{Env, Interpreter},
     helpers,
     value::Value,
+    Verbosity,
 };
 
 macro_rules! run_test {
@@ -11,7 +12,8 @@ macro_rules! run_test {
 
         let mut interpreter = Interpreter::new(parsed.table.clone());
         // Set a specific seed so different runs generate the same result
-        let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42);
+        let mut env =
+            Env::with_rand_state(interpreter.var_storage.clone(), 0x42, Verbosity::default());
 
         let init = interpreter.eval(&mut env, init_def.expr.clone());
         assert_eq!(init.unwrap(), Value::bool(true));
@@ -100,7 +102,7 @@ fn powerset_large_set_pick_test() -> Result<(), Box<dyn std::error::Error>> {
     let init_def = parsed.find_definition_by_name("init")?;
 
     let mut interpreter = Interpreter::new(parsed.table.clone());
-    let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42);
+    let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42, Verbosity::default());
 
     let init = interpreter.eval(&mut env, init_def.expr.clone());
     // Should not panic or overflow - just check it runs successfully
@@ -132,7 +134,7 @@ fn powerset_very_large_set_pick_test() -> Result<(), Box<dyn std::error::Error>>
     let init_def = parsed.find_definition_by_name("init")?;
 
     let mut interpreter = Interpreter::new(parsed.table.clone());
-    let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42);
+    let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 0x42, Verbosity::default());
 
     let init = interpreter.eval(&mut env, init_def.expr.clone());
     // Should not panic or overflow - just check it runs successfully

--- a/evaluator/tests/simulator_tests.rs
+++ b/evaluator/tests/simulator_tests.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use quint_evaluator::{helpers, progress};
+use quint_evaluator::{helpers, progress, Verbosity};
 
 #[test]
 fn tictactoe_ok() {
@@ -8,7 +8,14 @@ fn tictactoe_ok() {
 
     let parsed = helpers::parse_from_path(file_path, "init", "step", Some("inv"), None).unwrap();
     // Pass an invariant that should hold
-    let result = parsed.simulate(10, 100, 0, progress::no_report(), None);
+    let result = parsed.simulate(
+        10,
+        100,
+        0,
+        progress::no_report(),
+        None,
+        Verbosity::default(),
+    );
     assert!(result.is_ok());
     // Should not find violation
     assert!(result.unwrap().result);
@@ -21,7 +28,14 @@ fn tictactoe_violation() {
     let parsed =
         helpers::parse_from_path(file_path, "init", "step", Some("XHasNotWon"), None).unwrap();
     // Pass an invariant that should not hold
-    let result = parsed.simulate(10, 100, 1, progress::no_report(), None);
+    let result = parsed.simulate(
+        10,
+        100,
+        1,
+        progress::no_report(),
+        None,
+        Verbosity::default(),
+    );
     assert!(result.is_ok());
     // Should find violation
     assert!(!result.as_ref().unwrap().result);
@@ -45,7 +59,14 @@ fn instances_ok() {
         helpers::parse_from_path(file_path, "init", "step", Some("inv"), Some("instances"))
             .unwrap();
     // Pass an invariant that should hold
-    let result = parsed.simulate(10, 100, 0, progress::no_report(), None);
+    let result = parsed.simulate(
+        10,
+        100,
+        0,
+        progress::no_report(),
+        None,
+        Verbosity::default(),
+    );
     assert!(result.is_ok());
     // Should not find violation
     assert!(result.unwrap().result);
@@ -60,7 +81,14 @@ fn instance_overrides_ok() {
         helpers::parse_from_path(file_path, "init", "step", Some("inv2"), Some("instances"))
             .unwrap();
     // Pass an invariant that should hold
-    let result = parsed.simulate(10, 100, 0, progress::no_report(), None);
+    let result = parsed.simulate(
+        10,
+        100,
+        0,
+        progress::no_report(),
+        None,
+        Verbosity::default(),
+    );
     assert!(result.is_ok());
     // Should not find violation
     assert!(result.unwrap().result);
@@ -80,7 +108,14 @@ fn one_of_empty_set_ok() {
     )
     .unwrap();
 
-    let result = parsed.simulate(10, 100, 0, progress::no_report(), None);
+    let result = parsed.simulate(
+        10,
+        100,
+        0,
+        progress::no_report(),
+        None,
+        Verbosity::default(),
+    );
 
     // The simulation should succeed without runtime errors
     assert!(result.is_ok());

--- a/evaluator/tests/stateful_tests.rs
+++ b/evaluator/tests/stateful_tests.rs
@@ -2,6 +2,7 @@ use quint_evaluator::{
     evaluator::{Env, Interpreter},
     helpers,
     value::Value,
+    Verbosity,
 };
 
 macro_rules! run_test {
@@ -11,7 +12,11 @@ macro_rules! run_test {
 
         let mut interpreter = Interpreter::new(parsed.table.clone());
         // Set a specific seed so different runs generate the same result
-        let mut env = Env::with_rand_state(interpreter.var_storage.clone(), 123_456);
+        let mut env = Env::with_rand_state(
+            interpreter.var_storage.clone(),
+            123_456,
+            Verbosity::default(),
+        );
 
         let init = interpreter.eval(&mut env, init_def.expr.clone());
         assert_eq!(init.unwrap(), Value::bool(true));

--- a/evaluator/tests/tester_tests.rs
+++ b/evaluator/tests/tester_tests.rs
@@ -1,5 +1,5 @@
 use quint_evaluator::tester::TestCase;
-use quint_evaluator::{helpers, progress};
+use quint_evaluator::{helpers, progress, Verbosity};
 use std::error::Error;
 use std::path::Path;
 
@@ -28,7 +28,7 @@ fn passing_test_ok() {
     let file_path = Path::new("fixtures/runs.qnt");
     let test_case = parse_test_from_path(file_path, "passingTest").unwrap();
 
-    let result = test_case.execute(Some(0), 1, progress::no_report());
+    let result = test_case.execute(Some(0), 1, progress::no_report(), Verbosity::default());
 
     // Test passed - no errors
     assert_eq!(result.errors.len(), 0);
@@ -41,7 +41,7 @@ fn failing_test_returns_qnt511() {
     let file_path = Path::new("fixtures/runs.qnt");
     let test_case = parse_test_from_path(file_path, "failingTest").unwrap();
 
-    let result = test_case.execute(Some(0), 1, progress::no_report());
+    let result = test_case.execute(Some(0), 1, progress::no_report(), Verbosity::default());
 
     // Test failed with QNT511 (test returned false)
     assert_eq!(result.errors.len(), 1);
@@ -58,7 +58,7 @@ fn failing_assert_returns_qnt508() {
     let file_path = Path::new("fixtures/runs.qnt");
     let test_case = parse_test_from_path(file_path, "failingAssertTest").unwrap();
 
-    let result = test_case.execute(Some(0), 1, progress::no_report());
+    let result = test_case.execute(Some(0), 1, progress::no_report(), Verbosity::default());
 
     // Test failed with QNT508 (assertion failed)
     assert_eq!(result.errors.len(), 1);
@@ -73,7 +73,7 @@ fn failing_expect_action_returns_qnt508() {
     let file_path = Path::new("fixtures/runs.qnt");
     let test_case = parse_test_from_path(file_path, "failingExpectActionTest").unwrap();
 
-    let result = test_case.execute(Some(0), 1, progress::no_report());
+    let result = test_case.execute(Some(0), 1, progress::no_report(), Verbosity::default());
 
     // Test failed with QNT508
     assert_eq!(result.errors.len(), 1);

--- a/quint/rust-backend-local-tests.md
+++ b/quint/rust-backend-local-tests.md
@@ -86,7 +86,8 @@ quint run \
 
 This test verifies that q::debug output is printed when using the Rust backend.
 
-<!-- !test in rust backend debug -->
+**FIXME: the next PR should reintroduce logging**
+<!-- !test check rust backend debug -->
 ```
 cat > /tmp/debug_test.qnt << 'EOF'
 module debugTest {
@@ -106,14 +107,10 @@ quint run \
   --backend=rust \
   --max-samples=1 \
   --main=debugTest \
+  --verbosity=3 \
   /tmp/debug_test.qnt 2>&1 | grep "this tests debug"
 
 rm /tmp/debug_test.qnt
-```
-
-<!-- !test out rust backend debug -->
-```
-> this tests debug 42
 ```
 
 ## `expect` does not duplicate states in traces for `quint run`


### PR DESCRIPTION
Currently, `q::debug` is not very useful in the rust evaluator. It's multi-threaded design makes it so many messages appear in the console and it's really difficult to track from which traces they are coming from.

This patch is the first part of a redesign of how `q::debug` works. In it, we're tracking debug messages as per state diagnostics in the traces. The best traces are selected, preserving diagnostics when applicable, so at the CLI interface we'll report only diagnostics associated with the reported traces at the end.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
