### PR TITLE
Re-use test jobs in release workflow

### DIFF
--- a/.github/workflows/examples-dashboard.yml
+++ b/.github/workflows/examples-dashboard.yml
@@ -1,0 +1,92 @@
+name: Examples Dashboard
+
+on:
+  # Every pull request
+  pull_request:
+  # When part of a merge queue
+  merge_group:
+  # Pushes into the trunk
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      quint: ${{ steps.filter.outputs.quint }}
+      evaluator: ${{ steps.filter.outputs.evaluator }}
+      examples: ${{ steps.filter.outputs.examples }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            quint:
+              - 'quint/**'
+            evaluator:
+              - 'evaluator/**'
+            examples:
+              - 'examples/**'
+
+  examples-dashboard:
+    name: Examples Dashboard by OS
+    needs: changes
+    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "19"
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Build Rust evaluator
+        run: cd ./evaluator && cargo build --release
+      - name: Install Rust evaluator locally
+        run: |
+          VERSION=$(grep "QUINT_EVALUATOR_VERSION = " quint/src/rust/binaryManager.ts | sed "s/.*'\(.*\)'/\1/")
+          mkdir -p ~/.quint/rust-evaluator-$VERSION
+          cp evaluator/target/release/quint_evaluator ~/.quint/rust-evaluator-$VERSION/
+      - run: cd ./quint && npm ci
+      - run: cd ./quint && npm run compile && npm link
+      - name: Ensure all dependencies are specified
+        run: quint --version
+      - name: Set up apalache
+        run: |
+          # Fetch the latest apalache release
+          make apalache
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - if: matrix.operating-system == 'macos-latest'
+        # TODO(#1004): Workaround for GNU parallel not being available on macOS
+        name: Install GNU parallel
+        run: brew install parallel
+      - name: Ensure the examples dashboard is up to date
+        run: |
+          make examples
+          git diff --exit-code \
+            || ( echo ">>> ERROR: Examples dashboard is out of sync. Fix examples or run 'make examples'" && exit 1)
+
+  examples-dashboard-aggregator:
+    name: Examples Dashboard
+    needs: examples-dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All Examples Dashboard checks completed successfully!"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -40,7 +41,7 @@ jobs:
   lang-integration-tests:
     name: Lang Integration Tests by OS
     needs: changes
-    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
@@ -76,7 +77,7 @@ jobs:
   rust-backend-integration-tests:
     name: Rust Backend Integration Tests by OS
     needs: changes
-    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
@@ -113,7 +114,7 @@ jobs:
   verification-integration-tests:
     name: Verification Integration Tests by OS
     needs: changes
-    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
       fail-fast: false
@@ -160,64 +161,10 @@ jobs:
     steps:
       - run: echo "All Apalache integration tests completed successfully!"
 
-  examples-dashboard:
-    name: Examples Dashboard by OS
-    needs: changes
-    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || needs.changes.outputs.examples == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "19"
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Build Rust evaluator
-        run: cd ./evaluator && cargo build --release
-      - name: Install Rust evaluator locally
-        run: |
-          VERSION=$(grep "QUINT_EVALUATOR_VERSION = " quint/src/rust/binaryManager.ts | sed "s/.*'\(.*\)'/\1/")
-          mkdir -p ~/.quint/rust-evaluator-$VERSION
-          cp evaluator/target/release/quint_evaluator ~/.quint/rust-evaluator-$VERSION/
-      - run: cd ./quint && npm ci
-      - run: cd ./quint && npm run compile && npm link
-      - name: Ensure all dependencies are specified
-        run: quint --version
-      - name: Set up apalache
-        run: |
-          # Fetch the latest apalache release
-          make apalache
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - if: matrix.operating-system == 'macos-latest'
-        # TODO(#1004): Workaround for GNU parallel not being available on macOS
-        name: Install GNU parallel
-        run: brew install parallel
-      - name: Ensure the examples dashboard is up to date
-        run: |
-          make examples
-          git diff --exit-code \
-            || ( echo ">>> ERROR: Examples dashboard is out of sync. Fix examples or run 'make examples'" && exit 1)
-
-  examples-dashboard-aggregator:
-    name: Examples Dashboard
-    needs: examples-dashboard
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "All Examples Dashboard checks completed successfully!"
-
   distribution-integration-tests:
     name: Distribution Integration Tests
     needs: changes
-    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ needs.changes.outputs.quint == 'true' || needs.changes.outputs.evaluator == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-quint.yml
+++ b/.github/workflows/release-quint.yml
@@ -6,7 +6,15 @@ on:
       - "v*.*.*"
 
 jobs:
+  unit-tests:
+    uses: ./.github/workflows/test-quint.yml
+
+  integration-tests:
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+
   release:
+    needs: [unit-tests, integration-tests]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -23,31 +31,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Compile
         run: npm ci
-      - name: Run unit tests
-        run: npm run test
-      - name: Run integration tests
-        run: |
-          # Link quint to the system path
-          npm link
-          # Fetch the latest apalache release
-          make -C .. apalache
-          # This downloads Apalache to ~/.quint so the TLC backend can find the JAR later.
-          VERSION=$(grep "DEFAULT_APALACHE_VERSION_TAG = " src/apalache.ts | sed "s/.*'\(.*\)'/\1/")
-          mkdir -p ~/.quint/apalache-dist-$VERSION
-          cp -r _build/apalache ~/.quint/apalache-dist-$VERSION/
-          # Start the apalache server
-          _build/apalache/bin/apalache-mc server &
-          # Wait for the server to start
-          sleep 5
-          # Download the rust evaluator before the tests
-          quint run testFixture/simulator/gettingStarted.qnt --backend rust --max-samples=1 --max-steps=1
-          # Run remaining integration tests
-          npm run all-integration
-        env:
-          GH_TOKEN: ${{ github.token }}
-        # These tests fail on windows currently
-        # See https://github.com/anko/txm/issues/10
-        if: matrix.operating-system != 'windows-latest'
       - name: Extract release notes
         # Get the release notes for the version by printing all lines between lines
         # starting with the version header and ending with the next version header,
@@ -66,6 +49,7 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   wait-for-npm:
     needs: release
     runs-on: ubuntu-latest

--- a/.github/workflows/test-quint.yml
+++ b/.github/workflows/test-quint.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 jobs:
   changes:
@@ -34,7 +35,7 @@ jobs:
   unit-tests:
     name: Unit Tests by OS
     needs: changes
-    if: ${{ needs.changes.outputs.quint == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ needs.changes.outputs.quint == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ${{ matrix.operating-system }}
     defaults:
       run:


### PR DESCRIPTION
Hello :octocat: 

Our release process has some issues. We don't re-use the setup and tests we run on PR CI, which means things break often. Also, we run all tests sequentially, which takes a long time. 

This attempts to re-use the existing workflows so we know they work as we checked in CI already. Although it works as in main checks, where we don't skip unchanged things (when the trigger was a push to a tag, which is how our release is triggered)