### PR TITLE
fix(tlc): isolate JVM tmpdir per invocation

### DIFF
--- a/quint/src/tlc.ts
+++ b/quint/src/tlc.ts
@@ -122,6 +122,7 @@ export async function verify(
     const proc = spawn('java', [
       maxHeap,
       stackSize,
+      `-Djava.io.tmpdir=${tmpDir}`,
       '-cp',
       jarPath,
       'tlc2.TLC',


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->
Hey,
Parallel TLC invocations (in verification integration tests) race on shared `stdlib` files in the system `tmpdir`, causing intermittent CI failures like: 
`Encountered an exception while attempt to validate /tmp/Apalache.tla  (No such file or directory)`

`tlc.ts` creates a unique per-invocation `tmpDir` via `mkdtempSync` for our `.tla/.cfg` files and TLC's -metadir, but the JVM is spawned without `-Djava.io.tmpdir`. the tla modules extracted from the JAR (`Integers.tla`, `TLC.tla`, …) are written straight into `/tmp`, shared across every concurrent run.

The fix is to pass `-Djava.io.tmpdir=${tmpDir} `to the JVM so each invocation extracts stdlib resources into its own isolated directory. 

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
