### PR TITLE
Update TextMate grammar

### DIFF
--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -62,7 +62,11 @@
 				},
 				{
 					"name": "storage.type.quint",
-					"match": "\\b(Tup|Rec|Set|List|int|str|bool)\\b"
+					"match": "\\b(Set|List|int|str|bool)\\b"
+				},
+				{
+					"name": "support.type.quint",
+					"match": "\\b(Map|Tup|Rec)\\b"
 				}
 			]
 		},

--- a/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
+++ b/vscode/quint-vscode/syntaxes/quint.tmLanguage.json
@@ -6,6 +6,9 @@
 			"include": "#hashbangLine"
 		},
 		{
+			"include": "#docComments"
+		},
+		{
 			"include": "#lineComments"
 		},
 		{
@@ -19,6 +22,9 @@
 		},
 		{
 			"include": "#constants"
+		},
+		{
+			"include": "#punctuation"
 		},
 		{
 			"include": "#operators"
@@ -44,7 +50,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.quint",
-					"match": "\\b(module|import|from|export|as|if|else|not|or|and|implies|iff|all|any|leadsTo|strongFair|weakFair)\\b"
+					"match": "\\b(module|import|from|export|as|if|else|match|not|or|and|implies|iff|all|any|leadsTo|strongFair|weakFair)\\b"
 				}
 			]
 		},
@@ -64,20 +70,14 @@
 			"patterns": [
 				{
 					"name": "keyword.operator.quint",
-					"match": "(=>|<=|>|<|=|!=|\\.|\\*|\\+|-|/|%|\\^)"
+					"match": "(=>|->|<=|>|<|=|!=|'|\\.|\\*|\\+|-|/|%|\\^)"
 				}
 			]
 		},
 		"strings": {
 			"name": "string.quoted.double.quint",
 			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.quint",
-					"match": "\\\\."
-				}
-			]
+			"end": "\""
 		},
 		"numbers": {
 			"patterns": [
@@ -91,7 +91,7 @@
 			"patterns": [
 				{
 					"name": "constant.language.quint",
-					"match": "(false|true|Bool|Int|Nat)"
+					"match": "\\b(false|true|Bool|Int|Nat)\\b"
 				}
 			]
 		},
@@ -99,7 +99,31 @@
 			"patterns": [
 				{
 					"name": "comment.line.hashbang.quint",
-					"match": "^#!.*$"
+					"match": "\\A#!.*$"
+				}
+			]
+		},
+		"docComments": {
+			"patterns": [
+				{
+					"name": "comment.block.documentation.quint",
+					"match": "///.*$"
+				}
+			]
+		},
+		"punctuation": {
+			"patterns": [
+				{
+					"name": "keyword.operator.spread.quint",
+					"match": "\\.\\.\\."
+				},
+				{
+					"name": "punctuation.accessor.quint",
+					"match": "::"
+				},
+				{
+					"name": "punctuation.separator.quint",
+					"match": "\\|"
 				}
 			]
 		},


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->
Hey,
This PR  aligns `vscode/quint-vscode/syntaxes/quint.tmLanguage.json` with `Quint.g4`: adds missing tokens (`match`, `->`, `'`, `...`, `::`, `|`, `///` doc comments), word-bounds constants, removes invalid string escapes, and reclassifies `Map`/`Tup`/`Rec` to `support.type` in preparation for the Github Linguist PR.

<!-- Please ensure that your PR includes the following, as needed -->
- [ ] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [ ] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
