### PR TITLE
Upgrade to Apalache 0.62.1

### DIFF
--- a/.github/workflows/examples-dashboard.yml
+++ b/.github/workflows/examples-dashboard.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "19"
+          java-version: "21"
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build Rust evaluator

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "19"
+          java-version: "21"
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build Rust evaluator
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "19"
+          java-version: "21"
       - run: cd ./quint && npm ci
       - run: cd ./quint && npm run compile && npm link
       - run: npm install -g txm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- Upgraded the default Apalache version to 0.62.1, which requires Java 21 or newer.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -187,7 +187,7 @@ quint run bank.qnt --invariant=no_negatives
 However, the simulator might miss several executions. To make sure we fixed the problem, we should run the model checker, by using the `verify` subcommand.
 
 <Callout>
-The model checker requires Java Development Kit >= 17. We recommend version 17 of the [Eclipse Temurin](https://adoptium.net/) or [Zulu](https://www.azul.com/downloads/?version=java-17-lts&package=jdk#download-openjdk) builds of OpenJDK.
+The model checker requires Java Development Kit >= 21. We recommend version 21 of the [Eclipse Temurin](https://adoptium.net/) or [Zulu](https://www.azul.com/downloads/?version=java-21-lts&package=jdk#download-openjdk) builds of OpenJDK.
 </Callout>
 ```sh
 quint verify bank.qnt --invariant=no_negatives

--- a/quint/integration-tests/distribution/apalache.md
+++ b/quint/integration-tests/distribution/apalache.md
@@ -32,7 +32,7 @@ QUINT_HOME="$quint_home" quint verify --verbosity=1 ../examples/language-feature
 
 <!-- !test out server not running -->
 ```
-Downloading Apalache distribution 0.56.1... done.
+Downloading Apalache distribution 0.62.1... done.
 [ok] No violation found (duration).
 [ok] No violation found (duration).
 ```

--- a/quint/integration-tests/verification.md
+++ b/quint/integration-tests/verification.md
@@ -19,6 +19,19 @@ bash -
 
 ## Configuration errors
 
+### Legacy Apalache configuration is rejected cleanly
+
+<!-- !test in legacy Apalache config -->
+```
+quint verify --apalache-config=./testFixture/apalache/legacyConfig.json ../examples/language-features/booleans.qnt
+```
+
+<!-- !test exit 1 -->
+<!-- !test err legacy Apalache config -->
+```
+error: $.input: Unknown configuration key.
+```
+
 ### Verifying spec with invalid init param produces an error
 
 <!-- !test in invalid init -->

--- a/quint/src/apalache.ts
+++ b/quint/src/apalache.ts
@@ -76,13 +76,10 @@ export function createConfig(
 ): ApalacheConfig {
   return {
     ...loadedConfig,
-    input: {
-      ...(loadedConfig.input ?? {}),
-      source: {
-        type: 'string',
-        format: 'qnt',
-        content: parsedSpec,
-      },
+    source: {
+      kind: 'string',
+      format: 'qnt',
+      content: parsedSpec,
     },
     checker: {
       ...(loadedConfig.checker ?? {}),
@@ -90,7 +87,7 @@ export function createConfig(
       init: init,
       next: next,
       inv: inv,
-      'temporal-props': args.temporal ? ['q::temporalProps'] : undefined,
+      temporal: args.temporal ? ['q::temporalProps'] : undefined,
       tuning: {
         ...(loadedConfig.checker?.tuning ?? {}),
         'search.simulation': args.randomTransitions ? 'true' : 'false',
@@ -108,7 +105,7 @@ export function serverEndpointToConnectionString(endpoint: ServerEndpoint): stri
   return `${endpoint.hostname}:${endpoint.port}`
 }
 
-export const DEFAULT_APALACHE_VERSION_TAG = '0.56.1'
+export const DEFAULT_APALACHE_VERSION_TAG = '0.62.1'
 // TODO: used by GitHub api approach: https://github.com/informalsystems/quint/issues/1124
 // const APALACHE_TGZ = 'apalache.tgz'
 
@@ -191,14 +188,18 @@ async function handleResponse(response: RunResponse): Promise<ApalacheResult<any
   }
 }
 
+function handleRpcError(error: any): ApalacheResult<any> {
+  return err(error.details ?? error.message ?? error)
+}
+
 // Construct the Apalache interface around the cmdExecutor
 function apalache(cmdExecutor: AsyncCmdExecutor): Apalache {
   const check = async (c: ApalacheConfig): Promise<ApalacheResult<void>> => {
-    return cmdExecutor.run({ cmd: 'CHECK', config: JSON.stringify(c) }).then(handleResponse)
+    return cmdExecutor.run({ cmd: 'CHECK', config: JSON.stringify(c) }).then(handleResponse, handleRpcError)
   }
 
   const tla = async (c: ApalacheConfig): Promise<ApalacheResult<string>> => {
-    return cmdExecutor.run({ cmd: 'TLA', config: JSON.stringify(c) }).then(handleResponse)
+    return cmdExecutor.run({ cmd: 'TLA', config: JSON.stringify(c) }).then(handleResponse, handleRpcError)
   }
 
   return { check, tla }

--- a/quint/src/compileToTlaplus.ts
+++ b/quint/src/compileToTlaplus.ts
@@ -35,12 +35,10 @@ export async function compileToTlaplus(
   verbosityLevel: number
 ): Promise<ApalacheResult<string>> {
   const config = {
-    input: {
-      source: {
-        type: 'string',
-        format: 'qnt',
-        content: parseDataJson,
-      },
+    source: {
+      kind: 'string',
+      format: 'qnt',
+      content: parseDataJson,
     },
   }
   const connectionResult = await connect(serverEndpoint, apalacheVersion, verbosityLevel)

--- a/quint/testFixture/apalache/legacyConfig.json
+++ b/quint/testFixture/apalache/legacyConfig.json
@@ -1,0 +1,7 @@
+{
+  "input": {
+    "source": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
This PR upgrades the version of Apalache to 0.62.1. Since we have updated the configuration file in Apalache (finally, [documented in the manual](https://apalache-mc.org/docs/apalache/config.html)), this required minimal changes to the interaction logic.

Below is the list of changes between the currently pinned version and the new version (AI-generated):

# Apalache changes from 0.56.1 to 0.62.1

Source: [Apalache `CHANGES.md` at v0.62.1](https://github.com/apalache-mc/apalache/blob/v0.62.1/CHANGES.md)

## 0.62.0 — 2026-08-18

### Breaking changes

- Minimum Java runtime raised from 18 to 21.
- `OutputManager` state became local to each `Tool.run`. Direct callers must use `OutputManager.withScope`; asynchronous callers must propagate the captured scope.

## 0.61.0 — 2026-08-06

### Bug fix

- Released artifacts were retargeted from Java 25 bytecode to Java 17, temporarily restoring Java 17 runtime compatibility. Java 25 remained the recommended runtime and development toolchain.

## 0.60.0 — 2026-08-05

### Breaking change

- Minimum Java runtime raised from 17 to 25.

## 0.59.0 — 2026-08-05

### Breaking changes

- Configuration moved to strict JSON in `.apalache.json` or `${user.home}/.tlaplus/apalache.json`.
- HOCON `.cfg` files were removed.
- The JSON configuration structure was simplified. See PR #3409.

### Features

- Published the `tla-ir` and `tla-io` Scala libraries to Maven Central under `org.apalache-mc`.

### Bug fix

- Folding over infinite sets such as `Nat` or `Int` now reports a known limitation instead of unsoundly treating the set as empty. See #1691.

### Documentation

- Added ADR026 covering explicit configuration and command options.

## 0.58.3 — 2026-07-09

### Features

- Expanded constant simplification for empty-set membership, subset identities, unions, intersections, differences, and self-operations. See #1238.

### Bug fixes

- `TLCGet` and `TLCSet` register keys can now be either strings or integers. See #3274.
- `FoldSet` over non-enumerated sets no longer silently returns its base value. Supported sets are expanded; unsupported cases fail explicitly. See #3385.
- Fixed SANY parsing errors. See #3401.
- Unbounded quantifiers now produce proper source-located errors instead of crashing the type checker. See #2816.

## 0.58.2 — 2026-06-22

- No changes listed.

## 0.58.0 — 2026-05-29

### Feature

- Added experimental CVC5 support for the OOPSLA19 encoding.

### Bug fix

- Fixed crashes during temporal checking when `Next` contained certain nested `IF`/`CASE`, disjunction, or conjunction expressions returning sets or functions. See #2107.

The changelog also contains an empty duplicate 0.58.0 heading dated 2026-05-22.

## 0.57.1 — 2026-05-22

### Breaking changes

- Upgraded the TLA+ parser to SANY 1.8.0 and added Unicode support, potentially changing parsing behavior and diagnostics. See #3341.
- Upgraded Scala to 2.13.18.

### Feature

- Extended set simplification rules. See #3343.

### Bug fixes

- Fixed SANY importer crashes involving named `ASSUME` definitions. See #3318.
- Fixed preprocessing failures when named `ASSUME` declarations were referenced from operator bodies. See #3326.

## 0.57.0 — 2026-04-24

### Feature

- Added support for TLC's `CHECK_DEADLOCK` configuration keyword. Explicit Apalache CLI/configuration settings still take precedence. See #3311.

-----------------

<!-- Please ensure that your PR includes the following, as needed -->
- [x] I have read and I understand the [Note on AI-assisted contributions](https://github.com/informalsystems/quint/blob/main/CONTRIBUTING.md#note-on-ai-assisted-contributions)
- [x] Changes manually tested locally and confirmed to work as described
      (including screenshots is helpful)
- [x] Tests added for any new code
- [x] Documentation added for any new functionality
- [x] Entries added to the respective `CHANGELOG.md` for any new functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
