### PR TITLE
Fix EINVAL when spawning Apalache server on Windows

### DIFF
--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -469,6 +469,26 @@ export async function fetchApalache(apalacheVersion: string, verbosityLevel: num
 }
 
 /**
+ * Compute the options used to spawn the Apalache server process.
+ *
+ * On Windows, the Apalache launcher is a `.bat` file. Since Node 18.20.2 /
+ * 20.12.2 / 21.7.2 (CVE-2024-27980), `child_process.spawn` refuses to launch
+ * `.bat`/`.cmd` files when `shell: false`, failing with `EINVAL` instead.
+ * Passing `shell: true` opts back in; this is safe here because the spawned
+ * arguments are fully controlled by us (a literal `'server'` and a numeric
+ * port), not user-supplied strings that could carry shell metacharacters.
+ *
+ * @param platform the value of `process.platform`
+ * @param stdio the stdio configuration to use for the spawned process
+ */
+export function apalacheSpawnOptions(
+  platform: NodeJS.Platform,
+  stdio: StdioOptions
+): { shell: boolean; stdio: StdioOptions } {
+  return { shell: platform === 'win32', stdio }
+}
+
+/**
  * Connect to an already running Apalache server, or – if unsuccessful – fetch
  * Apalache, spawn it, and connect to it.
  *
@@ -509,9 +529,7 @@ export async function connect(
             verbosityLevel >= verbosity.defaultLevel
               ? ['ignore', process.stdout, process.stderr]
               : ['ignore', 'ignore', 'ignore']
-          // importantly, do not wrap the command in a shell,
-          // as this will prevent the child process from being properly terminated
-          const options = { shell: false, stdio: stdio }
+          const options = apalacheSpawnOptions(process.platform, stdio)
           const args = ['server', `--port=${serverEndpoint.port}`]
           const apalache = child_process.spawn(exe, args, options)
 
@@ -520,10 +538,22 @@ export async function connect(
             debugLog(verbosityLevel, 'Shutting down Apalache server')
             // Remove 'exit' listeners on Apalache, to avoid exiting in that handler with a different code
             apalache.removeAllListeners('exit')
-            // Try to kill Apalache
-            let killed = apalache.kill('SIGTERM')
-            if (!killed) {
-              debugLog(verbosityLevel, `Could not kill Apalache server, exiting`)
+            if (options.shell && apalache.pid) {
+              // On Windows, we spawned Apalache via a shell (cmd.exe) to launch the
+              // .bat launcher, so apalache.pid is the shell's pid, not the underlying
+              // Java process. Killing just the shell would orphan Apalache, so we
+              // kill the whole process tree instead.
+              try {
+                child_process.execSync(`taskkill /pid ${apalache.pid} /T /F`)
+              } catch (e) {
+                debugLog(verbosityLevel, `Could not kill Apalache server, exiting: ${e}`)
+              }
+            } else {
+              // Try to kill Apalache
+              let killed = apalache.kill('SIGTERM')
+              if (!killed) {
+                debugLog(verbosityLevel, `Could not kill Apalache server, exiting`)
+              }
             }
           }
 

--- a/quint/test/apalache.test.ts
+++ b/quint/test/apalache.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+import { apalacheSpawnOptions, parseServerEndpoint } from '../src/apalache'
+
+describe('apalacheSpawnOptions', () => {
+  it('spawns with a shell on win32, so that the .bat launcher can run', () => {
+    // Node refuses to spawn .bat/.cmd files with shell: false on Windows
+    // (CVE-2024-27980), failing with EINVAL. shell: true is required.
+    expect(apalacheSpawnOptions('win32', 'ignore')).to.deep.equal({ shell: true, stdio: 'ignore' })
+  })
+
+  it('spawns without a shell on non-Windows platforms', () => {
+    // Avoiding an intermediate shell process lets us terminate Apalache directly.
+    expect(apalacheSpawnOptions('linux', 'ignore')).to.deep.equal({ shell: false, stdio: 'ignore' })
+    expect(apalacheSpawnOptions('darwin', 'ignore')).to.deep.equal({ shell: false, stdio: 'ignore' })
+  })
+})
+
+describe('parseServerEndpoint', () => {
+  it('parses a valid hostname:port', () => {
+    const result = parseServerEndpoint('localhost:8822')
+    expect(result.isRight()).to.be.true
+    expect(result.value).to.deep.equal({ hostname: 'localhost', port: 8822 })
+  })
+})


### PR DESCRIPTION
## Summary
- `child_process.spawn` refuses to launch `.bat`/`.cmd` files with `shell:false` on Windows since the CVE-2024-27980 fix (Node 18.20.2/20.12.2/21.7.2), failing synchronously with `EINVAL` instead of an `ENOENT`-style error. Since the `apalache-mc` launcher is a `.bat` file on win32, `quint verify`/`quint run --apalache` never got the server off the ground.
- Opt back into `shell:true` only on win32, where the spawned arguments are fully controlled (a literal `'server'` and a numeric port), so there's no injection risk.
- Since `shell:true` makes `apalache.pid` refer to the `cmd.exe` wrapper rather than the underlying Java process, use `taskkill /T` to kill the whole process tree on shutdown instead of `SIGTERM`.

## Test plan
- [x] Added unit tests in `quint/test/apalache.test.ts`
- [x] Manual verification of `quint verify` on Windows