### PR TITLE
Use `reduce` to not overflow the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `--step`/`--init` resolving to a state variable instead of an action when the variable is named `step` or `init` (#1969)
 - `quint compile --target=json` no longer requires `init` and `step` to exist in the module (#1971)
+- Prevent stack overflow in `getTraceStatistics` (#1992)
 
 ### Security
 

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -62,8 +62,8 @@ export interface TraceStatistics {
 
 export function getTraceStatistics(traceLengths: number[]): TraceStatistics {
   return {
-    maxTraceLength: Math.max(...traceLengths),
-    minTraceLength: Math.min(...traceLengths),
+    maxTraceLength: traceLengths.reduce((a, b) => Math.max(a, b), 0),
+    minTraceLength: traceLengths.reduce((a, b) => Math.min(a, b), Infinity),
     averageTraceLength: traceLengths.reduce((a, b) => a + b, 0) / traceLengths.length,
   }
 }

--- a/quint/test/simulation.test.ts
+++ b/quint/test/simulation.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+import { getTraceStatistics } from '../src/simulation'
+
+describe('getTraceStatistics', () => {
+  it('computes max, min, and average for a small array', () => {
+    const stats = getTraceStatistics([1, 5, 3, 7, 2])
+    expect(stats.maxTraceLength).to.equal(7)
+    expect(stats.minTraceLength).to.equal(1)
+    expect(stats.averageTraceLength).to.equal(3.6)
+  })
+
+  it('handles a single-element array', () => {
+    const stats = getTraceStatistics([42])
+    expect(stats.maxTraceLength).to.equal(42)
+    expect(stats.minTraceLength).to.equal(42)
+    expect(stats.averageTraceLength).to.equal(42)
+  })
+
+  // Regression: Math.max(...arr) / Math.min(...arr) overflow Node's argument
+  // stack at ~65k elements (nodejs/node#43043). 100k is comfortably above
+  // the threshold and runs fast.
+  it("does not stack-overflow on arrays larger than Node's argument-stack limit", () => {
+    const n = 100_000
+    const lengths = Array.from({ length: n }, (_, i) => (i % 100) + 1)
+    const stats = getTraceStatistics(lengths)
+    expect(stats.maxTraceLength).to.equal(100)
+    expect(stats.minTraceLength).to.equal(1)
+    expect(stats.averageTraceLength).to.be.closeTo(50.5, 0.01)
+  })
+})


### PR DESCRIPTION
Huge number of traces was leading to stack overflows in simulation.ts. This is being solved by using `reduce` instead of generating one big `max`/`min` call that is taking all traces as an argument.

<!-- Review CONTRIBUTING.md for contribution guidelines and helpful material -->

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
      - Claude was used to find and fix this.
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [ ] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
