### PR TITLE
Fix tuples benchmark broken by compile init/step default changes

### DIFF
--- a/evaluator/benches/tuples.rs
+++ b/evaluator/benches/tuples.rs
@@ -3,7 +3,7 @@ use std::process::Stdio;
 use std::{io::Write, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use quint_evaluator::{evaluator::run, ir::QuintOutput};
+use quint_evaluator::{evaluator::run, helpers};
 use tempfile::NamedTempFile;
 
 fn run_in_rust(input: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -13,21 +13,7 @@ fn run_in_rust(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         }}"
     );
 
-    // A unique filename so multiple tests can run in parallel
-    let mut file = NamedTempFile::new()?;
-
-    file.write_all(quint_content.as_bytes())?;
-
-    let output = Command::new("quint")
-        .arg("compile")
-        .arg(file.path())
-        .stdout(std::process::Stdio::piped())
-        .output()
-        .unwrap();
-
-    let serialized_quint = String::from_utf8(output.stdout).unwrap();
-
-    let parsed: QuintOutput = serde_json::from_str(serialized_quint.as_str()).unwrap();
+    let parsed = helpers::parse(&quint_content, None)?;
 
     let def = parsed.find_definition_by_name("input").unwrap();
 


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->
The `tuples` benchmark called `quint compile <file>` with no extra args. After #1971, `compile` now defaults `--init`/`--step` to `"init"`/`"step"` whenever `--flatten=true` (the default), causing compilation to fail since the generated module has no `init`/`step` definitions.
Switched `run_in_rust` to `helpers::parse`, which passes `--flatten=false` (matching the rest of the benchmarks)
<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->