### PR TITLE
Ignore non-boolean Rust test results

### DIFF
--- a/evaluator/fixtures/runs.qnt
+++ b/evaluator/fixtures/runs.qnt
@@ -19,6 +19,11 @@ module simple_test {
     1 + 1 == 3
   }
 
+  // Test that returns a non-boolean value
+  run ignoredTest = {
+    1
+  }
+
   // Test that uses assert and fails (fails with QNT508)
   run failingAssertTest = {
     assert(1 + 1 == 3)

--- a/evaluator/src/tester.rs
+++ b/evaluator/src/tester.rs
@@ -68,6 +68,7 @@ impl TestCase {
             violation: false,
             seed,
         };
+        let mut ignored = false;
 
         for _ in 0..max_samples {
             let prev_rng_state = env.rand.get_state();
@@ -81,8 +82,8 @@ impl TestCase {
             trace.states = std::mem::take(&mut env.trace);
 
             match test_result {
-                Ok(result) => {
-                    if !result.as_bool() {
+                Ok(result) => match result.as_bool_opt() {
+                    Some(false) => {
                         let error =
                             QuintError::new("QNT511", &format!("Test {test_name} returned false"))
                                 .with_reference(test_def_id);
@@ -90,10 +91,16 @@ impl TestCase {
                         trace.violation = true;
                         break;
                     }
-                    if env.rand.get_state() == prev_rng_state {
+                    Some(true) => {
+                        if env.rand.get_state() == prev_rng_state {
+                            break;
+                        }
+                    }
+                    None => {
+                        ignored = true;
                         break;
                     }
-                }
+                },
                 Err(e) => {
                     errors.push(e);
                     break;
@@ -101,7 +108,9 @@ impl TestCase {
             }
         }
 
-        let status = if errors.is_empty() {
+        let status = if ignored {
+            TestStatus::Ignored
+        } else if errors.is_empty() {
             TestStatus::Passed
         } else {
             TestStatus::Failed

--- a/evaluator/src/value.rs
+++ b/evaluator/src/value.rs
@@ -487,6 +487,14 @@ impl Value {
         }
     }
 
+    /// Convert a boolean value to `bool`, returning `None` for non-boolean values.
+    pub fn as_bool_opt(&self) -> Option<bool> {
+        match self.0.as_ref() {
+            ValueInner::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
     /// Convert a string value to `Str`. Panics if the wrong type is given,
     /// which should never happen as input expressions are type-checked.
     pub fn as_str(&self) -> Str {

--- a/evaluator/tests/tester_tests.rs
+++ b/evaluator/tests/tester_tests.rs
@@ -1,12 +1,18 @@
-use quint_evaluator::tester::TestCase;
+use quint_evaluator::tester::{TestCase, TestStatus};
 use quint_evaluator::{helpers, progress, Verbosity};
 use std::error::Error;
 use std::path::Path;
 
 /// Helper to parse a test definition from a Quint file
 fn parse_test_from_path(file_path: &Path, test_name: &str) -> Result<TestCase, Box<dyn Error>> {
+    let source_path = if file_path.is_absolute() {
+        file_path.to_path_buf()
+    } else {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(file_path)
+    };
+
     // Use helpers to compile the file
-    let output = helpers::parse(&std::fs::read_to_string(file_path)?, None)?;
+    let output = helpers::parse(&std::fs::read_to_string(source_path)?, None)?;
 
     // Find the test definition
     let test_op_def = output.find_definition_by_name(test_name)?;
@@ -51,6 +57,19 @@ fn failing_test_returns_qnt511() {
     assert!(!result.errors[0].trace.is_empty());
     assert_eq!(result.errors[0].trace[0], test_case.test_def.id());
     assert_eq!(result.seed, 0);
+}
+
+#[test]
+fn non_boolean_test_is_ignored() {
+    let file_path = Path::new("fixtures/runs.qnt");
+    let test_case = parse_test_from_path(file_path, "ignoredTest").unwrap();
+
+    let result = test_case.execute(Some(0), 1, progress::no_report(), Verbosity::default());
+
+    assert!(matches!(result.status, TestStatus::Ignored));
+    assert_eq!(result.errors.len(), 0);
+    assert_eq!(result.seed, 0);
+    assert!(result.nsamples > 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1941

## Summary
- Treat non-boolean Rust test results as ignored instead of panicking.
- Add a safe boolean accessor for evaluator values.
- Add regression coverage for a run that returns a non-boolean value.

## Tests
- `PATH="$PWD/.test-bin:$PATH" CARGO_HOME=$PWD/evaluator/.cargo-home CARGO_TARGET_DIR=$PWD/evaluator/target cargo test --manifest-path evaluator/Cargo.toml --test tester_tests --locked`
- `PATH="$PWD/.test-bin:$PATH" CARGO_HOME=$PWD/evaluator/.cargo-home CARGO_TARGET_DIR=$PWD/evaluator/target cargo test --manifest-path evaluator/Cargo.toml --locked`
- `QUINT_HOME="$PWD/.quint-home" PATH="$PWD/.test-bin:$PATH" quint test examples/language-features/counters.qnt --backend=rust`
- `git diff --check`

AI assistance was used: OpenAI GPT-5 helped draft and review the implementation. I reviewed, tested, and take responsibility for the final changes.

- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality

Documentation and changelog entries are not applicable because this is a bug fix, not new functionality.