### PR TITLE
Switch Rust evaluator to MiMalloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved memory allocation profile of LSP-server log messages (#1877)
 - Stream JSON in and out or rust evaluator to reduce memory allocations (#1882)
 - Improved power set sampling coverage in the Rust backend (#1888)
+- Changed default Rust allocator to MiMalloc (#1914)
 
 ### Deprecated
 ### Removed

--- a/evaluator/Cargo.lock
+++ b/evaluator/Cargo.lock
@@ -644,6 +644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +698,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -847,6 +866,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "itf",
+ "mimalloc",
  "num-bigint",
  "num-traits",
  "rand",

--- a/evaluator/Cargo.toml
+++ b/evaluator/Cargo.toml
@@ -32,6 +32,7 @@ chrono = "0.4.40"
 hipstr = { version = "0.8.0", features = ["serde"] }
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2.19"
+mimalloc = "0.1.48"
 
 [dev-dependencies]
 insta = {version = "1.22.0", features = ["yaml"]}

--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -24,6 +24,9 @@ use quint_evaluator::Verbosity;
 use quint_evaluator::{helpers, log};
 use serde::{Deserialize, Serialize};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(FromArgs)]
 #[argh(description = "Quint simulator")]
 struct TopLevel {


### PR DESCRIPTION
We have run out or memory in some large specifications while using the Rust simulator. We've experimented with the [MiMalloc](https://github.com/microsoft/mimalloc) allocator and managed to execute very large simulations without memory issues. The design of MiMalloc is meant for applications with high allocation throughput, specially with small short-lived objects, and it's specially efficient at reducing memory fragmentation.

Micro benchmarks show that performance is mostly unaffected in terms of avg. execution time but, sample density has improved, making executions more predictable.

*evaluator/JMT (blue=patch; red=main)*:

<img width="446" height="284" alt="image" src="https://github.com/user-attachments/assets/0dccae5e-e2f2-4703-8c67-d636fb113cf3" />

I believe we have enough signals to justify replacing the default allocator for MiMalloc for now.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
