### PR TITLE
fix(RS): Fix stale MBT annotation on the initial state of `--mbt` traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+- Fixed the Rust evaluator sometimes recording a wrong `mbt::actionTaken` and `mbt::nondetPicks` on the initial state of `--mbt` traces (#2012)
 - Fixed `--step`/`--init` resolving to a state variable instead of an action when the variable is named `step` or `init` (#1969)
 - `quint compile --target=json` no longer requires `init` and `step` to exist in the module (#1971)
 - Prevent stack overflow in `getTraceStatistics` (#1992)

--- a/evaluator/fixtures/mbt_metadata.qnt
+++ b/evaluator/fixtures/mbt_metadata.qnt
@@ -1,0 +1,22 @@
+module mbtMetadata {
+  // Every run of this spec dead-ends: once n == 2, both picks of z disable
+  // incBy, so step evaluates to false
+
+  var n: int
+
+  def inv = n >= 0
+
+  action init = n' = 0
+
+  action incBy(z: int): bool = all {
+    n + z <= 2,
+    n' = n + z,
+  }
+
+  action step = {
+    nondet z = 1.to(2).oneOf()
+    any {
+      incBy(z),
+    }
+  }
+}

--- a/evaluator/src/simulator.rs
+++ b/evaluator/src/simulator.rs
@@ -202,6 +202,11 @@ impl ParsedQuint {
             trace_witnessed.fill(false);
             let mut remaining = compiled_witnesses.len();
 
+            // Clear storage so that metadata left by a previous sample's
+            // failed step attempt is not recorded into this sample's initial
+            // state.
+            env.var_storage.borrow_mut().clear_metadata();
+
             // Wrap execute calls to catch panics and print seed
             let result = catch_unwind(AssertUnwindSafe(|| -> Result<bool, QuintError> {
                 if !init.execute(env)?.as_bool() {

--- a/evaluator/tests/simulator_tests.rs
+++ b/evaluator/tests/simulator_tests.rs
@@ -185,6 +185,59 @@ fn tictactoe_n_traces_1_fast_return() {
 }
 
 #[test]
+/// The initial state of every trace should be annotated with `init` and no
+/// nondet picks, even when a previous sample ended in a failed step attempt
+fn mbt_initial_state_metadata_reset() {
+    let file_path: &Path = Path::new("fixtures/mbt_metadata.qnt");
+
+    let parsed = helpers::parse_from_path(file_path, "init", "step", Some("inv"), None).unwrap();
+    let config = SimulationConfig {
+        steps: 5,
+        samples: 20,
+        n_traces: 20,
+        seed: Some(0x42),
+        store_metadata: true,
+        verbosity: Verbosity::default(),
+    };
+    let result = parsed.simulate(config, progress::no_report());
+    assert!(result.is_ok());
+    let result = result.unwrap();
+    assert!(!result.best_traces.is_empty());
+
+    for (i, trace) in result.best_traces.iter().enumerate() {
+        let state0 = &trace
+            .states
+            .first()
+            .expect("every trace should have an initial state")
+            .value;
+        let record = state0.as_record_map();
+
+        let action_taken = record
+            .get("mbt::actionTaken")
+            .expect("initial state should have mbt::actionTaken");
+        assert_eq!(
+            action_taken.as_str().as_str(),
+            "init",
+            "trace {i}: initial state labeled {:?} instead of \"init\"",
+            action_taken.as_str()
+        );
+
+        let picks = record
+            .get("mbt::nondetPicks")
+            .expect("initial state should have mbt::nondetPicks")
+            .as_record_map();
+        for (name, pick) in picks.iter() {
+            let (label, _) = pick.as_variant();
+            assert_eq!(
+                label.as_str(),
+                "None",
+                "trace {i}: initial state has leaked nondet pick for {name}"
+            );
+        }
+    }
+}
+
+#[test]
 fn tictactoe_best_traces_quality_order() {
     let file_path: &Path = Path::new("fixtures/tictactoe.qnt");
 


### PR DESCRIPTION
This PR fixes #2011. When simulating with `--mbt`, the Rust evaluator sometimes records the initial state of a trace with `mbt::actionTaken` set to the composite step action's name (e.g. `"step"`) instead of `"init"`, and with `mbt::nondetPicks` populated with values no transition in the trace used. See the issue for a minimal reproduction and full analysis.

The MBT registers `action_taken` and `nondet_picks` in `Storage` are cleared after a state is recorded (`Env::shift`) and before each candidate inside `any` — but never at the start of a sample. A sample that ends because `step` evaluated to `false` leaves the failed attempt's values in the registers, and since `track_action` is first-write-wins, the next sample's `init` cannot relabel them: `shift` records that sample's initial state with the previous sample's stale metadata.

### Fix

- **Rust** (`evaluator/src/simulator.rs`): clear the metadata registers at the start of every sample in `simulate_with_env`, so the sample boundary is a metadata boundary regardless of how the previous sample ended. This is a no-op when `--mbt` is not set, and matches the TypeScript simulator, which resets its `VarStorage` (including MBT metadata) at the top of every run.

A regression test was added (`evaluator/tests/simulator_tests.rs`, with fixture `evaluator/fixtures/mbt_metadata.qnt` — a spec whose every sample dead-ends): it fails before this change with `initial state labeled "step" instead of "init"` and passes after. Manually verified with the issue's reproduction: 200/200 corrupted initial states before, 0/200 after; a spec with intermittent dead-ends goes from 91/100 to 0/100; non-initial annotations are unchanged (machine-checked against the state payloads).

- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [x] Documentation added for any new functionality (N/A)
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

**AI disclosure:** This PR was developed with AI assistance (Claude). The fix, tests, and manual verification were reviewed by a human.
