### PR TITLE
fix: Rename ITF files in integrations tests

### DIFF
--- a/quint/integration-tests/runtime/rust/run.md
+++ b/quint/integration-tests/runtime/rust/run.md
@@ -278,12 +278,12 @@ Use --seed=0x1d4c5 --backend=rust to reproduce.
 
 <!-- !test in run itf -->
 ```
-quint run --backend=rust --out-itf=out-itf-example.itf.json --max-steps=5 --seed=123 \
+quint run --backend=rust --out-itf=run-itf.itf.json --max-steps=5 --seed=123 \
   --invariant=no_negatives \
   --verbosity=0 \
   ./testFixture/simulator/gettingStarted.qnt
-cat out-itf-example.itf.json | jq '.states[0]."balances"."#map"[0]'
-rm out-itf-example.itf.json
+cat run-itf.itf.json | jq '.states[0]."balances"."#map"[0]'
+rm run-itf.itf.json
 ```
 
 <!-- !test out run itf -->
@@ -300,9 +300,9 @@ rm out-itf-example.itf.json
 
 <!-- !test in successful run itf -->
 ```
-quint run --backend=rust --out-itf=out-itf-example.itf.json --max-steps=5 --seed=123  --verbosity=0 ./testFixture/simulator/gettingStarted.qnt
-cat out-itf-example.itf.json | jq '.states[0]."balances"."#map"[0]'
-rm out-itf-example.itf.json
+quint run --backend=rust --out-itf=successful-run-itf.itf.json --max-steps=5 --seed=123  --verbosity=0 ./testFixture/simulator/gettingStarted.qnt
+cat successful-run-itf.itf.json | jq '.states[0]."balances"."#map"[0]'
+rm successful-run-itf.itf.json
 ```
 
 <!-- !test out successful run itf -->
@@ -319,12 +319,12 @@ rm out-itf-example.itf.json
 
 <!-- !test in run with n-traces itf violation -->
 ```
-quint run --backend=rust --out-itf=out-itf-example.itf.json --n-traces=3 --max-steps=5 --max-samples=10000 --seed=123 --verbosity=0  ./testFixture/simulator/gettingStarted.qnt \
+quint run --backend=rust --out-itf=run-with-n-traces-itf-violation.itf.json --n-traces=3 --max-steps=5 --max-samples=10000 --seed=123 --verbosity=0  ./testFixture/simulator/gettingStarted.qnt \
    --invariant=no_negatives 
-cat out-itf-example0.itf.json | jq '.["#meta"].status'
-cat out-itf-example1.itf.json | jq '.["#meta"].status'
-cat out-itf-example2.itf.json | jq '.["#meta"].status'
-rm out-itf-example*.itf.json
+cat run-with-n-traces-itf-violation0.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf-violation1.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf-violation2.itf.json | jq '.["#meta"].status'
+rm run-with-n-traces-itf-violation*.itf.json
 ```
 
 <!-- !test out run with n-traces itf violation -->
@@ -508,10 +508,10 @@ when using `quint run` with `--out-itf`.
 
 <!-- !test in expect no duplicate states in run -->
 ```
-quint run --backend=rust --out-itf=expect-run.itf.json --max-steps=20 --seed=42 --verbosity=0 \
+quint run --backend=rust --out-itf=expect-no-duplicate-states-in-run.itf.json --max-steps=20 --seed=42 --verbosity=0 \
   ./testFixture/expectNoStateDuplication.qnt
-cat expect-run.itf.json | jq '.states | length'
-rm expect-run.itf.json
+cat expect-no-duplicate-states-in-run.itf.json | jq '.states | length'
+rm expect-no-duplicate-states-in-run.itf.json
 ```
 
 <!-- !test out expect no duplicate states in run -->
@@ -565,11 +565,11 @@ Traces are identical
 ```
 quint run \
   --backend=rust \
-  --out-itf=rust-out.itf.json \
+  --out-itf=rust-backend-itf-output.itf.json \
   --max-steps=5 \
   ./testFixture/simulator/gettingStarted.qnt > /dev/null
-cat rust-out.itf.json | jq '.vars'
-rm rust-out.itf.json
+cat rust-backend-itf-output.itf.json | jq '.vars'
+rm rust-backend-itf-output.itf.json
 ```
 
 <!-- !test out rust backend itf output -->

--- a/quint/integration-tests/runtime/typescript/run.md
+++ b/quint/integration-tests/runtime/typescript/run.md
@@ -427,12 +427,12 @@ error: Invariant violated
 
 <!-- !test in run itf -->
 ```
-quint run --backend=typescript --out-itf=out-itf-example.itf.json --max-steps=5 --seed=123 \
+quint run --backend=typescript --out-itf=run-itf.itf.json --max-steps=5 --seed=123 \
   --invariant=totalSupplyDoesNotOverflowInv \
   --verbosity=0 \
   ../examples/tutorials/coin.qnt
-cat out-itf-example.itf.json | jq '.states[0]."balances"."#map"[0]'
-rm out-itf-example.itf.json
+cat run-itf.itf.json | jq '.states[0]."balances"."#map"[0]'
+rm run-itf.itf.json
 ```
 
 <!-- !test out run itf -->
@@ -449,12 +449,12 @@ rm out-itf-example.itf.json
 
 <!-- !test in run itf with metadata -->
 ```
-quint run --backend=typescript --out-itf=out-itf-mbt-example.itf.json --max-steps=5 --seed=123 \
+quint run --backend=typescript --out-itf=run-itf-with-metadata.itf.json --max-steps=5 --seed=123 \
   --invariant=totalSupplyDoesNotOverflowInv --mbt\
   --verbosity=0 \
   ../examples/tutorials/coin.qnt
-cat out-itf-mbt-example.itf.json | jq '.states[1]'
-rm out-itf-mbt-example.itf.json
+cat run-itf-with-metadata.itf.json | jq '.states[1]'
+rm run-itf-with-metadata.itf.json
 ```
 
 <!-- !test out run itf with metadata -->
@@ -522,9 +522,9 @@ rm out-itf-mbt-example.itf.json
 
 <!-- !test in successful run itf -->
 ```
-quint run --backend=typescript --out-itf=out-itf-example.itf.json --max-steps=5 --seed=123  --verbosity=0 ../examples/tutorials/coin.qnt
-cat out-itf-example.itf.json | jq '.states[0]."balances"."#map"[0]'
-rm out-itf-example.itf.json
+quint run --backend=typescript --out-itf=successful-run-itf.itf.json --max-steps=5 --seed=123  --verbosity=0 ../examples/tutorials/coin.qnt
+cat successful-run-itf.itf.json | jq '.states[0]."balances"."#map"[0]'
+rm successful-run-itf.itf.json
 ```
 
 <!-- !test out successful run itf -->
@@ -541,10 +541,10 @@ rm out-itf-example.itf.json
 
 <!-- !test in run with n-traces itf -->
 ```
-quint run --backend=typescript --out-itf=out-itf-example.itf.json --n-traces=3 --mbt --max-steps=5 --seed=123 --verbosity=0 --max-samples=10000 ../examples/tutorials/coin.qnt
-cat out-itf-example0.itf.json | jq '.["#meta"].status'
-cat out-itf-example1.itf.json | jq '.states[0]["mbt::actionTaken"]'
-rm out-itf-example*.itf.json
+quint run --backend=typescript --out-itf=run-with-n-traces-itf.itf.json --n-traces=3 --mbt --max-steps=5 --seed=123 --verbosity=0 --max-samples=10000 ../examples/tutorials/coin.qnt
+cat run-with-n-traces-itf0.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf1.itf.json | jq '.states[0]["mbt::actionTaken"]'
+rm run-with-n-traces-itf*.itf.json
 ```
 
 <!-- !test out run with n-traces itf -->
@@ -557,12 +557,12 @@ rm out-itf-example*.itf.json
 
 <!-- !test in run with n-traces itf violation -->
 ```
-quint run --backend=typescript --out-itf=out-itf-example.itf.json --n-traces=3 --max-steps=5 --seed=123 --verbosity=0 --max-samples=10000 ../examples/tutorials/coin.qnt \
+quint run --backend=typescript --out-itf=run-with-n-traces-itf-violation.itf.json --n-traces=3 --max-steps=5 --seed=123 --verbosity=0 --max-samples=10000 ../examples/tutorials/coin.qnt \
    --invariant=totalSupplyDoesNotOverflowInv 
-cat out-itf-example0.itf.json | jq '.["#meta"].status'
-cat out-itf-example1.itf.json | jq '.["#meta"].status'
-cat out-itf-example2.itf.json | jq '.["#meta"].status'
-rm out-itf-example*.itf.json
+cat run-with-n-traces-itf-violation0.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf-violation1.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf-violation2.itf.json | jq '.["#meta"].status'
+rm run-with-n-traces-itf-violation*.itf.json
 ```
 
 <!-- !test out run with n-traces itf violation -->
@@ -651,11 +651,11 @@ Use --seed=0x2b442ab439177 --backend=typescript to reproduce.
 <!-- !test exit 1 -->
 <!-- !test in run itf default verbosity -->
 ```
-output=$(quint run --backend=typescript --out-itf=out.itf.json --max-steps=5 --seed=123 \
+output=$(quint run --backend=typescript --out-itf=run-itf-default-verbosity.itf.json --max-steps=5 --seed=123 \
   --invariant=totalSupplyDoesNotOverflowInv \
   ../examples/tutorials/coin.qnt 2>&1)
 exit_code=$?
-rm out.itf.json
+rm run-itf-default-verbosity.itf.json
 echo "$output" | head
 exit $exit_code
 ```
@@ -700,10 +700,10 @@ when using `quint run` with `--out-itf`.
 
 <!-- !test in expect no duplicate states in run -->
 ```
-quint run --backend=typescript --out-itf=expect-run.itf.json --max-steps=20 --seed=42 --verbosity=0 \
+quint run --backend=typescript --out-itf=expect-no-duplicate-states-in-run.itf.json --max-steps=20 --seed=42 --verbosity=0 \
   ./testFixture/expectNoStateDuplication.qnt
-cat expect-run.itf.json | jq '.states | length'
-rm expect-run.itf.json
+cat expect-no-duplicate-states-in-run.itf.json | jq '.states | length'
+rm expect-no-duplicate-states-in-run.itf.json
 ```
 
 <!-- !test out expect no duplicate states in run -->
@@ -754,11 +754,11 @@ Traces are identical
 <!-- !test in itf output -->
 ```
 quint run --backend=typescript \
-  --out-itf=ts-out.itf.json \
+  --out-itf=itf-output.itf.json \
   --max-steps=5 \
   ./testFixture/simulator/gettingStarted.qnt > /dev/null
-cat ts-out.itf.json | jq '.vars'
-rm ts-out.itf.json
+cat itf-output.itf.json | jq '.vars'
+rm itf-output.itf.json
 ```
 
 <!-- !test out itf output -->


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->
Hey,
`txm` runs the test blocks inside a single markdown file in parallel from the same cwd, so multiple tests in `run.md` that all wrote to `out-itf-example.itf.json` raced on it and one test's `rm` would delete another's itf file which produced flaky no such file or directory failures on CI.

The fix gives each test block in `rust/run.md` and `typescript/run.md` its own ITF filename derived from the test name (e.g. run-itf.itf.json, run-with-n-traces-itf-violation.itf.json), so concurrent blocks can't collide.
<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
