### PR TITLE
Fix violation/diagnostics display issues in Rust

### DIFF
--- a/quint/src/repl.ts
+++ b/quint/src/repl.ts
@@ -104,8 +104,7 @@ class ReplState {
     rng: Rng,
     useRustEvaluator: boolean = false,
     existingEvaluator?: Evaluator | ReplServerWrapper,
-    existingNameResolver?: NameResolver,
-    out?: writer
+    existingNameResolver?: NameResolver
   ) {
     const recorder = newTraceRecorder(verbosityLevel, rng)
     this.moduleHist = ''
@@ -117,7 +116,7 @@ class ReplState {
       // Reuse existing evaluator (important for Rust backend to avoid spawning multiple subprocesses)
       this.evaluator = existingEvaluator
     } else if (useRustEvaluator) {
-      this.evaluator = new ReplServerWrapper(new Map(), recorder, rng, out ?? (text => process.stdout.write(text)))
+      this.evaluator = new ReplServerWrapper(new Map(), recorder, rng)
     } else {
       this.evaluator = new Evaluator(new Map(), recorder, rng)
     }
@@ -245,7 +244,7 @@ export function quintRepl(
 
   // the state
   const rng = options.seed !== undefined ? newRng(options.seed) : newRng()
-  const state: ReplState = new ReplState(options.verbosity, rng, useRustEvaluator, undefined, undefined, out)
+  const state: ReplState = new ReplState(options.verbosity, rng, useRustEvaluator)
 
   // we let the user type a multiline string, which is collected here:
   let multilineText = ''
@@ -772,7 +771,7 @@ async function tryEval(out: writer, state: ReplState, newInput: string): Promise
 
         if (shifted && verbosity.hasDiffs(state.verbosity)) {
           const diffDoc = diffRuntimeValueDoc(oldState!, newState!, { collapseThreshold: 2 })
-          out(format(terminalWidth(), 0, diffDoc) + '\n')
+          console.log(format(terminalWidth(), 0, diffDoc))
         }
 
         if (missing.length > 0) {

--- a/quint/src/rust/replServerWrapper.ts
+++ b/quint/src/rust/replServerWrapper.ts
@@ -84,14 +84,12 @@ export class ReplServerWrapper {
   public recorder: TraceRecorder
   private verbosityLevel: number
   private traceCache?: Trace
-  private out: (text: string) => void
 
   private initializationPromise: Promise<void>
 
-  constructor(table: LookupTable, recorder: TraceRecorder, rng: Rng, out: (text: string) => void) {
+  constructor(table: LookupTable, recorder: TraceRecorder, rng: Rng) {
     this.recorder = recorder
     this.verbosityLevel = recorder.verbosityLevel
-    this.out = out
     this.initializationPromise = this.initialize(table, rng.getState())
   }
 
@@ -252,7 +250,7 @@ export class ReplServerWrapper {
       for (const diag of diagnostics) {
         const value = ofItfValue(diag.value, zerog.nextId)
         const doc: Doc = group([brackets(text('DEBUG')), space, text(diag.label), line(), prettyQuintEx(value)])
-        this.out(format(columns, 0, doc) + '\n')
+        console.log(format(columns, 0, doc))
       }
     }
   }


### PR DESCRIPTION
Hello 👥 
This is a quick PR to fix the bug where the wrong trace is returned by rust backend when a violation is found. 
Edit: I grouped together in this PR(for convenience) the fix for switched diagnostics display.  
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
