### PR TITLE
Fix import for yargs on node 27+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed an import issue affecting yargs on node 27 (#1926)
+
 ### Security
 
 ## v0.31.0 -- 2026-02-27

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -11,7 +11,7 @@
  */
 
 import os from 'os'
-import yargs from 'yargs/yargs'
+import yargs from 'yargs'
 
 import {
   CLIProcedure,


### PR DESCRIPTION
I've stumbled upon a import bug after upgrading my node version:

```
$ quint repl .exit
file:///home/erickpintor/Projects/Informal/quint/quint/node_modules/yargs/yargs:3
const {applyExtends, cjsPlatformShim, Parser, Yargs, processArgv} = require('./build/index.cjs')
                                                                    ^

ReferenceError: require is not defined in ES module scope, you can use import instead
    at file:///home/erickpintor/Projects/Informal/quint/quint/node_modules/yargs/yargs:3:69
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:534:37)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:366:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1628:24)
    at Module._compile (node:internal/modules/cjs/loader:1793:5)
    at Object..js (node:internal/modules/cjs/loader:1951:10)
    at Module.load (node:internal/modules/cjs/loader:1532:32)
    at Module._load (node:internal/modules/cjs/loader:1334:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1555:12)

Node.js v25.7.0
```

This patch fixes it locally.

Closes #https://github.com/informalsystems/quint/issues/1926.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
