### PR TITLE
fix: detect state variable shadowing --init/--step action names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed `--step`/`--init` resolving to a state variable instead of an action when the variable is named `step` or `init` (#1969)
+
 ### Security
 
 ## v0.32.0 -- 2026-03-31

--- a/quint/integration-tests/verification.md
+++ b/quint/integration-tests/verification.md
@@ -30,7 +30,7 @@ quint verify --init=invalidInit ../examples/language-features/booleans.qnt
 <!-- !test err invalid init -->
 ```
 error: [QNT404] Name 'invalidInit' not found
-error: name resolution failed
+error: Argument error
 ```
 
 

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -398,9 +398,11 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
 
   const recorder = newTraceRecorder(options.verbosity, options.rng, options.numberOfTraces)
 
-  const argsParsingResult = mergeInMany(
-    [prev.args.init, prev.args.step, invariantString, ...prev.args.witnesses].map(e => toExpr(prev, e))
-  )
+  const argsParsingResult = mergeInMany([
+    toExpr(prev, prev.args.init, { kind: 'action', flag: 'init' }),
+    toExpr(prev, prev.args.step, { kind: 'action', flag: 'step' }),
+    ...[invariantString, ...prev.args.witnesses].map(e => toExpr(prev, e)),
+  ])
   if (argsParsingResult.isLeft()) {
     return cliErr('Argument error', {
       ...simulator,
@@ -547,6 +549,20 @@ export async function compile(typechecked: TypecheckedStage): Promise<CLIProcedu
   const main = typechecked.modules.find(m => m.name === mainName)
   if (!main) {
     return cliErr(`module ${mainName} does not exist`, { ...typechecked, errors: [], sourceCode: new Map() })
+  }
+
+  // Validate that --init and --step don't resolve to state variables (same check as runSimulator)
+  for (const [name, flag] of [
+    [args.init, 'init'],
+    [args.step, 'step'],
+  ] as const) {
+    const checkResult = toExpr(typechecked, name, { kind: 'action', flag })
+    if (checkResult.isLeft()) {
+      return cliErr('Argument error', {
+        ...typechecked,
+        errors: [checkResult.value].map(mkErrorMessage(new Map())),
+      })
+    }
   }
 
   const extraDefsAsText = [`action q::init = ${args.init}`, `action q::step = ${args.step}`]

--- a/quint/src/cliHelpers.ts
+++ b/quint/src/cliHelpers.ts
@@ -42,17 +42,18 @@ export function toExpr(
     return left(prev.resolver.errors[0])
   }
 
-  // When used as --init or --step, the resolved name must be an action, not a state variable.
-  // A variable named 'step' or 'init' shadows the default action name, causing confusing
+  // When used as --init or --step, the resolved name must be an action.
+  // A non-action definition (var, val, const, etc.) with the same name causes confusing
   // runtime errors or silently wrong results.
   if (expectedRole?.kind === 'action' && parseResult.expr.kind === 'name') {
     const def = prev.resolver.table.get(parseResult.expr.id)
-    if (def && def.kind === 'var') {
+    if (def && (def.kind !== 'def' || def.qualifier !== 'action')) {
+      const defKind = def.kind === 'def' ? def.qualifier : def.kind
       return left({
         code: 'QNT501',
         message:
-          `'${input}' resolves to a state variable, not an action. ` +
-          `Rename the variable or use --${expectedRole.flag} to specify a different action name.`,
+          `'${input}' is a ${defKind}, not an action. ` +
+          `Use --${expectedRole.flag} to specify an action name.`,
       })
     }
   }

--- a/quint/src/cliHelpers.ts
+++ b/quint/src/cliHelpers.ts
@@ -51,9 +51,7 @@ export function toExpr(
       const defKind = def.kind === 'def' ? def.qualifier : def.kind
       return left({
         code: 'QNT501',
-        message:
-          `'${input}' is a ${defKind}, not an action. ` +
-          `Use --${expectedRole.flag} to specify an action name.`,
+        message: `default --${expectedRole.flag} action name '${input}' is used by a ${defKind} declaration`,
       })
     }
   }

--- a/quint/src/cliHelpers.ts
+++ b/quint/src/cliHelpers.ts
@@ -25,7 +25,11 @@ export function mkErrorMessage(sourceMap: SourceMap): (_: QuintError) => ErrorMe
   }
 }
 
-export function toExpr(prev: TypecheckedStage, input: string): Either<QuintError, QuintEx> {
+export function toExpr(
+  prev: TypecheckedStage,
+  input: string,
+  expectedRole?: { kind: 'action'; flag: string }
+): Either<QuintError, QuintEx> {
   const mainName = guessMainModule(prev)
   const parseResult = parseExpressionOrDeclaration(input, '<input>', prev.idGen, prev.sourceMap)
   if (parseResult.kind !== 'expr') {
@@ -36,6 +40,21 @@ export function toExpr(prev: TypecheckedStage, input: string): Either<QuintError
   walkExpression(prev.resolver, parseResult.expr)
   if (prev.resolver.errors.length > 0) {
     return left(prev.resolver.errors[0])
+  }
+
+  // When used as --init or --step, the resolved name must be an action, not a state variable.
+  // A variable named 'step' or 'init' shadows the default action name, causing confusing
+  // runtime errors or silently wrong results.
+  if (expectedRole?.kind === 'action' && parseResult.expr.kind === 'name') {
+    const def = prev.resolver.table.get(parseResult.expr.id)
+    if (def && def.kind === 'var') {
+      return left({
+        code: 'QNT501',
+        message:
+          `'${input}' resolves to a state variable, not an action. ` +
+          `Rename the variable or use --${expectedRole.flag} to specify a different action name.`,
+      })
+    }
   }
 
   return right(parseResult.expr)

--- a/quint/test/cli.test.ts
+++ b/quint/test/cli.test.ts
@@ -32,7 +32,6 @@ describe('the typecheck CLI routine', () =>
   }))
 
 // Module where a state variable named 'step' shadows the default --step action name.
-// Used by tests for both 'step' and 'init' shadowing (the init case has its own module below).
 const stepVarModule = `
 module stepVarModule {
   var x: int
@@ -52,6 +51,25 @@ const stepVarLoaded = {
   warnings: [],
 }
 
+// Module where a val named 'step' shadows the default --step action name.
+const stepValModule = `
+module stepValModule {
+  var x: int
+  val step = 42
+
+  action init = all { x' = 0 }
+  action doStep = all { x' = x + 1 }
+}
+`
+
+const stepValLoaded = {
+  args: {},
+  path: 'mocked/stepVal',
+  sourceCode: new Map([['mocked/stepVal', stepValModule]]),
+  stage: 'loading' as stage,
+  warnings: [],
+}
+
 describe('toExpr with expectedRole', () => {
   it('rejects a state variable when expectedRole is action', async () => {
     const parsed = await parse(stepVarLoaded)
@@ -61,7 +79,21 @@ describe('toExpr with expectedRole', () => {
       const result = toExpr(tc, 'step', { kind: 'action', flag: 'step' })
       assert.isTrue(result.isLeft(), 'expected toExpr to return Left for var named step')
       result.mapLeft(err => {
-        assert.include(err.message, 'resolves to a state variable')
+        assert.include(err.message, 'not an action')
+        assert.include(err.message, '--step')
+      })
+    })
+  })
+
+  it('rejects a val when expectedRole is action', async () => {
+    const parsed = await parse(stepValLoaded)
+    const typechecked = await parsed.asyncChain(typecheck)
+
+    typechecked.map(tc => {
+      const result = toExpr(tc, 'step', { kind: 'action', flag: 'step' })
+      assert.isTrue(result.isLeft(), 'expected toExpr to return Left for val named step')
+      result.mapLeft(err => {
+        assert.include(err.message, 'not an action')
         assert.include(err.message, '--step')
       })
     })
@@ -111,7 +143,7 @@ module initVarModule {
       const result = toExpr(tc, 'init', { kind: 'action', flag: 'init' })
       assert.isTrue(result.isLeft(), 'expected toExpr to return Left for var named init')
       result.mapLeft(err => {
-        assert.include(err.message, 'resolves to a state variable')
+        assert.include(err.message, 'not an action')
         assert.include(err.message, '--init')
       })
     })

--- a/quint/test/cli.test.ts
+++ b/quint/test/cli.test.ts
@@ -2,6 +2,7 @@
 import { describe, it } from 'mocha'
 import { assert } from 'chai'
 import { parse, stage, typecheck } from '../src/cliCommands'
+import { toExpr } from '../src/cliHelpers'
 
 const exModule = `
 module exModule {
@@ -29,3 +30,90 @@ describe('the typecheck CLI routine', () =>
       .then(parsed => parsed.asyncChain(typecheck))
       .then(res => res.map(s => assert.equal(s.stage, 'typechecking')))
   }))
+
+// Module where a state variable named 'step' shadows the default --step action name.
+// Used by tests for both 'step' and 'init' shadowing (the init case has its own module below).
+const stepVarModule = `
+module stepVarModule {
+  var x: int
+  var step: int
+
+  action init = all { x' = 0, step' = 0 }
+  action doStep = all { x' = x + 1, step' = step + 1 }
+  val inv = x >= 0
+}
+`
+
+const stepVarLoaded = {
+  args: {},
+  path: 'mocked/stepVar',
+  sourceCode: new Map([['mocked/stepVar', stepVarModule]]),
+  stage: 'loading' as stage,
+  warnings: [],
+}
+
+describe('toExpr with expectedRole', () => {
+  it('rejects a state variable when expectedRole is action', async () => {
+    const parsed = await parse(stepVarLoaded)
+    const typechecked = await parsed.asyncChain(typecheck)
+
+    typechecked.map(tc => {
+      const result = toExpr(tc, 'step', { kind: 'action', flag: 'step' })
+      assert.isTrue(result.isLeft(), 'expected toExpr to return Left for var named step')
+      result.mapLeft(err => {
+        assert.include(err.message, 'resolves to a state variable')
+        assert.include(err.message, '--step')
+      })
+    })
+  })
+
+  it('accepts an action when expectedRole is action', async () => {
+    const parsed = await parse(stepVarLoaded)
+    const typechecked = await parsed.asyncChain(typecheck)
+
+    typechecked.map(tc => {
+      const result = toExpr(tc, 'doStep', { kind: 'action', flag: 'step' })
+      assert.isTrue(result.isRight(), 'expected toExpr to return Right for action named doStep')
+    })
+  })
+
+  it('accepts a state variable when expectedRole is not set', async () => {
+    const parsed = await parse(stepVarLoaded)
+    const typechecked = await parsed.asyncChain(typecheck)
+
+    typechecked.map(tc => {
+      const result = toExpr(tc, 'step')
+      assert.isTrue(result.isRight(), 'expected toExpr to accept var when no expectedRole')
+    })
+  })
+
+  it('rejects a state variable named init when expectedRole is action', async () => {
+    const initVarModule = `
+module initVarModule {
+  var x: int
+  var init: int
+  action myInit = all { x' = 0, init' = 0 }
+  action step = all { x' = x + 1, init' = init }
+  val inv = x >= 0
+}
+`
+    const initVarLoaded = {
+      args: {},
+      path: 'mocked/initVar',
+      sourceCode: new Map([['mocked/initVar', initVarModule]]),
+      stage: 'loading' as stage,
+      warnings: [],
+    }
+    const parsed = await parse(initVarLoaded)
+    const typechecked = await parsed.asyncChain(typecheck)
+
+    typechecked.map(tc => {
+      const result = toExpr(tc, 'init', { kind: 'action', flag: 'init' })
+      assert.isTrue(result.isLeft(), 'expected toExpr to return Left for var named init')
+      result.mapLeft(err => {
+        assert.include(err.message, 'resolves to a state variable')
+        assert.include(err.message, '--init')
+      })
+    })
+  })
+})

--- a/quint/test/cli.test.ts
+++ b/quint/test/cli.test.ts
@@ -79,7 +79,7 @@ describe('toExpr with expectedRole', () => {
       const result = toExpr(tc, 'step', { kind: 'action', flag: 'step' })
       assert.isTrue(result.isLeft(), 'expected toExpr to return Left for var named step')
       result.mapLeft(err => {
-        assert.include(err.message, 'not an action')
+        assert.include(err.message, 'is used by a')
         assert.include(err.message, '--step')
       })
     })
@@ -93,7 +93,7 @@ describe('toExpr with expectedRole', () => {
       const result = toExpr(tc, 'step', { kind: 'action', flag: 'step' })
       assert.isTrue(result.isLeft(), 'expected toExpr to return Left for val named step')
       result.mapLeft(err => {
-        assert.include(err.message, 'not an action')
+        assert.include(err.message, 'is used by a')
         assert.include(err.message, '--step')
       })
     })
@@ -143,7 +143,7 @@ module initVarModule {
       const result = toExpr(tc, 'init', { kind: 'action', flag: 'init' })
       assert.isTrue(result.isLeft(), 'expected toExpr to return Left for var named init')
       result.mapLeft(err => {
-        assert.include(err.message, 'not an action')
+        assert.include(err.message, 'is used by a')
         assert.include(err.message, '--init')
       })
     })


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
- [x] Tests added for any new code
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

**AI disclosure:** This PR was developed with AI assistance (Claude). The fix, tests, and manual verification were reviewed by a human.

---

## Problem

When a module defines a state variable named `step` or `init`, `quint run` resolves the `--step`/`--init` defaults to the variable instead of the transition action. The failure mode depends on the variable type and backend:

| | `var step: int` | `var step: bool` (init false) | `var step: bool` (init true) | `var init` |
|---|---|---|---|---|
| **rust** | `[QNT500] Expected boolean` | Silent: only init state, reports ok | `[QNT502] Variable x not set` | `[QNT502]` + error reporter crash |
| **typescript** | Uncaught JS exception | Silent: only init state, reports ok | `[QNT502] Variable x not set` | `[QNT502]` + error reporter crash |

The `var step: bool` case initialized to `false` is the most misleading. The simulator evaluates the variable (which is `false`) as the step result, treats the step as disabled, and reports success with only the init state. No error, no warning:

```
$ quint run example.qnt --invariant=inv --max-steps=10
[State 0] { step: false, x: 0 }
[ok] No violation found
Trace length statistics: max=1, min=1, average=1.00
```

When initialized to `true`, the simulator treats the step as succeeding but no state variables are assigned, so the next invariant check crashes with `Variable x not set`.

The same issue affects `quint compile` and `quint verify`. The generated `q::step`/`q::init` definitions silently bind to the variable.

**Repro (`var step: int`):**
```quint
module example {
  var x: int
  var step: int
  action init = all { x' = 0, step' = 0 }
  action doStep = all { x' = x + 1, step' = step + 1 }
  val inv = x >= 0
}
```

**Repro (`var step: bool`, silent wrong result):**
```quint
module example {
  var x: int
  var step: bool
  action init = all { x' = 0, step' = false }
  action doStep = all { x' = x + 1, step' = not(step) }
  val inv = x >= 0
}
```

Workaround: `--step=doStep` or `--init=myInit`.

## Fix

Add an optional `expectedRole` parameter to `toExpr()` in `cliHelpers.ts`. When resolving `--init` or `--step` arguments, check if the resolved name is a state variable (`kind === 'var'`) and return a descriptive error instead of letting downstream code crash or silently misbehave.

Validation runs before backend selection, so all backends (rust, typescript) and all commands (run, compile, verify) are covered.

**After:**
```
error: [QNT501] 'step' resolves to a state variable, not an action.
Rename the variable or use --step to specify a different action name.
```

## Changes

- `quint/src/cliHelpers.ts`: Add `expectedRole?: { kind: 'action', flag: string }` to `toExpr()`, check resolved definition kind, include the correct flag name in the error message
- `quint/src/cliCommands.ts`: Pass the role constraint for `--init` and `--step` in both `runSimulator()` and `compile()`
- `quint/test/cli.test.ts`: 4 new tests (rejects `var step`, rejects `var init` with `--init` in message, accepts action, accepts var without role constraint)
- `CHANGELOG.md`: Entry under UNRELEASED / Fixed