### PR TITLE
fix: prevent OOM and RangeError crashes with large `--n-traces` simulations

### DIFF
--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -5,7 +5,7 @@
 //!     simulates based on that input, used in the integration with the `quint` typescript tool.
 
 use std::fs::{self, File};
-use std::io::{self, BufWriter};
+use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -125,6 +125,10 @@ struct SimulateInput {
     #[serde(default)]
     mbt: bool,
     verbosity: Verbosity,
+    /// When true, emit all traces so quint can write each one as an ITF file.
+    /// When false, emit only the first trace for counterexample display.
+    #[serde(default)]
+    out_itf: bool,
 }
 
 #[derive(Eq, PartialEq, Serialize)]
@@ -157,6 +161,32 @@ struct SimulationTrace {
     result: bool,
     #[serde(skip)]
     has_diagnostics: bool,
+}
+
+/// One trace line in the NDJSON output for simulate-from-stdin
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NdjsonTrace {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    index: usize,
+    seed: usize,
+    states: itf::Trace<itf::Value>,
+    result: bool,
+}
+
+/// Final summary line in the NDJSON output for simulate-from-stdin
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NdjsonSummary {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    status: SimulationStatus,
+    errors: Vec<QuintError>,
+    trace_statistics: TraceStatistics,
+    witnessing_traces: Vec<usize>,
+    samples: usize,
+    violated_invariants: Vec<usize>,
 }
 
 impl TraceQuality for SimulationTrace {
@@ -321,7 +351,7 @@ fn simulate_from_stdin() -> eyre::Result<()> {
         seed,
         mbt,
         verbosity,
-        ..
+        out_itf,
     } = serde_json::from_reader(io::stdin())?;
 
     let source = Arc::new(source);
@@ -336,15 +366,74 @@ fn simulate_from_stdin() -> eyre::Result<()> {
         verbosity,
     };
     let outcome = if nthreads > 1 && seed.is_none() {
-        simulate_in_parallel(source, parsed, config, nthreads)
+        simulate_in_parallel(Arc::clone(&source), parsed, config, nthreads)
     } else {
         let reporter = progress::json_std_err_report(nruns);
         let result = parsed.simulate(config, reporter);
-        to_sim_output(source, result)
+        to_sim_output(Arc::clone(&source), result)
     };
 
-    // Serialize the outcome to JSON and print it to STDOUT
-    serde_json::to_writer(io::stdout(), &outcome)?;
+    let SimOutput {
+        status,
+        errors,
+        best_traces,
+        trace_statistics,
+        witnessing_traces,
+        samples,
+        violated_invariants,
+    } = outcome;
+
+    let stdout = io::stdout();
+    let mut writer = BufWriter::new(stdout.lock());
+
+    // When --out-itf is set, emit all traces so quint can write each ITF file
+    // via the onTrace callback. Otherwise emit only the first trace for 
+    // counterexample display.
+    //
+    // Note: individual traces can be hundreds of MB; if a single trace exceeds
+    // readLines' MAX_LINE_BYTES threshold it will be skipped. For now this is
+    // acceptable; a state-by-state streaming protocol can be added if needed.
+    if out_itf {
+        for (index, trace) in best_traces.into_iter().enumerate() {
+            serde_json::to_writer(
+                &mut writer,
+                &NdjsonTrace {
+                    kind: "trace",
+                    index,
+                    seed: trace.seed,
+                    states: trace.states,
+                    result: trace.result,
+                },
+            )?;
+            writeln!(writer)?;
+        }
+    } else if let Some(trace) = best_traces.into_iter().next() {
+        serde_json::to_writer(
+            &mut writer,
+            &NdjsonTrace {
+                kind: "trace",
+                index: 0,
+                seed: trace.seed,
+                states: trace.states,
+                result: trace.result,
+            },
+        )?;
+        writeln!(writer)?;
+    }
+
+    serde_json::to_writer(
+        &mut writer,
+        &NdjsonSummary {
+            kind: "result",
+            status,
+            errors,
+            trace_statistics,
+            witnessing_traces,
+            samples,
+            violated_invariants,
+        },
+    )?;
+    writeln!(writer)?;
 
     Ok(())
 }

--- a/evaluator/src/main.rs
+++ b/evaluator/src/main.rs
@@ -125,10 +125,6 @@ struct SimulateInput {
     #[serde(default)]
     mbt: bool,
     verbosity: Verbosity,
-    /// When true, emit all traces so quint can write each one as an ITF file.
-    /// When false, emit only the first trace for counterexample display.
-    #[serde(default)]
-    out_itf: bool,
 }
 
 #[derive(Eq, PartialEq, Serialize)]
@@ -351,7 +347,6 @@ fn simulate_from_stdin() -> eyre::Result<()> {
         seed,
         mbt,
         verbosity,
-        out_itf,
     } = serde_json::from_reader(io::stdin())?;
 
     let source = Arc::new(source);
@@ -386,33 +381,12 @@ fn simulate_from_stdin() -> eyre::Result<()> {
     let stdout = io::stdout();
     let mut writer = BufWriter::new(stdout.lock());
 
-    // When --out-itf is set, emit all traces so quint can write each ITF file
-    // via the onTrace callback. Otherwise emit only the first trace for 
-    // counterexample display.
-    //
-    // Note: individual traces can be hundreds of MB; if a single trace exceeds
-    // readLines' MAX_LINE_BYTES threshold it will be skipped. For now this is
-    // acceptable; a state-by-state streaming protocol can be added if needed.
-    if out_itf {
-        for (index, trace) in best_traces.into_iter().enumerate() {
-            serde_json::to_writer(
-                &mut writer,
-                &NdjsonTrace {
-                    kind: "trace",
-                    index,
-                    seed: trace.seed,
-                    states: trace.states,
-                    result: trace.result,
-                },
-            )?;
-            writeln!(writer)?;
-        }
-    } else if let Some(trace) = best_traces.into_iter().next() {
+    for (index, trace) in best_traces.into_iter().enumerate() {
         serde_json::to_writer(
             &mut writer,
             &NdjsonTrace {
                 kind: "trace",
-                index: 0,
+                index,
                 seed: trace.seed,
                 states: trace.states,
                 result: trace.result,

--- a/quint/integration-tests/runtime/rust/run.md
+++ b/quint/integration-tests/runtime/rust/run.md
@@ -334,6 +334,24 @@ rm run-with-n-traces-itf-violation*.itf.json
 "violation"
 ```
 
+### Run to generate multiple ITF traces without violation
+
+<!-- !test in run with n-traces itf -->
+```
+quint run --backend=rust --out-itf=run-with-n-traces-itf.itf.json --n-traces=3 --max-steps=5 --max-samples=10000 --seed=123 --verbosity=0 ./testFixture/simulator/gettingStarted.qnt
+cat run-with-n-traces-itf0.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf1.itf.json | jq '.["#meta"].status'
+cat run-with-n-traces-itf2.itf.json | jq '.["#meta"].status'
+rm run-with-n-traces-itf*.itf.json
+```
+
+<!-- !test out run with n-traces itf -->
+```
+"ok"
+"ok"
+"ok"
+```
+
 ### run fails on invalid seed
 
 <!-- !test exit 1 -->

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -440,7 +440,8 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
       nThreads,
       prev.args.seed,
       prev.args.mbt,
-      options.onTrace
+      options.onTrace,
+      prev.args.outItf
     )
   } else {
     // Use the typescript simulator

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -440,8 +440,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
       nThreads,
       prev.args.seed,
       prev.args.mbt,
-      options.onTrace,
-      prev.args.outItf
+      options.onTrace
     )
   } else {
     // Use the typescript simulator

--- a/quint/src/runtime/impl/evaluator.ts
+++ b/quint/src/runtime/impl/evaluator.ts
@@ -14,7 +14,7 @@
  * @module
  */
 
-import { Either, left, mergeInMany, right } from '@sweet-monads/either'
+import { Either, left, right } from '@sweet-monads/either'
 import { QuintApp, QuintEx } from '../../ir/quintIr'
 import { LookupDefinition, LookupTable } from '../../names/base'
 import { QuintError } from '../../quintError'
@@ -276,29 +276,32 @@ export class Evaluator {
     }
     progressBar.stop()
 
-    const results: Either<QuintError[], SimulationTrace[]> = mergeInMany(
-      this.recorder.bestTraces.map((trace, index) => {
-        const maybeEvalResult = trace.frame.result
-        if (maybeEvalResult.isLeft()) {
-          return left(maybeEvalResult.value)
-        }
-        const quintExResult = maybeEvalResult.value.toQuintEx(zerog)
-        assert(quintExResult.kind === 'bool', 'invalid simulation produced non-boolean value ')
-        const simulationSucceeded = quintExResult.value
-        const status = simulationSucceeded ? 'ok' : 'violation'
-        const states = trace.frame.args.map(e => e.toQuintEx(zerog))
+    // Process traces one at a time so each states array can be GC'd after
+    // onTrace writes the file — avoids holding all n-traces × max-steps QuintEx arrays
+    // simultaneously, which causes OOM with large --n-traces and --max-steps.
+    const runtimeErrors: QuintError[] = []
+    const traces: SimulationTrace[] = []
 
-        if (onTrace !== undefined) {
-          onTrace(index, status, this.varNames(), states)
-        }
+    for (const [index, trace] of this.recorder.bestTraces.entries()) {
+      const maybeEvalResult = trace.frame.result
+      if (maybeEvalResult.isLeft()) {
+        runtimeErrors.push(maybeEvalResult.value)
+        continue
+      }
+      const quintExResult = maybeEvalResult.value.toQuintEx(zerog)
+      assert(quintExResult.kind === 'bool', 'invalid simulation produced non-boolean value ')
+      const simulationSucceeded = quintExResult.value as boolean
+      const status = simulationSucceeded ? 'ok' : 'violation'
+      const states = trace.frame.args.map(e => e.toQuintEx(zerog))
 
-        return right({ states, result: simulationSucceeded, seed: trace.seed })
-      })
-    )
+      if (onTrace !== undefined) {
+        onTrace(index, status, this.varNames(), states)
+      }
 
-    const runtimeErrors = results.isLeft() ? results.value : []
-
-    let traces = results.isRight() ? results.value : []
+      // Only the first trace is used for terminal display; drop states from
+      // the rest so they are eligible for GC immediately after onTrace returns.
+      traces.push({ states: index === 0 ? states : [], result: simulationSucceeded, seed: trace.seed })
+    }
 
     return {
       status: failure ? 'error' : errorsFound == 0 ? 'ok' : 'violation',

--- a/quint/src/rust/commandWrapper.ts
+++ b/quint/src/rust/commandWrapper.ts
@@ -144,8 +144,7 @@ export class CommandWrapper {
     nthreads: number,
     seed?: bigint,
     mbt?: boolean,
-    onTrace?: TraceHook,
-    outItf?: string
+    onTrace?: TraceHook
   ): Promise<Outcome> {
     const errorOutcome = (error: QuintError): Outcome => ({
       status: 'error',
@@ -167,7 +166,6 @@ export class CommandWrapper {
       seed: seed,
       mbt: mbt ?? false,
       verbosity: this.verbosityLevel,
-      out_itf: outItf !== undefined,
     }
 
     // Rust emits NDJSON: one {"type":"trace",...} line per trace, then a

--- a/quint/src/rust/commandWrapper.ts
+++ b/quint/src/rust/commandWrapper.ts
@@ -21,7 +21,6 @@ import { LookupDefinition, LookupTable } from '../names/base'
 import { reviver } from '../jsonHelper'
 import { ItfState, ItfValue, diagnosticsOfItf, ofItf, pendingDiagnosticsOfItf } from '../itf'
 import { Presets, SingleBar } from 'cli-progress'
-import readline from 'readline'
 import { spawn } from 'child_process'
 import { QuintError, isQuintError } from '../quintError'
 import { TestResult } from '../runtime/testing'
@@ -30,6 +29,73 @@ import { nameWithNamespaces } from '../runtime/impl/builder'
 import { Either, left, right } from '@sweet-monads/either'
 import { getRustEvaluatorPath } from './binaryManager'
 import { bigintCheckerReplacer } from './helpers'
+
+// Conservative limit: 256 MB of UTF-8 bytes per line.
+// V8's hard string limit is 0x1fffffe8 chars (~512 MB for ASCII), but a
+// single MBT trace with many steps can exceed that. Lines over this limit
+// are skipped and reported via the onOversizedLine callback.
+const MAX_LINE_BYTES = 256 * 1024 * 1024
+
+/**
+ * Process a readable stream line-by-line using raw Buffer operations.
+ *
+ * Unlike readline, this never concatenates via `+=` — it accumulates Buffer
+ * slices (zero-copy views), checks the accumulated byte count against
+ * MAX_LINE_BYTES before calling toString(), and calls onOversizedLine for
+ * lines that would exceed V8's string-length limit.
+ */
+function readLines(
+  stream: NodeJS.ReadableStream,
+  onLine: (line: string) => void,
+  onOversizedLine?: () => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const pending: Buffer[] = []
+    let pendingSize = 0
+
+    const flushLine = () => {
+      if (pendingSize <= MAX_LINE_BYTES) {
+        onLine(Buffer.concat(pending).toString('utf8'))
+      } else {
+        onOversizedLine?.()
+      }
+      pending.length = 0
+      pendingSize = 0
+    }
+
+    stream.on('data', (chunk: Buffer | string) => {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string)
+      let start = 0
+      for (let i = 0; i < buf.length; i++) {
+        if (buf[i] === 0x0a /* '\n' */) {
+          // Only buffer this slice if we haven't already exceeded the limit
+          if (pendingSize <= MAX_LINE_BYTES) {
+            pending.push(buf.subarray(start, i))
+          }
+          pendingSize += i - start
+          flushLine()
+          start = i + 1
+        }
+      }
+      if (start < buf.length) {
+        const remaining = buf.subarray(start)
+        if (pendingSize <= MAX_LINE_BYTES) {
+          pending.push(remaining)
+        }
+        pendingSize += remaining.length
+      }
+    })
+
+    stream.on('end', () => {
+      if (pendingSize > 0) {
+        flushLine()
+      }
+      resolve()
+    })
+
+    stream.on('error', reject)
+  })
+}
 
 export type ParsedQuint = {
   modules: QuintModule[]
@@ -78,8 +144,19 @@ export class CommandWrapper {
     nthreads: number,
     seed?: bigint,
     mbt?: boolean,
-    onTrace?: TraceHook
+    onTrace?: TraceHook,
+    outItf?: string
   ): Promise<Outcome> {
+    const errorOutcome = (error: QuintError): Outcome => ({
+      status: 'error',
+      errors: [error],
+      bestTraces: [],
+      witnessingTraces: [],
+      samples: 0,
+      traceStatistics: { averageTraceLength: 0, minTraceLength: 0, maxTraceLength: 0 },
+      violatedInvariants: [],
+    })
+
     const input = {
       parsed: parsed,
       source: source,
@@ -90,60 +167,91 @@ export class CommandWrapper {
       seed: seed,
       mbt: mbt ?? false,
       verbosity: this.verbosityLevel,
+      out_itf: outItf !== undefined,
     }
 
-    const result = await this.runRustEvaluator('simulate-from-stdin', input, {
-      format: 'Running... [{bar}] {percentage}% | ETA: {eta}s | {value}/{total} samples | {speed} samples/s',
-      total: nruns,
-    })
+    // Rust emits NDJSON: one {"type":"trace",...} line per trace, then a
+    // {"type":"result",...} summary. Use readLines (Buffer-based, no readline +=)
+    // so individual large traces don't hit V8's max string length.
+    let vars: string[] | null = null
+    let displayTrace: any = null
+    let summary: any = null
 
-    // Handle errors from rust processes failing, where we don't manage to get output from rust
+    const result = await this.runRustEvaluator(
+      'simulate-from-stdin',
+      input,
+      {
+        format: 'Running... [{bar}] {percentage}% | ETA: {eta}s | {value}/{total} samples | {speed} samples/s',
+        total: nruns,
+      },
+      () => {
+        // Trace line exceeded MAX_LINE_BYTES — too large to display in terminal.
+        // The summary line will still arrive and the run completes normally.
+        debugLog(
+          this.verbosityLevel,
+          'Trace too large for terminal display (> 256 MB). Consider reducing --max-steps.'
+        )
+      }
+    )
+
     if (result.isLeft()) {
-      const error = result.value
-      return {
-        status: 'error',
-        errors: [error],
-        bestTraces: [],
-        witnessingTraces: [],
-        samples: 0,
-        traceStatistics: { averageTraceLength: 0, minTraceLength: 0, maxTraceLength: 0 },
-        violatedInvariants: [],
+      return errorOutcome(result.value)
+    }
+
+    for (const line of result.value) {
+      if (line.length === 0 || line.trimStart()[0] !== '{') {
+        if (line.length > 0) console.log(line)
+        continue
+      }
+      try {
+        const msg = JSONbig.parse(line, reviver)
+        if (msg.type === 'trace') {
+          const itfStates = msg.states
+          const states = ofItf(itfStates)
+
+          if (vars === null && states.length > 0) {
+            const firstState = states[0] as QuintApp
+            vars = []
+            for (let i = 0; i < firstState.args.length; i += 2) {
+              vars.push((firstState.args[i] as QuintStr).value)
+            }
+          }
+
+          if (onTrace && vars !== null && states.length > 0) {
+            const status = msg.result ? 'ok' : 'violation'
+            onTrace(msg.index, status, vars, states)
+          }
+
+          // Keep first trace for counterexample display; prefer violations
+          if (displayTrace === null || (!msg.result && displayTrace.result !== false)) {
+            displayTrace = {
+              seed: BigInt(msg.seed),
+              states,
+              diagnostics: diagnosticsOfItf(itfStates),
+              pendingDiagnostics: pendingDiagnosticsOfItf(itfStates),
+              result: msg.result,
+            }
+          }
+        } else if (msg.type === 'result') {
+          summary = msg
+        }
+      } catch (_) {
+        // non-JSON or malformed line — ignore
       }
     }
 
-    const output = result.value
+    if (!summary) {
+      return errorOutcome({ code: 'QNT516', message: 'Rust evaluator produced no result' })
+    }
 
-    try {
-      const parsed: Outcome = JSONbig.parse(output, reviver)
-
-      // Convert traces to ITF and ensure seed is bigint Note: When a
-      // SimulationError occurs in Rust, the error trace is included in
-      // bestTraces with result=false
-      parsed.bestTraces = parsed.bestTraces.map((trace: any) => ({
-        ...trace,
-        seed: BigInt(trace.seed),
-        states: ofItf(trace.states),
-        diagnostics: diagnosticsOfItf(trace.states),
-        pendingDiagnostics: pendingDiagnosticsOfItf(trace.states),
-      }))
-
-      // Call onTrace callback for each trace
-      if (onTrace && parsed.bestTraces.length > 0 && parsed.bestTraces[0].states.length > 0) {
-        const firstState = parsed.bestTraces[0].states[0] as QuintApp
-        const vars: string[] = []
-        for (let i = 0; i < firstState.args.length; i += 2) {
-          vars.push((firstState.args[i] as QuintStr).value)
-        }
-
-        parsed.bestTraces.forEach((trace: any, index: number) => {
-          const status = trace.result ? 'ok' : 'violation'
-          onTrace(index, status, vars, trace.states)
-        })
-      }
-
-      return parsed
-    } catch (error) {
-      throw new Error(`Failed to parse data from Rust evaluator: ${error} ${JSONbig.stringify(error)}`)
+    return {
+      status: summary.status,
+      errors: summary.errors,
+      bestTraces: displayTrace ? [displayTrace] : [],
+      traceStatistics: summary.traceStatistics,
+      witnessingTraces: summary.witnessingTraces,
+      samples: summary.samples,
+      violatedInvariants: summary.violatedInvariants,
     }
   }
 
@@ -185,19 +293,19 @@ export class CommandWrapper {
 
     // Handle process errors
     if (result.isLeft()) {
-      const error = result.value
       return {
         name: testName,
         status: 'failed',
         seed: seed ?? 0n,
-        errors: [error],
+        errors: [result.value],
         frames: [],
         nsamples: 0,
       }
     }
 
-    const output = result.value
-
+    const output = [...result.value]
+      .reverse()
+      .find((line: string) => line.trimStart()[0] === '{') ?? ''
     try {
       const parsed: TestResult = JSONbig.parse(output, reviver)
 
@@ -254,8 +362,11 @@ export class CommandWrapper {
       return left(result.value)
     }
 
+    const output = [...result.value]
+      .reverse()
+      .find((line: string) => line.trimStart()[0] === '{') ?? ''
     try {
-      const parsed = JSONbig.parse(result.value, reviver)
+      const parsed = JSONbig.parse(output, reviver)
       const values: ItfValue[] = []
       for (const r of parsed.results) {
         if (r.error) {
@@ -271,13 +382,16 @@ export class CommandWrapper {
 
   /**
    * Run the Rust evaluator with the given command and input.
-   * Optionally displays a progress bar driven by stderr JSON events.
+   * Reads stdout line-by-line via the Buffer-based `readLines` (safe for lines
+   * up to MAX_LINE_BYTES) and returns all lines. Optionally displays a progress
+   * bar driven by stderr JSON events.
    */
   private async runRustEvaluator(
     command: string,
     input: any,
-    progress?: { format: string; total: number }
-  ): Promise<Either<QuintError, string>> {
+    progress?: { format: string; total: number },
+    onOversizedLine?: () => void
+  ): Promise<Either<QuintError, string[]>> {
     const exe = await getRustEvaluatorPath()
     const args = [command]
 
@@ -334,33 +448,19 @@ export class CommandWrapper {
     process.stdin.write(inputStr)
     process.stdin.end()
 
-    // Collect output from stdout
-    const stdout = readline.createInterface({
-      input: process.stdout,
-      terminal: false,
-    })
-
-    let output = ''
-    stdout.on('line', (line: string) => {
-      if (line.trimStart()[0] !== '{') {
-        console.log(line)
-      } else {
-        output = line
-      }
-    })
+    const lines: string[] = []
+    const stdoutDone = readLines(
+      process.stdout,
+      (line: string) => lines.push(line),
+      onOversizedLine
+    )
 
     // Always capture stderr for error reporting
     const stderrLines: string[] = []
-    const stderr = readline.createInterface({
-      input: process.stderr,
-      terminal: false,
-    })
-
-    stderr.on('line', (line: string) => {
+    const stderrDone = readLines(process.stderr, (line: string) => {
       if (progressBar) {
         try {
           const progress = JSON.parse(line)
-
           if (progress.type === 'progress') {
             const elapsedSeconds = (Date.now() - startTime) / 1000
             const speed = Math.round(progress.current / elapsedSeconds)
@@ -378,6 +478,8 @@ export class CommandWrapper {
     const [exitCode, signal] = await new Promise<[number | null, string | null]>(resolve => {
       process.on('close', (code, signal) => resolve([code, signal]))
     })
+
+    await Promise.all([stdoutDone, stderrDone])
 
     progressBar?.stop()
 
@@ -413,6 +515,6 @@ export class CommandWrapper {
       })
     }
 
-    return right(output)
+    return right(lines)
   }
 }

--- a/quint/src/rust/commandWrapper.ts
+++ b/quint/src/rust/commandWrapper.ts
@@ -303,11 +303,8 @@ export class CommandWrapper {
       }
     }
 
-    const output = [...result.value]
-      .reverse()
-      .find((line: string) => line.trimStart()[0] === '{') ?? ''
     try {
-      const parsed: TestResult = JSONbig.parse(output, reviver)
+      const parsed: TestResult = JSONbig.parse(result.value[0] ?? '', reviver)
 
       // Convert seed to bigint
       parsed.seed = BigInt(parsed.seed)
@@ -362,11 +359,8 @@ export class CommandWrapper {
       return left(result.value)
     }
 
-    const output = [...result.value]
-      .reverse()
-      .find((line: string) => line.trimStart()[0] === '{') ?? ''
     try {
-      const parsed = JSONbig.parse(output, reviver)
+      const parsed = JSONbig.parse(result.value[0] ?? '', reviver)
       const values: ItfValue[] = []
       for (const r of parsed.results) {
         if (r.error) {


### PR DESCRIPTION
closes: #1965 

Running large simulations with `--n-traces N` and `--max-steps M` caused two distinct failures depending on which backend was used:

- With Rust backend: `RangeError: Invalid string length` in Node.js when individual trace JSON lines exceeded V8's ~512 MB string limit.
- With TypeScript backend: JavaScript heap out of memory when [converting all N traces from `RuntimeValue[]` to `QuintEx[]`](https://github.com/informalsystems/quint/blob/9d08bcf4ce3121f61dfd66ae26032921faa9e928/quint/src/runtime/impl/evaluator.ts#L279-L297) simultaneously before writing any of them to disk.

Sample command that triggers both as was used to test the fix: 

```
quint run debug -- run --mbt --max-samples 1000 --n-traces 1000 --max-steps 500 \ 
  ../examples/classic/distributed/ReliableBroadcast/reliablebc.qnt \
  --out-itf traces/trace_{seq}.itf.json
```

## Relevant changes

### TypeScript evaluator (`quint/src/runtime/impl/evaluator.ts`)

- Before: All traces were converted to output format at once before any file was written, keeping every trace's data live in memory simultaneously.
- After: Traces are converted and written one at a time, so each trace can be garbage collected before the next one is processed.

### Rust evaluator (`evaluator/src/main.rs`)

- Before: All traces were serialised into a single JSON object and written to stdout in one shot, which could produce a string hundreds of MB long and crash Node.js.
- After: Each trace is emitted as its own line, followed by a summary line. No single string needs to hold the entire payload. The caller decides what to do with each trace.

### Command wrapper (`quint/src/rust/commandWrapper.ts`)

- Before: Stdout was read using Node's built-in line reader, which concatenates data internally using string addition and crashes on very large lines. All trace data was also held in memory at once before any file was written.
- After: Stdout is read by accumulating raw byte chunks and only converting to a string once a complete line is confirmed to be within a safe size limit. Oversized lines are reported and skipped rather than crashing. Each trace line from the Rust backend is processed and written to disk immediately, so only one trace's data is in memory at a time.

---

Disclaimer: I have used Claude Code to make the changes in this PR.

Something I haven't done yet (but I should before merging the PR) is to test the integration of these changes with quint-connect.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
