### PR TITLE
fix: move distribution tests up the order to have clean state

### DIFF
--- a/.github/workflows/release-quint.yml
+++ b/.github/workflows/release-quint.yml
@@ -32,8 +32,8 @@ jobs:
           # Fetch the latest apalache release
           make -C .. apalache
           # Run the apalache distribution test first (requires clean state: no server, no existing dist).
-          # This downloads Apalache to ~/.quint so the TLC backend can find the JAR later.
           npm run apalache-distribution-integration
+          # This downloads Apalache to ~/.quint so the TLC backend can find the JAR later.
           VERSION=$(grep "DEFAULT_APALACHE_VERSION_TAG = " src/apalache.ts | sed "s/.*'\(.*\)'/\1/")
           mkdir -p ~/.quint/apalache-dist-$VERSION
           cp -r _build/apalache ~/.quint/apalache-dist-$VERSION/


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
