### PR TITLE
Implement q::debug for the REPL + the rust backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `Nat` and `Int` to rust backend (#1894)
 - Added support for the `--n-traces` flag in the Rust backend (#1898)
 - Added support for `--invariants` flag in the Rust backend (#1902)
+- The rust backend will report diagnostics for the REPL (#1909)
 
 ### Changed
 

--- a/quint/rust-backend-integration-tests/quint-repl.md
+++ b/quint/rust-backend-integration-tests/quint-repl.md
@@ -211,14 +211,14 @@ quint --backend=rust -r ../examples/language-features/instances.qnt::instances "
 <!-- !test in repl debug prints value to stdout and returns value -->
 
 ```
-echo 'q::debug("value:", { foo: 42, bar: "Hello, World!" })' | quint --backend=rust | tail -n +3
+quint --backend=rust --verbosity=3 'q::debug("value:", { foo: 42, bar: "Hello, World!" })' | tail -n +3
 ```
 
 <!-- !test out repl debug prints value to stdout and returns value -->
 ```
->>> > value: { bar: "Hello, World!", foo: 42 }
+>>> q::debug("value:", { foo: 42, bar: "Hello, World!" })
+[DEBUG] value: { bar: "Hello, World!", foo: 42 }
 { bar: "Hello, World!", foo: 42 }
->>> 
 ```
 
 ### REPL continues to work after missing name errors


### PR DESCRIPTION
This patch wires the rust backend diagnostics mechanism with the REPL output so that debug messages can be printed in the REPL when enabled.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
