### PR TITLE
Install Quint skills across coding agents

### DIFF
--- a/quint/README.md
+++ b/quint/README.md
@@ -234,7 +234,7 @@ Cosmos in 2023.
   Model-based testing framework for Rust. Automatically validate your implementation against your Quint spec by replaying generated test traces.
 - [Quint Trace Explorer:](https://github.com/informalsystems/quint-trace-explorer)
   Terminal UI for navigating execution traces. Highlights state changes to make it easy to understand what has happened.
-- [Quint Claude Code Skills:](https://github.com/quint-co/quint/tree/main/skills) Language reference and modeling skills that help Claude write and reason about `.qnt` specifications.
+- [Quint Agent Skills:](https://github.com/quint-co/quint/tree/main/skills) Language reference and modeling skills that help AI coding agents write and reason about `.qnt` specifications.
 
 
 ## Community

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,11 +2,13 @@
 
 This folder contains [Agent Skills](https://github.com/anthropics/skills) for writing and reasoning about Quint specifications: a language reference (`quint-lang`) and a modeling guide (`quint-modeling`) for authoring `.qnt` files.
 
-The skills use the open `SKILL.md` format and work across agents that support it, including GitHub Copilot, Claude Code, Cursor, OpenAI Codex CLI, and Gemini CLI.
+The skills use the open `SKILL.md` format and work across agents that support it, including Claude Code, Cursor, OpenAI Codex CLI, and Gemini CLI.
+
+Quint skills can be installed via the GitHub CLI, Claude Code plugin, or manually. The installation instructions are provided below.
 
 ## Installing via the GitHub CLI
 
-Requires the [GitHub CLI](https://cli.github.com) `v2.90.0` or newer. Installs the skills into any supported agent:
+If you have the [GitHub CLI](https://cli.github.com) `v2.90.0` or newer, you can install the skills into any supported agent with a single command:
 
 ```
 gh skill install quint-co/quint --all --pin main
@@ -45,6 +47,6 @@ Arguments:
   <agent>   Target agent: claude, cursor, codex, or gemini
 
 Options:
-  --user    Install into the home directory instead of the current project (default: project)
-  --force   Overwrite an existing skill of the same name
+  --user       Install into the home directory instead of the current project (default: project)
+  --overwrite  Replace an already-installed skill of the same name
 ```

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,18 +1,56 @@
-# Quint Claude Code skills
+# Quint agent skills
 
-This folder contains [Claude Code](https://code.claude.com) skills that help Claude write and reason about Quint specifications: a language reference and a modeling guide for authoring `.qnt` specifications.
+This folder contains [Agent Skills](https://github.com/anthropics/skills) for writing and reasoning about Quint specifications: a language reference (`quint-lang`) and a modeling guide (`quint-modeling`) for authoring `.qnt` files.
 
-## Install as a plugin (recommended)
+The skills use the open `SKILL.md` format and work across agents that support it, including GitHub Copilot, Claude Code, Cursor, OpenAI Codex CLI, and Gemini CLI.
 
-No need to clone the repository. In Claude Code, register the Quint repo as a plugin marketplace and install the plugin:
+## Installing via the GitHub CLI
+
+Requires the [GitHub CLI](https://cli.github.com) `v2.90.0` or newer. Installs the skills into any supported agent:
+
+```
+gh skill install quint-co/quint --all --pin main
+```
+
+The command prompts for:
+
+- the target agent (Copilot, Claude Code, Cursor, Codex, or Gemini)
+- the installation scope (global or project)
+
+To install a single skill, name it instead of passing `--all`:
+
+```
+gh skill install quint-co/quint quint-lang --pin main
+```
+
+## Installing via Claude Code plugin
+
+In Claude Code, add the Quint organization to the marketplace and install the plugin:
 
 ```
 /plugin marketplace add quint-co/quint
 /plugin install quint@quint
 ```
 
-This installs both skills. Once installed, the skills load automatically when you ask Claude something relevant.
+## Installing manually
 
-Alternatively, you can install the skills manually by copying the skill folders in this directory into your home directory (`~/.claude/skills/`) or into a specific project (`.claude/skills/`).
+For setups without the GitHub CLI, the `install.sh` script installs the skills for a chosen agent:
 
-Skills can run code, so review them before installing, as you would any tooling.
+```
+curl -fsSL https://raw.githubusercontent.com/quint-co/quint/main/skills/install.sh | bash -s -- <agent> [options]
+```
+
+```
+Arguments:
+  <agent>   Target agent: claude, cursor, codex, or gemini
+
+Options:
+  --user    Install into the home directory instead of the current project (default: project)
+  --force   Overwrite an existing skill of the same name
+```
+
+If the Quint repository is already cloned, run the script directly from its root:
+
+```
+./skills/install.sh <agent> [options]
+```

--- a/skills/README.md
+++ b/skills/README.md
@@ -48,9 +48,3 @@ Options:
   --user    Install into the home directory instead of the current project (default: project)
   --force   Overwrite an existing skill of the same name
 ```
-
-If the Quint repository is already cloned, run the script directly from its root:
-
-```
-./skills/install.sh <agent> [options]
-```

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Install the Quint agent skills (quint-lang, quint-modeling) into the skills
+# directory of any SKILL.md-compatible coding agent.
+#
+# The skills are written in the open Agent Skills format, so the same folders
+# work unchanged across agents — this script just symlinks them into the place
+# each agent looks, so a `git pull` keeps the installed skills up to date.
+#
+# Usage:
+#   skills/install.sh <agent> [--user] [--force]
+#
+#   <agent>   One of: claude | cursor | codex | gemini
+#   --user    Install for your user (home dir) instead of the current project
+#   --force   Overwrite an existing skill of the same name
+#
+# Run from a checkout, or straight from the web (clones into a cache dir):
+#   curl -fsSL https://raw.githubusercontent.com/quint-co/quint/main/skills/install.sh | bash -s -- cursor
+set -euo pipefail
+
+REPO_URL="https://github.com/quint-co/quint.git"
+SKILLS=(quint-lang quint-modeling)
+
+# --- pretty output -----------------------------------------------------------
+if [ -t 1 ]; then
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; RED=$'\033[31m'; GREEN=$'\033[32m'; RESET=$'\033[0m'
+else
+  BOLD=''; DIM=''; RED=''; GREEN=''; RESET=''
+fi
+info()  { printf '%s\n' "$*"; }
+ok()    { printf '%s%s%s\n' "$GREEN" "$*" "$RESET"; }
+die()   { printf '%serror:%s %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: skills/install.sh <agent> [--user] [--force]
+  <agent>   claude | cursor | codex | gemini
+  --user    install into your home dir instead of the current project
+  --force   overwrite an existing skill of the same name
+EOF
+}
+
+# --- parse args --------------------------------------------------------------
+AGENT=""; SCOPE="project"; FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --user)        SCOPE="user" ;;
+    --force)       FORCE=1 ;;
+    -h|--help)     usage; exit 0 ;;
+    claude|cursor|codex|gemini) AGENT="$arg" ;;
+    *) die "unknown argument: $arg (run with --help)" ;;
+  esac
+done
+[ -n "$AGENT" ] || { usage; die "missing <agent>"; }
+
+# --- resolve the target skills directory -------------------------------------
+case "$AGENT" in
+  claude) sub=".claude/skills" ;;
+  cursor) sub=".cursor/skills" ;;
+  codex)  sub=".codex/skills"  ;;
+  gemini) sub=".gemini/skills" ;;
+esac
+if [ "$SCOPE" = "user" ]; then
+  DEST="$HOME/$sub"   # e.g. ~/.claude/skills
+else
+  DEST="$PWD/$sub"
+fi
+
+# --- locate the source skills folders ----------------------------------------
+# Prefer a checkout next to this script; otherwise clone into a cache dir so
+# symlinks have a stable, updatable target (curl | bash case).
+SRC=""
+if SELF="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"; then
+  if [ -d "$SELF/quint-lang" ] && [ -d "$SELF/quint-modeling" ]; then
+    SRC="$SELF"
+  fi
+fi
+if [ -z "$SRC" ]; then
+  command -v git >/dev/null 2>&1 || die "git is required to fetch the skills"
+  CACHE="${XDG_DATA_HOME:-$HOME/.local/share}/quint"
+  if [ -d "$CACHE/.git" ]; then
+    info "${DIM}Updating cached skills in $CACHE${RESET}"
+    git -C "$CACHE" pull --quiet --ff-only || info "${DIM}(could not update cache, using existing)${RESET}"
+  else
+    info "${DIM}Fetching skills into $CACHE${RESET}"
+    mkdir -p "$(dirname "$CACHE")"
+    git clone --quiet --depth 1 "$REPO_URL" "$CACHE"
+  fi
+  SRC="$CACHE/skills"
+  [ -d "$SRC/quint-lang" ] || die "skills not found after clone ($SRC)"
+fi
+
+# --- install -----------------------------------------------------------------
+info "Installing Quint skills"
+info "  agent:  ${BOLD}$AGENT${RESET}  (${SCOPE} scope)"
+info "  source: $SRC"
+info "  dest:   $DEST"
+info ""
+
+mkdir -p "$DEST"
+for skill in "${SKILLS[@]}"; do
+  target="$DEST/$skill"
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    if [ "$FORCE" -eq 1 ]; then
+      rm -rf "$target"
+    else
+      info "  ${DIM}skip${RESET}    $skill (already exists — use --force to overwrite)"
+      continue
+    fi
+  fi
+  ln -s "$SRC/$skill" "$target"
+  ok "  linked  $skill -> $SRC/$skill"
+done
+
+info ""
+ok "Done. Restart $AGENT (or reload the workspace) so it picks up the skills."
+info "${DIM}Skills can run code — review them before use, as you would any tooling.${RESET}"

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 #
 # Install the Quint agent skills (quint-lang, quint-modeling) into the skills
-# directory of any SKILL.md-compatible coding agent.
-#
-# The skills are written in the open Agent Skills format, so the same folders
-# work unchanged across agents — this script just symlinks them into the place
-# each agent looks, so a `git pull` keeps the installed skills up to date.
+# directory of a SKILL.md-compatible coding agent.
 #
 # Usage:
 #   skills/install.sh <agent> [--user] [--force]
@@ -14,7 +10,7 @@
 #   --user    Install for your user (home dir) instead of the current project
 #   --force   Overwrite an existing skill of the same name
 #
-# Run from a checkout, or straight from the web (clones into a cache dir):
+# Example:
 #   curl -fsSL https://raw.githubusercontent.com/quint-co/quint/main/skills/install.sh | bash -s -- cursor
 set -euo pipefail
 
@@ -27,9 +23,9 @@ if [ -t 1 ]; then
 else
   BOLD=''; DIM=''; RED=''; GREEN=''; RESET=''
 fi
-info()  { printf '%s\n' "$*"; }
-ok()    { printf '%s%s%s\n' "$GREEN" "$*" "$RESET"; }
-die()   { printf '%serror:%s %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
+info() { printf '%s\n' "$*"; }
+ok()   { printf '%s%s%s\n' "$GREEN" "$*" "$RESET"; }
+die()  { printf '%serror:%s %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
 
 usage() {
   cat <<'EOF'
@@ -44,9 +40,9 @@ EOF
 AGENT=""; SCOPE="project"; FORCE=0
 for arg in "$@"; do
   case "$arg" in
-    --user)        SCOPE="user" ;;
-    --force)       FORCE=1 ;;
-    -h|--help)     usage; exit 0 ;;
+    --user)    SCOPE="user" ;;
+    --force)   FORCE=1 ;;
+    -h|--help) usage; exit 0 ;;
     claude|cursor|codex|gemini) AGENT="$arg" ;;
     *) die "unknown argument: $arg (run with --help)" ;;
   esac
@@ -66,50 +62,28 @@ else
   DEST="$PWD/$sub"
 fi
 
-# --- locate the source skills folders ----------------------------------------
-# Prefer a checkout next to this script; otherwise clone into a cache dir so
-# symlinks have a stable, updatable target (curl | bash case).
-SRC=""
-if SELF="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"; then
-  if [ -d "$SELF/quint-lang" ] && [ -d "$SELF/quint-modeling" ]; then
-    SRC="$SELF"
-  fi
-fi
-if [ -z "$SRC" ]; then
-  command -v git >/dev/null 2>&1 || die "git is required to fetch the skills"
-  CACHE="${XDG_DATA_HOME:-$HOME/.local/share}/quint"
-  if [ -d "$CACHE/.git" ]; then
-    info "${DIM}Updating cached skills in $CACHE${RESET}"
-    git -C "$CACHE" pull --quiet --ff-only || info "${DIM}(could not update cache, using existing)${RESET}"
-  else
-    info "${DIM}Fetching skills into $CACHE${RESET}"
-    mkdir -p "$(dirname "$CACHE")"
-    git clone --quiet --depth 1 "$REPO_URL" "$CACHE"
-  fi
-  SRC="$CACHE/skills"
-  [ -d "$SRC/quint-lang" ] || die "skills not found after clone ($SRC)"
-fi
+# --- fetch the skill folders -------------------------------------------------
+# Clone a temporary copy of the repo and remove it once the skills are copied.
+command -v git >/dev/null 2>&1 || die "git is required to install the skills"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+info "${DIM}Fetching skills...${RESET}"
+git clone --quiet --depth 1 "$REPO_URL" "$TMP/quint"
+SRC="$TMP/quint/skills"
+[ -d "$SRC/quint-lang" ] || die "skills not found in clone"
 
 # --- install -----------------------------------------------------------------
-info "Installing Quint skills"
-info "  agent:  ${BOLD}$AGENT${RESET}  (${SCOPE} scope)"
-info "  source: $SRC"
-info "  dest:   $DEST"
-info ""
-
+info "Installing Quint skills into ${BOLD}$DEST${RESET} (${SCOPE} scope)"
 mkdir -p "$DEST"
 for skill in "${SKILLS[@]}"; do
   target="$DEST/$skill"
-  if [ -e "$target" ] || [ -L "$target" ]; then
-    if [ "$FORCE" -eq 1 ]; then
-      rm -rf "$target"
-    else
-      info "  ${DIM}skip${RESET}    $skill (already exists — use --force to overwrite)"
-      continue
-    fi
+  if [ -e "$target" ] && [ "$FORCE" -ne 1 ]; then
+    info "  ${DIM}skip${RESET}       $skill (already exists — use --force to overwrite)"
+    continue
   fi
-  ln -s "$SRC/$skill" "$target"
-  ok "  linked  $skill -> $SRC/$skill"
+  rm -rf "$target"
+  cp -R "$SRC/$skill" "$target"
+  ok "  installed  $skill"
 done
 
 info ""

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -4,11 +4,11 @@
 # directory of a SKILL.md-compatible coding agent.
 #
 # Usage:
-#   skills/install.sh <agent> [--user] [--force]
+#   skills/install.sh <agent> [--user] [--overwrite]
 #
-#   <agent>   One of: claude | cursor | codex | gemini
-#   --user    Install for your user (home dir) instead of the current project
-#   --force   Overwrite an existing skill of the same name
+#   <agent>     One of: claude | cursor | codex | gemini
+#   --user      Install for your user (home dir) instead of the current project
+#   --overwrite Replace an already-installed skill of the same name
 #
 # Example:
 #   curl -fsSL https://raw.githubusercontent.com/quint-co/quint/main/skills/install.sh | bash -s -- cursor
@@ -29,20 +29,20 @@ die()  { printf '%serror:%s %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
 
 usage() {
   cat <<'EOF'
-Usage: skills/install.sh <agent> [--user] [--force]
-  <agent>   claude | cursor | codex | gemini
-  --user    install into your home dir instead of the current project
-  --force   overwrite an existing skill of the same name
+Usage: skills/install.sh <agent> [--user] [--overwrite]
+  <agent>      claude | cursor | codex | gemini
+  --user       install into your home dir instead of the current project
+  --overwrite  replace an already-installed skill of the same name
 EOF
 }
 
 # --- parse args --------------------------------------------------------------
-AGENT=""; SCOPE="project"; FORCE=0
+AGENT=""; SCOPE="project"; OVERWRITE=0
 for arg in "$@"; do
   case "$arg" in
-    --user)    SCOPE="user" ;;
-    --force)   FORCE=1 ;;
-    -h|--help) usage; exit 0 ;;
+    --user)      SCOPE="user" ;;
+    --overwrite) OVERWRITE=1 ;;
+    -h|--help)   usage; exit 0 ;;
     claude|cursor|codex|gemini) AGENT="$arg" ;;
     *) die "unknown argument: $arg (run with --help)" ;;
   esac
@@ -77,8 +77,8 @@ info "Installing Quint skills into ${BOLD}$DEST${RESET} (${SCOPE} scope)"
 mkdir -p "$DEST"
 for skill in "${SKILLS[@]}"; do
   target="$DEST/$skill"
-  if [ -e "$target" ] && [ "$FORCE" -ne 1 ]; then
-    info "  ${DIM}skip${RESET}       $skill (already exists — use --force to overwrite)"
+  if [ -e "$target" ] && [ "$OVERWRITE" -ne 1 ]; then
+    info "  ${DIM}skip${RESET}       $skill (already exists — use --overwrite to replace)"
     continue
   fi
   rm -rf "$target"


### PR DESCRIPTION
Hey, 
This PR updates the installation instructions for the Quint skills to be agent agnostic. 

---
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [ ] Tests added for any new code
- [x] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
