### PR TITLE
fix(RS): Fix Rust backend crash on user record fields named `reference` or `trace`

### DIFF
--- a/evaluator/src/ir.rs
+++ b/evaluator/src/ir.rs
@@ -19,6 +19,8 @@ pub type QuintName = HipStr<'static>;
 pub struct QuintError {
     pub code: String,
     pub message: String,
+    // Serialized as "#trace" so it cannot collide with user record fields.
+    #[serde(rename = "#trace")]
     pub trace: Vec<QuintId>,
 }
 

--- a/quint/integration-tests/runtime/rust/run.md
+++ b/quint/integration-tests/runtime/rust/run.md
@@ -100,6 +100,16 @@ Tests that `quint run` works with nested setOfMaps and oneOf.
 <!-- !test check 1736 -->
     quint run --backend=rust testFixture/bug1736setOfMaps.qnt
 
+### OK on run 1981
+
+Regression test for [#1981](https://github.com/informalsystems/quint/issues/1981).
+Tests that `quint run` works when user record fields are named `reference` or
+`trace`, which used to collide with the Rust evaluator's QuintError JSON keys
+and crash deserialization.
+
+<!-- !test check 1981 -->
+    quint run --backend=rust testFixture/bug1981fieldNameCollision.qnt
+
 ### Run finds an invariant violation
 
 The command `run` finds an invariant violation.

--- a/quint/src/jsonHelper.ts
+++ b/quint/src/jsonHelper.ts
@@ -1,3 +1,5 @@
+import { QuintError } from './quintError'
+
 // Preprocess troublesome types so they are represented in JSON.
 //
 // We need it particularly because, by default, serialization of Map and Set
@@ -18,28 +20,16 @@ export function replacer(_key: String, value: any): any {
 }
 
 /**
- * Reviver function for JSON.parse to ensure proper type conversions during deserialization.
+ * Convert a QuintError parsed from the Rust evaluator's wire format into the
+ * TS-internal shape: rename `#trace` to `trace` and convert each id to bigint.
  *
- * A "reviver" is the standard JavaScript term for the optional second parameter to JSON.parse(),
- * which is called for each key-value pair during parsing, allowing transformation of values.
- *
- * This reviver ensures that:
- * - QuintError.reference fields are converted from numbers to bigint
- *
- * @param key - The property key being parsed
- * @param value - The parsed value
- * @returns The potentially transformed value
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter
+ * Rust serializes the trace field as `#trace` so it cannot collide with user
+ * record fields named `trace` in the simulator output.
  */
-export function reviver(key: string, value: any): any {
-  // Convert QuintError.reference from number to bigint (TS backend compatibility)
-  if (key === 'reference' && value !== null && value !== undefined) {
-    return BigInt(value)
+export function reviveQuintError(err: any): QuintError {
+  const { ['#trace']: trace, ...rest } = err
+  if (Array.isArray(trace)) {
+    return { ...rest, trace: trace.map((v: any) => BigInt(v)) }
   }
-  // Convert QuintError.trace elements from number to bigint (Rust backend)
-  if (key === 'trace' && Array.isArray(value)) {
-    return value.map((v: any) => BigInt(v))
-  }
-  return value
+  return rest
 }

--- a/quint/src/rust/commandWrapper.ts
+++ b/quint/src/rust/commandWrapper.ts
@@ -18,7 +18,7 @@ import { TraceHook } from '../cliReporting'
 import { debugLog } from '../verbosity'
 import JSONbig from 'json-bigint'
 import { LookupDefinition, LookupTable } from '../names/base'
-import { reviver } from '../jsonHelper'
+import { reviveQuintError } from '../jsonHelper'
 import { ItfState, ItfValue, diagnosticsOfItf, ofItf, pendingDiagnosticsOfItf } from '../itf'
 import { Presets, SingleBar } from 'cli-progress'
 import readline from 'readline'
@@ -114,7 +114,8 @@ export class CommandWrapper {
     const output = result.value
 
     try {
-      const parsed: Outcome = JSONbig.parse(output, reviver)
+      const parsed: Outcome = JSONbig.parse(output)
+      parsed.errors = parsed.errors.map(reviveQuintError)
 
       // Convert traces to ITF and ensure seed is bigint Note: When a
       // SimulationError occurs in Rust, the error trace is included in
@@ -199,7 +200,8 @@ export class CommandWrapper {
     const output = result.value
 
     try {
-      const parsed: TestResult = JSONbig.parse(output, reviver)
+      const parsed: TestResult = JSONbig.parse(output)
+      parsed.errors = parsed.errors.map(reviveQuintError)
 
       // Convert seed to bigint
       parsed.seed = BigInt(parsed.seed)
@@ -255,11 +257,11 @@ export class CommandWrapper {
     }
 
     try {
-      const parsed = JSONbig.parse(result.value, reviver)
+      const parsed = JSONbig.parse(result.value)
       const values: ItfValue[] = []
       for (const r of parsed.results) {
         if (r.error) {
-          return left(r.error)
+          return left(reviveQuintError(r.error))
         }
         values.push(r.value)
       }

--- a/quint/src/rust/replServerWrapper.ts
+++ b/quint/src/rust/replServerWrapper.ts
@@ -23,7 +23,7 @@ import { Trace } from '../runtime/impl/trace'
 import { ChildProcess, spawn } from 'child_process'
 import readline from 'readline'
 import JSONbig from 'json-bigint'
-import { reviver } from '../jsonHelper'
+import { reviveQuintError } from '../jsonHelper'
 import { bigintCheckerReplacer } from './helpers'
 import { ofItfValue } from '../itf'
 import { RuntimeValue, rv } from '../runtime/impl/runtimeValue'
@@ -151,7 +151,10 @@ export class ReplServerWrapper {
 
     this.stdout.on('line', (line: string) => {
       try {
-        const response: ReplResponse = JSONbig.parse(line, reviver)
+        const response: ReplResponse = JSONbig.parse(line)
+        if ('err' in response && response.err) {
+          response.err = reviveQuintError(response.err)
+        }
 
         if (response.response === 'FatalError') {
           // Store the fatal error and shut down

--- a/quint/testFixture/bug1981fieldNameCollision.qnt
+++ b/quint/testFixture/bug1981fieldNameCollision.qnt
@@ -1,0 +1,16 @@
+module bug1981fieldNameCollision {
+  type Inner = { authority: int, round: int }
+
+  var data: { reference: Inner, trace: List[Inner] }
+
+  action init = {
+    data' = { reference: { authority: 0, round: 0 }, trace: [] }
+  }
+
+  action step = {
+    data' = {
+      reference: { authority: 1, round: data.reference.round + 1 },
+      trace: data.trace.append(data.reference),
+    }
+  }
+}


### PR DESCRIPTION
<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->
Hey,
This PR fixes #1981 . The Rust backend crashed with `TypeError: Cannot convert object to primitive value` whenever a user spec had a state variable containing a record field named `reference` or `trace`.

The TS wrapper around the Rust evaluator parsed its JSON output with a recursive `reviver` that called `BigInt(value)` on **any** key named `reference` or `trace`, assuming those keys could only come from a `QuintError`. But the Rust evaluator serializes user state into the same JSON tree, so a user record like

  ```quint
  type StatementBlock = { reference: BlockReference, parents: Set[BlockReference] }
  ```

produced `"reference": { authority, round, index }` in the output. The reviver then called `BigInt({...})` on the user record and threw an error.`commandWrapper.ts` re-wrapped the failure into the cryptic message reported in the issue.

### Fix

  - **Rust** (`evaluator/src/ir.rs`): serialize `QuintError.trace` as `#trace`. The `#` prefix is invalid in Quint identifiers, so the wire key can never collide with a user record field (ITF already uses this for `#meta`, `#set`, `#map`, etc.)
  - **TS** (`quint/src/jsonHelper.ts`): drop the recursive `reviver`. Add `reviveQuintError(err)` which renames `#trace` → `trace` and converts each id to `bigint`.
  - **TS** (`commandWrapper.ts`, `replServerWrapper.ts`): parse without a reviver, then apply `reviveQuintError` at the few known QuintError sites (`parsed.errors` for simulate/test, `r.error` for `evaluateAtState`, `response.err` in the REPL wrapper). 

A regression integration test was added.

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
