### PR TITLE
Fix minor CLI display bugs for Rust

### DIFF
--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -511,7 +511,8 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
         )
 
         // Use Rust-provided violated invariants if available, otherwise fall back to TS evaluation
-        if (prev.args.backend === 'rust' && outcome.violatedInvariants.length > 0) {
+        // Only print individual violations when there are multiple invariants
+        if (prev.args.backend === 'rust' && outcome.violatedInvariants.length > 0 && individualInvariants.length > 1) {
           printViolatedInvariantsByIndex(outcome.violatedInvariants, individualInvariants)
         } else {
           printViolatedInvariants(states[states.length - 1], individualInvariants, prev)

--- a/quint/src/graphics.ts
+++ b/quint/src/graphics.ts
@@ -337,7 +337,7 @@ export function printTrace(
       filteredState = { ...state, args: filteredArgs }
     }
 
-    if (index < diagnostics.length) {
+    if (index < diagnostics.length && diagnostics[index].length > 0) {
       for (const msg of diagnostics[index]) {
         const doc: Doc = group([brackets(text('DEBUG')), space, text(msg.label), line(), prettyQuintEx(msg.value)])
         console.out(format(console.width, 0, doc))


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->
Hey, 
when updating the CI tests, I found 2 small display issues:

- the `--invariant` flag behaves similar to `--invariants` and displays the list of violated invariants when using the rust backend.
- the trace rendering has an extra line break when using the rust backend. This was added with the diagnostics support and I found it was better to remove this extra line if we have no diagnostics to print. 

Before:
<img width="1224" height="420" alt="image" src="https://github.com/user-attachments/assets/ef0d2ec6-45d3-41cc-96ef-7dab2d21649a" />
After:
<img width="1028" height="318" alt="image" src="https://github.com/user-attachments/assets/705f300f-9d87-4ab1-8112-8f47b64708b4" />

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
