### PR TITLE
Introduce Rust diagnostics to the ts cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `quint repl --backend=rust` to use the REPL with the Rust backend (#1891)
 - Added out of bounds integer literal detection when serializing input to the Rust backend (#1890)
 - Added support for the `--witnesses` flag in the Rust backend (#1889)
+- The rust backend will now report per step diagnostics via `q::debug` (#1893)
 
 ### Changed
 

--- a/quint/rust-backend-integration-tests/quint-run.md
+++ b/quint/rust-backend-integration-tests/quint-run.md
@@ -809,6 +809,7 @@ quint run \
   --backend=rust \
   --max-samples=1 \
   --main=debugTest \
+  --verbosity=3 \
   /tmp/debug_test.qnt 2>&1 | grep "this tests debug"
 
 rm /tmp/debug_test.qnt
@@ -816,6 +817,6 @@ rm /tmp/debug_test.qnt
 
 <!-- !test out rust backend debug -->
 ```
-> this tests debug 42
+[DEBUG] this tests debug 42
 ```
 

--- a/quint/rust-backend-integration-tests/quint-test.md
+++ b/quint/rust-backend-integration-tests/quint-test.md
@@ -349,3 +349,39 @@ rm NoExpectTest.itf.json WithExpectTest.itf.json
 6
 6
 ```
+
+### Debug while testing
+
+This test verifies that q::debug output is printed when using the Rust backend.
+
+<!-- !test in rust backend test debug -->
+```
+cat > /tmp/debug_test.qnt << 'EOF'
+module debugTest {
+  var x: int
+
+  action init = {
+    x' = q::debug("this tests debug", 42)
+  }
+
+  action step = {
+    x' = x + 1
+  }
+
+  run simpleTest =
+    init.then(step)
+}
+EOF
+
+quint test \
+  --backend=rust \
+  --verbosity=3 \
+  /tmp/debug_test.qnt 2>&1 | grep "this tests debug"
+
+rm /tmp/debug_test.qnt
+```
+
+<!-- !test out rust backend test debug -->
+```
+       [DEBUG] this tests debug 42
+```

--- a/quint/rust-backend-local-tests.md
+++ b/quint/rust-backend-local-tests.md
@@ -86,8 +86,7 @@ quint run \
 
 This test verifies that q::debug output is printed when using the Rust backend.
 
-**FIXME: the next PR should reintroduce logging**
-<!-- !test check rust backend debug -->
+<!-- !test in rust backend debug -->
 ```
 cat > /tmp/debug_test.qnt << 'EOF'
 module debugTest {
@@ -111,6 +110,11 @@ quint run \
   /tmp/debug_test.qnt 2>&1 | grep "this tests debug"
 
 rm /tmp/debug_test.qnt
+```
+
+<!-- !test out rust backend debug -->
+```
+[DEBUG] this tests debug 42
 ```
 
 ## `expect` does not duplicate states in traces for `quint run`

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -461,10 +461,11 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
 
   simulator.seed = outcome.bestTraces[0]?.seed
   const states = outcome.bestTraces[0]?.states
+  const diagnostics = outcome.bestTraces[0]?.diagnostics || []
   const frames = recorder.bestTraces[0]?.frame?.subframes
 
   if (states && states.length > 0) {
-    maybePrintCounterExample(verbosityLevel, states, frames, prev.args.hide || [])
+    maybePrintCounterExample(verbosityLevel, states, diagnostics, frames, prev.args.hide || [])
   }
 
   switch (outcome.status) {

--- a/quint/src/graphics.ts
+++ b/quint/src/graphics.ts
@@ -22,6 +22,7 @@ import {
   nest,
   parens,
   richtext,
+  space,
   text,
   textify,
 } from './prettierimp'
@@ -34,6 +35,7 @@ import { TypeScheme } from './types/base'
 import { canonicalTypeScheme } from './types/printing'
 import { declarationToString, qualifierToString, rowToString } from './ir/IRprinting'
 import { simplifyRow } from './types/simplification'
+import { DebugMessage } from './itf'
 
 /**
  * An abstraction of a Console of bounded text width.
@@ -302,6 +304,7 @@ export function printExecutionFrameRec(box: ConsoleBox, frame: ExecutionFrame, i
 export function printTrace(
   console: ConsoleBox,
   states: QuintEx[],
+  diagnostics: DebugMessage[][],
   frames: ExecutionFrame[],
   hideVars: string[] = []
 ): void {
@@ -332,6 +335,15 @@ export function printTrace(
         }
       }
       filteredState = { ...state, args: filteredArgs }
+    }
+
+    if (index < diagnostics.length) {
+      for (const msg of diagnostics[index]) {
+        const doc: Doc = group([brackets(text('DEBUG')), space, text(msg.label), line(), prettyQuintEx(msg.value)])
+        console.out(format(console.width, 0, doc))
+        console.out('\n')
+      }
+      console.out('\n')
     }
 
     const stateDoc: Doc = [group([brackets(richtext(b, `State ${index}`)), line()]), prettyQuintEx(filteredState)]

--- a/quint/src/runtime/testing.ts
+++ b/quint/src/runtime/testing.ts
@@ -13,6 +13,7 @@ import { Rng } from '../rng'
 import { QuintError } from '../quintError'
 import { TraceHook } from '../cliReporting'
 import { QuintEx } from '../ir/quintIr'
+import { DebugMessage } from '../itf'
 
 /**
  * Various settings to be passed to the testing framework.
@@ -31,6 +32,7 @@ export interface TestOptions {
 export interface TestTrace {
   seed: number
   states: QuintEx[]
+  diagnostics?: DebugMessage[][]
   result: boolean
 }
 
@@ -58,7 +60,7 @@ export interface TestResult {
   /**
    * If the trace was recorded, frames contains the history.
    */
-  frames: ExecutionFrame[]
+  frames?: ExecutionFrame[]
   /**
    * Traces from the Rust evaluator (ITF format converted to QuintEx)
    */

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -12,6 +12,7 @@ import { QuintEx } from './ir/quintIr'
 import { Rng } from './rng'
 import { QuintError } from './quintError'
 import { TraceHook } from './cliReporting'
+import { DebugMessage } from './itf'
 
 /**
  * Various settings that have to be passed to the simulator to run.
@@ -33,6 +34,7 @@ export interface SimulatorOptions {
 
 export interface SimulationTrace {
   states: QuintEx[]
+  diagnostics?: DebugMessage[][]
   result: boolean
   seed: bigint
 }
@@ -45,16 +47,6 @@ export interface Outcome {
   status: SimulationStatus
   errors: QuintError[]
   bestTraces: SimulationTrace[]
-  witnessingTraces: number[]
-  samples: number
-  traceStatistics: TraceStatistics
-}
-
-/**
- * A result returned by the simulator.
- */
-export interface SimulationResult {
-  result: QuintEx
   witnessingTraces: number[]
   samples: number
   traceStatistics: TraceStatistics


### PR DESCRIPTION
This patch wires debug messages from the Rust evaluator into the ts CLI, reporting them both for simulate and test.

Where's what the output look like for the `examples/cosmos/bankTest.qnt`

```diff
diff --git a/examples/cosmos/bank/bankTest.qnt b/examples/cosmos/bank/bankTest.qnt
index d721d54d..513c63e5 100644
--- a/examples/cosmos/bank/bankTest.qnt
+++ b/examples/cosmos/bank/bankTest.qnt
@@ -26,7 +26,12 @@ module bankTest {

   action send(fromAddr: Addr, toAddr: Addr, coins: Coins): bool = all {
     val ctx = stateToCtx(0)
-    val result = SendKeeper::SendCoins(ctx, fromAddr, toAddr, coins)
+    val result = SendKeeper::SendCoins(
+      ctx,
+      q::debug("from", fromAddr),
+      q::debug("to", toAddr),
+      q::debug("coins", coins)
+    )
     match result {
       | BankOk(newCtx) => all {
         balances' = newCtx.balances,
```
```
$ quint run --backend=rust --verbosity=3 bankTest.qnt
An example execution:

[State 0]
{
  _lastError: "",
  balances: Map("king" -> Map("banana" -> 10000, "burger" -> 10000)),
  supply: Map("banana" -> 10000, "burger" -> 10000)
}

[DEBUG] from "donkeykong"
[DEBUG] to "mario"
[DEBUG] coins Map("banana" -> 8177)

[State 1]
{
  _lastError: "invalid coins or insufficient funds",
  balances: Map("king" -> Map("banana" -> 10000, "burger" -> 10000)),
  supply: Map("banana" -> 10000, "burger" -> 10000)
}

...
```

```
$ quint test --backend=rust --verbosity=3 bankTest.qnt

  bankTest
    ...
    1) sendTest failed after 1 test(s)
       [DEBUG] from "king"
       [DEBUG] to "donkeykong"
       [DEBUG] coins Map("banana" -> 1)
   ...
```


<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
